### PR TITLE
Make pg_cron officially optional: support external scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ Postgres has no built-in session history. When something was slow an hour ago, t
 |---|---|---|---|---|
 | Install | `\i` (pure SQL) | shared_preload_libraries | shared_preload_libraries (package or compile) | Separate infra |
 | Works on managed (RDS, Cloud SQL, Supabase, ...) | Yes | Cloud SQL only (as of early 2026) | Not known to be supported | Yes, with effort |
-| Sampling rate | 1s (via pg_cron) | 10ms (in-process) | 10ms (in-process) | 15-60s typical |
+| Sampling rate | 1s (via pg_cron, system cron, or any scheduler) | 10ms (in-process) | 10ms (in-process) | 15-60s typical |
 | Visibility | Inside Postgres | Inside Postgres | Inside Postgres | Outside only |
 | Storage | Disk (~30 MiB/day) | Memory only | Memory only | External store |
 | Historical queries | Yes (persistent) | Ring buffer (lost on restart) | Ring buffer (lost on restart) | Depends on setup |
 | Pure SQL | Yes | No (C extension) | No (C extension) | No |
 | Maintenance overhead | None | None | None | High |
-| Requirements | pg_cron 1.5+ | shared_preload_libraries (restart required) | shared_preload_libraries (restart required) | Agent + storage |
+| Requirements | None (pg_cron optional) | shared_preload_libraries (restart required) | shared_preload_libraries (restart required) | Agent + storage |
 
 ## Quick start
 
@@ -34,7 +34,7 @@ Postgres has no built-in session history. When something was slow an hour ago, t
 -- install (just run the SQL file — works on RDS, Cloud SQL, AlloyDB, etc.)
 \i sql/ash-install.sql
 
--- start sampling (1 sample/second via pg_cron)
+-- start sampling (1 sample/second — uses pg_cron if available, otherwise prints external scheduling instructions)
 select ash.start('1 second');
 
 -- wait a few minutes, then query
@@ -74,6 +74,9 @@ select ash.uninstall('yes');
 
 -- from 1.1 to 1.2
 \i sql/ash-1.1-to-1.2.sql
+
+-- from 1.2 to 1.3
+\i sql/ash-1.2-to-1.3.sql
 
 -- check version
 select * from ash.status();
