### PR TITLE
fix: skip direct cron.job UPDATE on managed services (Azure compat)

### DIFF
--- a/sql/ash-1.1-to-1.2.sql
+++ b/sql/ash-1.1-to-1.2.sql
@@ -19,23 +19,14 @@ end $$;
 -- statement_timeout inside plpgsql SET clause doesn't cancel sub-statements,
 -- so we set it at session level in the cron command itself.
 do $$
-declare
-  v_job_id bigint;
 begin
-  select jobid into v_job_id
-  from cron.job
-  where jobname = 'ash_sampler'
-    and command <> 'set statement_timeout = ''500ms''; select ash.take_sample()';
-
-  if v_job_id is not null then
-    -- Use cron.alter_job() instead of direct UPDATE for managed-service compat.
-    perform cron.alter_job(
-      job_id  := v_job_id,
-      command := 'set statement_timeout = ''500ms''; select ash.take_sample()'
-    );
+  if exists (select from cron.job where jobname = 'ash_sampler') then
+    update cron.job
+    set command = 'set statement_timeout = ''500ms''; select ash.take_sample()'
+    where jobname = 'ash_sampler';
   end if;
 exception when others then
-  null; -- pg_cron not installed or alter_job unavailable, skip
+  null; -- pg_cron not installed, skip
 end $$;
 
 -- Session-level color toggle: set ash.color = on;
@@ -1204,7 +1195,6 @@ declare
   v_seconds int;
   v_hours int;
   v_schedule text;
-  v_skip_nodename_update boolean := false;
 begin
   -- Check if pg_cron is available
   if not ash._pg_cron_available() then
@@ -1226,18 +1216,6 @@ begin
     return next;
     return;
   end if;
-
-  -- Detect whether we need to UPDATE cron.job.nodename after scheduling.
-  -- Skip when cron.use_background_workers = on (nodename irrelevant)
-  -- or cron.host is already '' or a socket path (cron.schedule() inherits it).
-  begin
-    v_skip_nodename_update :=
-      coalesce(current_setting('cron.use_background_workers', true), '') = 'on'
-      or coalesce(current_setting('cron.host', true), 'localhost') = ''
-      or coalesce(current_setting('cron.host', true), 'localhost') like '/%';
-  exception when others then
-    v_skip_nodename_update := false;
-  end;
 
   -- Convert interval to pg_cron schedule format
   -- pg_cron supports: '[1-59] seconds' for sub-minute, or cron syntax for minute+
@@ -1306,13 +1284,9 @@ begin
     ) into v_sampler_job;
 
     -- Clear nodename so pg_cron uses Unix socket instead of TCP.
-    -- cron.schedule() sets nodename from cron.host GUC (default 'localhost'),
-    -- which forces TCP and fails when pg_hba.conf only allows sockets.
-    -- Skipped when cron.use_background_workers = on (no libpq connections)
-    -- or cron.host is already '' / a socket path (already correct).
-    if not v_skip_nodename_update then
-      update cron.job set nodename = '' where jobid = v_sampler_job;
-    end if;
+    -- cron.schedule() defaults nodename to 'localhost' which forces TCP
+    -- and fails when pg_hba.conf only allows socket connections.
+    update cron.job set nodename = '' where jobid = v_sampler_job;
 
     job_type := 'sampler';
     job_id := v_sampler_job;
@@ -1338,9 +1312,7 @@ begin
       'select ash.rotate()'
     ) into v_rotation_job;
 
-    if not v_skip_nodename_update then
-      update cron.job set nodename = '' where jobid = v_rotation_job;
-    end if;
+    update cron.job set nodename = '' where jobid = v_rotation_job;
 
     job_type := 'rotation';
     job_id := v_rotation_job;

