### PR TITLE
rename: debug_logging() → set_debug_logging()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -286,7 +286,7 @@ jobs:
           $$;
           EOF
 
-      - name: Test debug_logging
+      - name: Test set_debug_logging
         env:
           PGPASSWORD: postgres
         run: |
@@ -300,15 +300,15 @@ jobs:
             assert v_result = false, 'debug_logging should default to false';
 
             -- Query current state via function
-            perform ash.debug_logging();
+            perform ash.set_debug_logging();
 
             -- Enable
-            perform ash.debug_logging(true);
+            perform ash.set_debug_logging(true);
             select debug_logging into v_result from ash.config where singleton;
             assert v_result = true, 'debug_logging should be true after enable';
 
             -- Disable
-            perform ash.debug_logging(false);
+            perform ash.set_debug_logging(false);
             select debug_logging into v_result from ash.config where singleton;
             assert v_result = false, 'debug_logging should be false after disable';
 
@@ -317,7 +317,7 @@ jobs:
               select 1 from ash.status() where metric = 'debug_logging'
             ), 'status should show debug_logging metric';
 
-            raise notice 'debug_logging tests PASSED';
+            raise notice 'set_debug_logging tests PASSED';
           end;
           $$;
           EOF
@@ -1422,7 +1422,7 @@ jobs:
 
             perform ash.take_sample();
             perform ash.status();
-            perform ash.debug_logging();
+            perform ash.set_debug_logging();
 
             -- Functions that should ERROR without pgss:
             begin

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ select * from ash.status();
 | `ash.status()` | Sampling status, version, partition info, debug_logging state |
 | `ash.take_sample()` | Take one sample manually (called automatically by the scheduler) |
 | `ash.rotate()` | Rotate sample partitions (called automatically, or manually for external schedulers) |
-| `ash.debug_logging(bool)` | Enable/disable per-session RAISE LOG in `take_sample()` for diagnostics. Call without argument to check current state |
+| `ash.set_debug_logging(bool)` | Enable/disable per-session RAISE LOG in `take_sample()` for diagnostics. Call without argument to check current state |
 | `ash.uninstall('yes')` | Drop the ash schema and remove pg_cron jobs |
 
 ### Relative time (last N hours)
@@ -586,17 +586,17 @@ Enable per-session RAISE LOG output from `take_sample()` — useful for diagnosi
 
 ```sql
 -- check current state
-select ash.debug_logging();
+select ash.set_debug_logging();
 
 -- enable: each take_sample() call logs every active session to the Postgres log
-select ash.debug_logging(true);
+select ash.set_debug_logging(true);
 
 -- sample output in the Postgres server log:
 -- LOG: ash.take_sample: pid=107 state=active wait_type=CPU* wait_event=CPU* backend_type=client backend query_id=-5287352711091412819
 -- LOG: ash.take_sample: pid=108 state=idle in transaction wait_type=Client wait_event=ClientRead backend_type=client backend query_id=-6949053775937549307
 
 -- disable
-select ash.debug_logging(false);
+select ash.set_debug_logging(false);
 ```
 
 ### pg_cron run history