@@ -538,7 +541,7 @@ See [issue #1](https://github.com/NikolayS/pg_ash/issues/1) for full benchmarks 
 ## Requirements
 
 - Postgres 14+ (requires `query_id` in `pg_stat_activity`)
-- pg_cron 1.5+ (for sub-minute scheduling)
+- pg_cron 1.5+ (optional — for built-in scheduling; see [Scheduling without pg_cron](#scheduling-without-pg_cron) for alternatives)
 - pg_stat_statements (optional — enables query text, `calls`, `total_exec_time_ms`, `mean_exec_time_ms` in `top_queries_with_text()` and `event_queries()`; all other functions work without it)
 
 **Note on `query_id`**: The default `compute_query_id = auto` only populates `query_id` when pg_stat_statements is in `shared_preload_libraries`. If `query_id` is NULL in `pg_stat_activity`, set:
@@ -585,11 +588,81 @@ select cron.schedule(
 
 `ash.start()` will warn about this overhead.
 
+### Scheduling without pg_cron
+
+pg_cron is **optional**. All core functions — `ash.take_sample()`, `ash.rotate()`, and all reporting — work without it. When pg_cron is not installed, `ash.start('1 second')` records the intended interval in `ash.config` and prints instructions for external scheduling.
+
+You can call `ash.take_sample()` from any external scheduler:
+
+**System cron** (1-minute minimum granularity):
+
+```bash
+# Every minute
+* * * * * psql -qAtX -d mydb -c "SET statement_timeout='500ms'; SELECT ash.take_sample();"
+
+# Every second (cron launches a loop each minute)
+* * * * * for i in $(seq 1 59); do psql -qAtX -d mydb -c "SET statement_timeout='500ms'; SELECT ash.take_sample();"; sleep 1; done
+```
+
+**Dedicated loop script** (most reliable for 1-second sampling):
+
+```bash
+#!/bin/bash
+# ash_sampler.sh — run via systemd, screen, tmux, or nohup
+while true; do
+  psql -qAtX -d mydb -c "SET statement_timeout='500ms'; SELECT ash.take_sample();" 2>/dev/null
+  sleep 1
+done
+```
+
+**systemd timer** (Linux, precise 1-second ticking):
+
+```ini
+# /etc/systemd/system/ash-sampler.service
+[Service]
+Type=oneshot
+ExecStart=psql -qAtX -d mydb -c "SET statement_timeout='500ms'; SELECT ash.take_sample();"
+User=postgres
+
+# /etc/systemd/system/ash-sampler.timer
+[Timer]
+OnActiveSec=0
+OnUnitActiveSec=1s
+AccuracySec=100ms
+[Install]
+WantedBy=timers.target
+```
+
+**psql `\watch`** (quick ad-hoc testing):
+
+```sql
+SELECT ash.take_sample() \watch 1
+```
+
+**Any language** (Python example):
+
+```python
+import psycopg2, time
+conn = psycopg2.connect("dbname=mydb")
+conn.autocommit = True
+while True:
+    with conn.cursor() as cur:
+        cur.execute("SET statement_timeout='500ms'; SELECT ash.take_sample()")
+    time.sleep(1)
+```
+
+Don't forget to also schedule `ash.rotate()` — once per `rotation_period` (default: daily):
+
+```bash
+# System cron: rotate daily at midnight
+0 0 * * * psql -qAtX -d mydb -c "SELECT ash.rotate();"
+```
+
 ## Known limitations
 
-- **Primary only** — pg_ash requires writes (`INSERT` into sample tables, `TRUNCATE` on rotation) and pg_cron, so it cannot run on physical standbys or read replicas. Install it on the primary; it samples all databases from there.
+- **Primary only** — pg_ash requires writes (`INSERT` into sample tables, `TRUNCATE` on rotation), so it cannot run on physical standbys or read replicas. Install it on the primary; it samples all databases from there.
 - **Observer-effect protection** — the sampler pg_cron command includes `SET statement_timeout = '500ms'` to prevent `take_sample()` from becoming a problem on overloaded servers. If `pg_stat_activity` is slow (thousands of backends), the sample is canceled rather than piling up. Normal execution is ~50ms — the 500ms cap gives 10× headroom. Adjust in `cron.job` if needed.
-- **Sampling gaps under heavy load** — pg_cron runs in a single background worker and under heavy load (lock storms, many concurrent sessions) it can't always keep up with the 1-second schedule. You may see gaps of 8s, 13s, or even 30s+ between samples — ironically during the most interesting moments. This is a fundamental pg_cron limitation, not a bug. If precise 1-second sampling matters, use an external sampler (e.g., a shell loop: `while true; do psql -c "select ash.take_sample()"; sleep 1; done`) which is more reliable under load.
+- **Sampling gaps under heavy load** — pg_cron runs in a single background worker and under heavy load (lock storms, many concurrent sessions) it can't always keep up with the 1-second schedule. You may see gaps of 8s, 13s, or even 30s+ between samples — ironically during the most interesting moments. This is a fundamental pg_cron limitation, not a bug. If precise 1-second sampling matters, use an [external sampler](#scheduling-without-pg_cron) which is more reliable under load.
 - **24-hour queries are slow** (~6s for full-day scan) — aggregate rollup tables are [planned](blueprints/ROLLUP_DESIGN.md).
 - **JIT protection built in** — all reader functions use `SET jit = off` to prevent JIT compilation overhead (which can be 10-750x slower depending on Postgres version and dataset size). No global configuration needed.
 - **Single-database install** — pg_ash installs in one database and samples all databases from there. Per-database filtering works via the `datid` column.

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -679,25 +679,51 @@ declare
   v_schedule text;
   v_skip_nodename_update boolean := false;
 begin
-  -- Check if pg_cron is available
-  if not ash._pg_cron_available() then
+  -- Validate interval
+  v_seconds := extract(epoch from p_interval)::int;
+  if v_seconds < 1 then
     job_type := 'error';
     job_id := null;
-    status := 'pg_cron extension not installed';
+    status := format('interval must be at least 1 second, got %s', p_interval);
     return next;
     return;
   end if;
 
-  -- Check pg_cron version (need >= 1.5 for second granularity)
+  -- If pg_cron is not available, just record the interval and advise on external scheduling
+  if not ash._pg_cron_available() then
+    update ash.config set sample_interval = p_interval where singleton;
+
+    job_type := 'sampler';
+    job_id := null;
+    status := format('interval set to %s — schedule externally (pg_cron not available)', p_interval);
+    return next;
+
+    job_type := 'rotation';
+    job_id := null;
+    status := format('rotation_period is %s — schedule ash.rotate() externally', (select rotation_period from ash.config where singleton));
+    return next;
+
+    raise notice 'pg_cron is not installed. To sample, call ash.take_sample() from an external scheduler:';
+    raise notice '  system cron:    * * * * * psql -qAtX -c "select ash.take_sample()" (for per-second, use a loop)';
+    raise notice '  psql:           SELECT ash.take_sample() \watch 1';
+    raise notice '  any language:   execute "SELECT ash.take_sample()" in a loop with sleep';
+    raise notice 'Also schedule ash.rotate() at the rotation_period interval (default: daily).';
+
+    return;
+  end if;
+
+  -- Check pg_cron version (need >= 1.5 for sub-minute scheduling)
   select extversion into v_cron_version
   from pg_extension where extname = 'pg_cron';
 
   if string_to_array(regexp_replace(v_cron_version, '[^0-9.]', '', 'g'), '.')::int[] < '{1,5}'::int[] then
-    job_type := 'error';
-    job_id := null;
-    status := format('pg_cron version %s too old, need >= 1.5', v_cron_version);
-    return next;
-    return;
+    if v_seconds < 60 then
+      job_type := 'error';
+      job_id := null;
+      status := format('pg_cron version %s too old for sub-minute scheduling (need >= 1.5). Use external scheduler or upgrade pg_cron.', v_cron_version);
+      return next;
+      return;
+    end if;
   end if;
 
   -- Detect whether we need to UPDATE cron.job.nodename after scheduling.
@@ -714,21 +740,13 @@ begin
 
   -- Convert interval to pg_cron schedule format
   -- pg_cron supports: '[1-59] seconds' for sub-minute, or cron syntax for minute+
-  v_seconds := extract(epoch from p_interval)::int;
-  if v_seconds < 1 then
-    job_type := 'error';
-    job_id := null;
-    status := format('interval must be at least 1 second, got %s', p_interval);
-    return next;
-    return;
-  end if;
-  
+
   -- Build schedule: seconds format for <60s, cron format for 60s+
   if v_seconds <= 59 then
     v_schedule := v_seconds || ' seconds';
   elsif v_seconds < 3600 then
     -- Convert to cron: every N minutes
-    if v_seconds % 60 != 0 then
+    if v_seconds % 60 <> 0 then
       job_type := 'error';
       job_id := null;
       status := format('interval must be exact minutes (60s, 120s, etc.), got %s', p_interval);
@@ -738,7 +756,7 @@ begin
     v_schedule := '*/' || (v_seconds / 60) || ' * * * *';
   else
     -- Convert to cron: every N hours (limit to 23 hours max for step syntax)
-    if v_seconds % 3600 != 0 then
+    if v_seconds % 3600 <> 0 then
       job_type := 'error';
       job_id := null;
       status := format('interval must be exact hours (3600s, 7200s, etc., up to 23h), got %s', p_interval);
@@ -821,7 +839,7 @@ begin
     return next;
   end if;
 
-  -- Update sample_interval in config
+  -- Update sample_interval in config (after all validation and job creation)
   update ash.config set sample_interval = p_interval where singleton;
 
   -- Warn about pg_cron run history overhead.
@@ -849,11 +867,11 @@ as $$
 declare
   v_job_id bigint;
 begin
-  -- Check if pg_cron is available
+  -- If pg_cron is not available, just remind about external scheduler
   if not ash._pg_cron_available() then
     job_type := 'info';
     job_id := null;
-    status := 'pg_cron not installed, no jobs to remove';
+    status := 'pg_cron not installed — remember to stop your external scheduler (cron, systemd timer, loop script, etc.)';
     return next;
     return;
   end if;
@@ -1039,7 +1057,7 @@ begin
       return next;
     end loop;
   else
-    metric := 'pg_cron_available'; value := 'no'; return next;
+    metric := 'pg_cron_available'; value := 'no (use external scheduler)'; return next;
   end if;
 
   return;


### PR DESCRIPTION
## Summary

Make pg_cron officially optional. When pg_cron is not installed:

- `ash.start()` records the interval in `ash.config` and prints `NOTICE` instructions for external scheduling (system cron, systemd timer, psql `\watch`, loop script)
- `ash.stop()` reminds users to stop their external scheduler
- `ash.status()` shows `no (use external scheduler)` instead of bare `no`

All core functions — `take_sample()`, `rotate()`, and all reporting — already worked without pg_cron. This change makes the optional nature explicit and provides first-class guidance.

Also:
- Fix `!=` → `<>` per code style
- Relax pg_cron version check: only block sub-minute intervals when pg_cron < 1.5 (allow minute+ intervals on older versions)
- New README section "Scheduling without pg_cron" with examples for system cron, systemd timer, psql `\watch`, and Python

## Changes

- `sql/ash-install.sql`: ~66 lines changed in `start()`, `stop()`, `status()`
- `README.md`: ~85 lines — requirements table, quick start comment, new section, updated limitations

No upgrade script changes — that's generated at release time.

## Test plan

- [x] Install without pg_cron → `ash.start('1 second')` prints hints, records interval
- [x] `ash.status()` shows `pg_cron_available | no (use external scheduler)`
- [x] `ash.stop()` shows external scheduler reminder
- [x] `ash.take_sample()` works without pg_cron
- [x] Sub-second interval rejected (`0.1 seconds` → error)
- [x] With pg_cron installed → `ash.start()` creates cron jobs (no regression)
- [x] `ash.stop()` removes jobs normally with pg_cron