### PR TITLE
fix: set version column DEFAULT to 1.3 in upgrade script

### DIFF
--- a/sql/ash-1.2-to-1.3.sql
+++ b/sql/ash-1.2-to-1.3.sql
@@ -17,8 +17,9 @@ begin
   end if;
 end $$;
 
--- Update version
+-- Update version (both data and column default for schema parity)
 update ash.config set version = '1.3' where singleton;
+alter table ash.config alter column version set default '1.3';
 
 -- Re-create all functions to match fresh install (schema parity).
 -- CREATE OR REPLACE is safe — only the function body changes.


### PR DESCRIPTION
The upgrade script updates the config row to version 1.3 but doesn't change the column DEFAULT. After upgrade path 1.0→1.1→1.2→1.3, the DEFAULT stays at '1.1' (from ash-1.1.sql), while fresh install has '1.3'.

Adds `ALTER TABLE ash.config ALTER COLUMN version SET DEFAULT '1.3'` for full schema parity.

Found during local testing on PG14/16/17.