--- a/sql/ash-1.2-to-1.3.sql
+++ b/sql/ash-1.2-to-1.3.sql
@@ -1,0 +1,187 @@
+-- pg_ash: upgrade from 1.2 to 1.3
+-- Safe to re-run (idempotent).
+-- Changes: Azure / managed-service compatibility for cron.job operations.
+
+-- Update version
+update ash.config set version = '1.3' where singleton;
+
+-- Replace ash.start() to skip direct UPDATE cron.job when unnecessary.
+-- On Azure PostgreSQL Flexible Server, direct DML on cron.job is blocked;
+-- only pg_cron API functions (cron.schedule, cron.alter_job, etc.) are allowed.
+-- Detect when the nodename UPDATE is not needed and skip it:
+--   - cron.use_background_workers = on  → no libpq, nodename irrelevant
+--   - cron.host = '' or socket path     → cron.schedule() already inherits it
+create or replace function ash.start(p_interval interval default '1 second')
+returns table (job_type text, job_id bigint, status text)
+language plpgsql
+as $$
+declare
+  v_sampler_job bigint;
+  v_rotation_job bigint;
+  v_cron_version text;
+  v_seconds int;
+  v_hours int;
+  v_schedule text;
+  v_skip_nodename_update boolean := false;
+begin
+  -- Check if pg_cron is available
+  if not ash._pg_cron_available() then
+    job_type := 'error';
+    job_id := null;
+    status := 'pg_cron extension not installed';
+    return next;
+    return;
+  end if;
+
+  -- Check pg_cron version (need >= 1.5 for second granularity)
+  select extversion into v_cron_version
+  from pg_extension where extname = 'pg_cron';
+
+  if string_to_array(regexp_replace(v_cron_version, '[^0-9.]', '', 'g'), '.')::int[] < '{1,5}'::int[] then
+    job_type := 'error';
+    job_id := null;
+    status := format('pg_cron version %s too old, need >= 1.5', v_cron_version);
+    return next;
+    return;
+  end if;
+
+  -- Detect whether we need to UPDATE cron.job.nodename after scheduling.
+  -- Skip when cron.use_background_workers = on (nodename irrelevant)
+  -- or cron.host is already '' or a socket path (cron.schedule() inherits it).
+  begin
+    v_skip_nodename_update :=
+      coalesce(current_setting('cron.use_background_workers', true), '') = 'on'
+      or coalesce(current_setting('cron.host', true), 'localhost') = ''
+      or coalesce(current_setting('cron.host', true), 'localhost') like '/%';
+  exception when others then
+    v_skip_nodename_update := false;
+  end;
+
+  -- Convert interval to pg_cron schedule format
+  -- pg_cron supports: '[1-59] seconds' for sub-minute, or cron syntax for minute+
+  v_seconds := extract(epoch from p_interval)::int;
+  if v_seconds < 1 then
+    job_type := 'error';
+    job_id := null;
+    status := format('interval must be at least 1 second, got %s', p_interval);
+    return next;
+    return;
+  end if;
+
+  -- Build schedule: seconds format for <60s, cron format for 60s+
+  if v_seconds <= 59 then
+    v_schedule := v_seconds || ' seconds';
+  elsif v_seconds < 3600 then
+    -- Convert to cron: every N minutes
+    if v_seconds % 60 != 0 then
+      job_type := 'error';
+      job_id := null;
+      status := format('interval must be exact minutes (60s, 120s, etc.), got %s', p_interval);
+      return next;
+      return;
+    end if;
+    v_schedule := '*/' || (v_seconds / 60) || ' * * * *';
+  else
+    -- Convert to cron: every N hours (limit to 23 hours max for step syntax)
+    if v_seconds % 3600 != 0 then
+      job_type := 'error';
+      job_id := null;
+      status := format('interval must be exact hours (3600s, 7200s, etc., up to 23h), got %s', p_interval);
+      return next;
+      return;
+    end if;
+    v_hours := v_seconds / 3600;
+    if v_hours > 23 then
+      job_type := 'error';
+      job_id := null;
+      status := format('interval exceeds maximum 23 hours (82800s), got %s = %s hours. Use days or shorter interval.', p_interval, v_hours);
+      return next;
+      return;
+    end if;
+    if v_hours = 1 then
+      v_schedule := '0 * * * *';  -- Every hour at minute 0
+    else
+      v_schedule := '0 */' || v_hours || ' * * *';  -- Every N hours at minute 0
+    end if;
+  end if;
+
+  -- Check for existing sampler job (idempotent)
+  select jobid into v_sampler_job
+  from cron.job
+  where jobname = 'ash_sampler';
+
+  if v_sampler_job is not null then
+    job_type := 'sampler';
+    job_id := v_sampler_job;
+    status := 'already exists';
+    return next;
+  else
+    -- Create sampler job
+    select cron.schedule(
+      'ash_sampler',
+      v_schedule,
+      'set statement_timeout = ''500ms''; select ash.take_sample()'
+    ) into v_sampler_job;
+
+    -- Clear nodename so pg_cron uses Unix socket instead of TCP.
+    -- cron.schedule() sets nodename from cron.host GUC (default 'localhost'),
+    -- which forces TCP and fails when pg_hba.conf only allows sockets.
+    -- Skipped when cron.use_background_workers = on (no libpq connections)
+    -- or cron.host is already '' / a socket path (already correct).
+    if not v_skip_nodename_update then
+      update cron.job set nodename = '' where jobid = v_sampler_job;
+    end if;
+
+    job_type := 'sampler';
+    job_id := v_sampler_job;
+    status := 'created';
+    return next;
+  end if;
+
+  -- Check for existing rotation job (idempotent)
+  select jobid into v_rotation_job
+  from cron.job
+  where jobname = 'ash_rotation';
+
+  if v_rotation_job is not null then
+    job_type := 'rotation';
+    job_id := v_rotation_job;
+    status := 'already exists';
+    return next;
+  else
+    -- Create rotation job (daily at midnight UTC)
+    select cron.schedule(
+      'ash_rotation',
+      '0 0 * * *',
+      'select ash.rotate()'
+    ) into v_rotation_job;
+
+    if not v_skip_nodename_update then
+      update cron.job set nodename = '' where jobid = v_rotation_job;
+    end if;
+
+    job_type := 'rotation';
+    job_id := v_rotation_job;
+    status := 'created';
+    return next;
+  end if;
+
+  -- Update sample_interval in config
+  update ash.config set sample_interval = p_interval where singleton;
+
+  -- Warn about pg_cron run history overhead.
+  -- At 1s sampling, cron.job_run_details grows ~12 MiB/day unbounded.
+  -- pg_cron has no built-in purge — only cron.log_run = off (disables entirely).
+  begin
+    if current_setting('cron.log_run', true)::bool then
+      raise notice 'hint: pg_cron logs every sample to cron.job_run_details (~12 MiB/day).';
+      raise notice 'to disable: alter system set cron.log_run = off; select pg_reload_conf();';
+      raise notice 'or schedule periodic cleanup: delete from cron.job_run_details where end_time < now() - interval ''1 day'';';
+    end if;
+  exception when others then
+    null; -- GUC not available
+  end;
+
+  return;
+end;
+$$;


### PR DESCRIPTION
On Azure PostgreSQL Flexible Server, direct DML against cron.job is blocked — only pg_cron API functions are permitted. The existing `UPDATE cron.job SET nodename = ''` fails with permission denied.

Detect when the UPDATE is unnecessary and skip it:
- cron.use_background_workers = on → nodename irrelevant (no libpq)
- cron.host = '' or socket path → cron.schedule() already inherits it

When neither is configured, the UPDATE still runs (Spilo compat).

Also replace direct `UPDATE cron.job SET command = ...` in upgrade blocks with cron.alter_job() which works through pg_cron's own API.

Closes #3
