### PR TITLE
docs: v1.3 release notes, upgrade headers, \ir fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ select ash.uninstall('yes');
 
 ```sql
 -- from 1.0 to 1.1
-\i sql/ash-1.1.sql
+\i sql/ash-1.0-to-1.1.sql
 
 -- from 1.1 to 1.2
 \i sql/ash-1.1-to-1.2.sql
@@ -144,17 +144,23 @@ select * from ash.status();
 ```
            metric           |             value
 ----------------------------+-------------------------------
- version                    | 1.2
+ version                    | 1.3
+ color                      | off
  current_slot               | 0
  sample_interval            | 00:00:01
  rotation_period            | 1 day
  include_bg_workers         | false
- samples_in_current_slot    | 56
+ debug_logging              | false
+ installed_at               | 2026-02-16 08:30:00.000000+00
+ rotated_at                 | 2026-02-16 08:30:00.000000+00
+ time_since_rotation        | 00:09:03.123456
  last_sample_ts             | 2026-02-16 08:39:03+00
+ samples_in_current_slot    | 56
+ samples_total              | 56
  wait_event_map_count       | 11
  wait_event_map_utilization | 0.03%
  query_map_count            | 8
- pg_cron_available          | no
+ pg_cron_available          | yes
 ```
 
 ### What hurt recently?

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,59 @@
+# pg_ash 1.3 release notes
+
+32 commits since v1.2. Upgrade from 1.2: `\i sql/ash-1.2-to-1.3.sql`. Fresh install or upgrade from any version: `\i sql/ash-install.sql`.
+
+## What changed
+
+### New: pg_cron now optional
+
+`ash.start()` works without pg_cron — records the interval and prints `NOTICE` instructions for external scheduling (system cron, systemd timer, psql `\watch`, Python loop). `ash.stop()` reminds you to stop your external scheduler. `ash.status()` shows `no (use external scheduler)` when pg_cron is absent. (#7)
+
+### New: set_debug_logging()
+
+`ash.set_debug_logging(true)` enables per-session `RAISE LOG` in `take_sample()` — each sampled backend emits a log line with pid, state, wait event, backend type, and query_id. Useful for diagnosing connection pooler behavior. Goes to server log only, independent of `client_min_messages`. (#8, refs #4)
+
+### New: pgss-dependent functions fail fast
+
+`top_queries_with_text()`, `event_queries()`, and `event_queries_at()` now raise a clear `EXCEPTION` with a `HINT` when `pg_stat_statements` is not installed, instead of silently returning NULLs. (#14, refs #10)
+
+### New: pgss-optional functions warn
+
+`top_queries()`, `top_queries_at()`, `samples()`, and `samples_at()` emit a `WARNING` when `pg_stat_statements` is missing — query_text returns NULL but the function still returns sample data. (#17)
+
+### Fixed: Azure compatibility
+
+`cron.alter_job()` API used instead of direct `UPDATE cron.job` — works on Azure Flexible Server where the table is read-only. Nodename update skipped when unnecessary (background workers mode or socket connection). (#6, fixes #3)
+
+### Fixed: minute and hour intervals
+
+`ash.start('5 minutes')` and `ash.start('6 hours')` now work. Sub-minute still requires pg_cron ≥ 1.5. Non-round intervals (e.g. 90 seconds) and intervals exceeding 23 hours are rejected with clear errors. (fixes #2)
+
+### Fixed: Azure pg_cron version strings
+
+pg_cron version `'4-1'` (Azure format) is now parsed correctly via `regexp_replace`. Previously caused a version check failure.
+
+### Improved: take_sample() optimization
+
+Removed `DISTINCT` from the Read 1 `pg_stat_activity` scan. Wait event dedup uses an in-memory `text[]` seen-set instead of per-row existence checks. (#8)
+
+### Improved: schema parity
+
+Upgrade script (`ash-1.2-to-1.3.sql`) re-creates all 38 functions, ensuring identical function bodies between fresh install and upgrade path. CI schema equivalence test validates this on every push. (#9, #13)
+
+### Improved: CI
+
+PG18 added to standard test matrix (dropped pgxn-tools workaround). `pg_stat_statements` loaded in CI for pgss-dependent testing. Degraded mode tests (without pgss, without pg_cron). Shell-level `WARNING` verification via stderr capture. SQL keywords lowercased in test file. (#14, #15, #17, #18)
+
+## Functions (38 total)
+
+| Function | Description |
+|---|---|
+| `set_debug_logging(bool)` | **New** — enable/disable per-session RAISE LOG in take_sample() |
+
+All other functions unchanged from 1.2. See README for the full reference.
+
+---
+
 # pg_ash 1.2 release notes
 
 51 commits since v1.1. Upgrade from 1.1: `\i sql/ash-1.1-to-1.2.sql`. Fresh install or upgrade from any version: `\i sql/ash-install.sql`.

--- a/sql/ash-1.0-to-1.1.sql
+++ b/sql/ash-1.0-to-1.1.sql
@@ -1,4 +1,4 @@
 -- pg_ash: upgrade from 1.0 to 1.1
 -- ash-1.1.sql is safe to run on top of 1.0 (IF NOT EXISTS / CREATE OR REPLACE)
 -- This file simply loads it.
-\i sql/ash-1.1.sql
+\ir ash-1.1.sql

--- a/sql/ash-1.2-to-1.3.sql
+++ b/sql/ash-1.2-to-1.3.sql
@@ -1,14 +1,15 @@
 -- pg_ash: upgrade from 1.2 to 1.3
 -- Safe to re-run (idempotent).
 -- Changes:
---   - Make pg_cron optional: ash.start() works without it (#7)
+--   - pg_cron now optional: ash.start() works without it (#7)
 --   - Azure / managed-service compatibility for cron.job operations (#6)
 --   - ash.set_debug_logging() — per-session RAISE LOG in take_sample() (#8)
 --     (renamed from debug_logging → set_debug_logging)
---   - take_sample() Read 1 loop: in-memory dedup, no DISTINCT scan
---   - Version column DEFAULT fix for schema parity (#9)
---   - Fix != to <> per code style
+--   - take_sample() optimization: in-memory dedup, no DISTINCT scan (#8)
 --   - pgss-dependent functions error without pg_stat_statements (#14, refs #10)
+--   - pgss-optional functions warn when pg_stat_statements missing (#17)
+--   - Version column DEFAULT fix for schema parity (#9)
+--   - Code style: != to <> (#7)
 
 -- Add debug_logging column to config if missing
 do $$

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -1,10 +1,9 @@
 -- pg_ash: Active Session History for Postgres
 -- Version: 1.3 (latest)
 -- Fresh install: \i sql/ash-install.sql
--- Upgrade from 1.0: \i sql/ash-1.0-to-1.1.sql then \i sql/ash-1.1-to-1.2.sql
--- Upgrade from 1.1: \i sql/ash-1.1-to-1.2.sql
---
--- leaves no partial schema behind.
+-- Upgrade from 1.0: \i sql/ash-1.0-to-1.1.sql, then \i sql/ash-1.1-to-1.2.sql, then \i sql/ash-1.2-to-1.3.sql
+-- Upgrade from 1.1: \i sql/ash-1.1-to-1.2.sql, then \i sql/ash-1.2-to-1.3.sql
+-- Upgrade from 1.2: \i sql/ash-1.2-to-1.3.sql
 
 
 -- Drop functions removed or changed in 1.1 (handled by DO block below)


### PR DESCRIPTION
Supersedes #20 (rebased on rename PR #21).

**Changes:**
- `RELEASE_NOTES.md` — v1.3 section with `set_debug_logging` name
- `ash-install.sql` header — complete upgrade paths to 1.3
- `ash-1.2-to-1.3.sql` header — add PRs #17, #8
- `ash-1.0-to-1.1.sql` — `\i sql/ash-1.1.sql` → `\ir ash-1.1.sql`
- `README.md` — upgrade uses `ash-1.0-to-1.1.sql`, status() example updated for v1.3 (17 metrics)

No code changes.