--- a/sql/ash-1.2-to-1.3.sql
+++ b/sql/ash-1.2-to-1.3.sql
@@ -3,7 +3,8 @@
 -- Changes:
 --   - Make pg_cron optional: ash.start() works without it (#7)
 --   - Azure / managed-service compatibility for cron.job operations (#6)
---   - ash.debug_logging() — per-session RAISE LOG in take_sample() (#8)
+--   - ash.set_debug_logging() — per-session RAISE LOG in take_sample() (#8)
+--     (renamed from debug_logging → set_debug_logging)
 --   - take_sample() Read 1 loop: in-memory dedup, no DISTINCT scan
 --   - Version column DEFAULT fix for schema parity (#9)
 --   - Fix != to <> per code style
@@ -194,8 +195,8 @@ begin
   -- Debug logging (when v_debug_logging = true):
   --   Uses RAISE LOG — goes to server log only, never to the client.
   --   Independent of log_min_messages and client_min_messages.
-  --   Enable:  select ash.debug_logging(true);
-  --   Disable: select ash.debug_logging(false);
+  --   Enable:  select ash.set_debug_logging(true);
+  --   Disable: select ash.set_debug_logging(false);
   --
   -- Both tasks share one pg_stat_activity scan. Wait event registration skips
   -- duplicates via a seen-set (text[] + ANY check) to avoid repeated lookups.
@@ -782,7 +783,10 @@ begin
 end;
 $$;
 
-create or replace function ash.debug_logging(p_enabled bool default null)
+-- Drop old function name (renamed debug_logging → set_debug_logging)
+drop function if exists ash.debug_logging(bool);
+
+create or replace function ash.set_debug_logging(p_enabled bool default null)
 returns text
 language plpgsql
 as $$
@@ -2639,12 +2643,12 @@ begin
   execute format('revoke all on function ash.uninstall(text) from public');
   execute format('revoke all on function ash.rotate() from public');
   execute format('revoke all on function ash.take_sample() from public');
-  execute format('revoke all on function ash.debug_logging(bool) from public');
+  execute format('revoke all on function ash.set_debug_logging(bool) from public');
 
   execute format('grant execute on function ash.start(interval) to %I', v_owner);
   execute format('grant execute on function ash.stop() to %I', v_owner);
   execute format('grant execute on function ash.uninstall(text) to %I', v_owner);
   execute format('grant execute on function ash.rotate() to %I', v_owner);
   execute format('grant execute on function ash.take_sample() to %I', v_owner);
-  execute format('grant execute on function ash.debug_logging(bool) to %I', v_owner);
+  execute format('grant execute on function ash.set_debug_logging(bool) to %I', v_owner);
 end $$;

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -29,7 +29,8 @@ begin
         'waits_by_type', 'waits_by_type_at',
         'event_queries', 'event_queries_at',
         'top_queries_with_text',
-        'uninstall'
+        'uninstall',
+        'debug_logging'
       )
   loop
     execute 'drop function if exists ' || r.sig;
@@ -300,8 +301,8 @@ begin
   -- Debug logging (when v_debug_logging = true):
   --   Uses RAISE LOG — goes to server log only, never to the client.
   --   Independent of log_min_messages and client_min_messages.
-  --   Enable:  select ash.debug_logging(true);
-  --   Disable: select ash.debug_logging(false);
+  --   Enable:  select ash.set_debug_logging(true);
+  --   Disable: select ash.set_debug_logging(false);
   --
   -- Both tasks share one pg_stat_activity scan. Wait event registration skips
   -- duplicates via a seen-set (text[] + ANY check) to avoid repeated lookups.
@@ -914,10 +915,10 @@ $$;
 -- It is independent of log_min_messages and client_min_messages.
 --
 -- Usage:
---   select ash.debug_logging(true);   -- enable
---   select ash.debug_logging(false);  -- disable
---   select ash.debug_logging();       -- show current state
-create or replace function ash.debug_logging(p_enabled bool default null)
+--   select ash.set_debug_logging(true);   -- enable
+--   select ash.set_debug_logging(false);  -- disable
+--   select ash.set_debug_logging();       -- show current state
+create or replace function ash.set_debug_logging(p_enabled bool default null)
 returns text
 language plpgsql
 as $$
@@ -2884,12 +2885,12 @@ begin
   execute format('revoke all on function ash.uninstall(text) from public');
   execute format('revoke all on function ash.rotate() from public');
   execute format('revoke all on function ash.take_sample() from public');
-  execute format('revoke all on function ash.debug_logging(bool) from public');
+  execute format('revoke all on function ash.set_debug_logging(bool) from public');
 
   execute format('grant execute on function ash.start(interval) to %I', v_owner);
   execute format('grant execute on function ash.stop() to %I', v_owner);
   execute format('grant execute on function ash.uninstall(text) to %I', v_owner);
   execute format('grant execute on function ash.rotate() to %I', v_owner);
   execute format('grant execute on function ash.take_sample() to %I', v_owner);
-  execute format('grant execute on function ash.debug_logging(bool) to %I', v_owner);
+  execute format('grant execute on function ash.set_debug_logging(bool) to %I', v_owner);
 end $$;


### PR DESCRIPTION
Makes the intent clear — `set_debug_logging(true)` is obviously a setter, `debug_logging(true)` reads like a getter.

**Changes:**
- Function renamed: `ash.debug_logging(bool)` → `ash.set_debug_logging(bool)`
- Old name added to nuclear drop list in `ash-install.sql`
- Explicit `drop function if exists ash.debug_logging(bool)` in upgrade script
- Column name `debug_logging` in `ash.config` unchanged
- Status metric name `debug_logging` unchanged
- README, CI tests updated

Still 38 functions.