### PR TITLE
docs: improve ash.sample discoverability (#35)

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,25 @@ select * from ash.samples('10 minutes', 20);
 select * from ash.samples_at('2026-02-14 03:00', '2026-02-14 03:05', 50);
 ```
 
+### Dump samples to CSV
+
+Always go through `ash.samples()` / `ash.samples_at()` — the underlying `ash.sample`
+table stores a packed `integer[]` and cannot be joined directly. The defaults for
+`ash.samples()` are `p_interval => '1 hour'` and `p_limit => 100`; pass a large
+`p_limit` when dumping.
+
+```sql
+-- dump every sample from the last hour
+\copy (select * from ash.samples('1 hour'::interval, 10000000)) to '/tmp/ash.csv' csv header
+
+-- dump a specific incident window
+\copy (select * from ash.samples_at('2026-02-14 03:00', '2026-02-14 03:05', 10000000)) to '/tmp/incident.csv' csv header
+```
+
+Use `\copy` (psql) rather than server-side `COPY TO` if `/tmp` isn't writable by
+the Postgres user (managed services), and check the exit status — silently
+redirecting stderr to `/dev/null` will hide errors like typos in table names.
+
 ### Timeline chart
 
 Visualize wait event patterns over time — spot spikes, correlate with deployments, see what changed.

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -142,6 +142,12 @@ create index if not exists sample_0_datid_ts_idx on ash.sample_0 (datid, sample_
 create index if not exists sample_1_datid_ts_idx on ash.sample_1 (datid, sample_ts);
 create index if not exists sample_2_datid_ts_idx on ash.sample_2 (datid, sample_ts);
 
+comment on table ash.sample is
+$$Packed wait-event samples. One row per (sample_ts, datid). Do not join directly — use ash.samples() / ash.samples_at() for decoded rows, or ash.decode_sample(data, slot) if you need a single sample's contents.$$;
+
+comment on column ash.sample.data is
+$$Packed int4[] encoding the sample's wait events and their query_map ids. Layout: groups of (-wait_id, count, query_map_id_1, ..., query_map_id_count). A negative marker starts each group; wait_id is negated for the marker so a positive count cannot be mistaken for a group boundary. Decode via ash.samples(), ash.samples_at(), or ash.decode_sample(data, slot).$$;
+
 -- Register wait event function (upsert, returns id)
 create or replace function ash._register_wait(p_state text, p_type text, p_event text)
 returns smallint
@@ -2640,6 +2646,15 @@ begin
   end if;
 end;
 $$;
+
+comment on function ash.samples(interval, int) is
+$$Decoded wait-event samples over the last p_interval (default '1 hour'), newest first, up to p_limit rows (default 100). Returns (sample_time, database_name, active_backends, wait_event, query_id, query_text). query_text requires pg_stat_statements; NULL otherwise.$$;
+
+comment on function ash.samples_at(timestamptz, timestamptz, int) is
+$$Decoded wait-event samples between p_start and p_end, newest first, up to p_limit rows (default 100). Same return shape as ash.samples().$$;
+
+comment on function ash.decode_sample(integer[], smallint) is
+$$Decodes a single ash.sample.data array into (wait_event, query_id, count) rows. Pass p_slot (ash.sample.slot) to resolve query_ids unambiguously; omitting it searches all query_map partitions and may return a stale id after rotation.$$;
 
 -- Migration: add version column if upgrading from older version
 do $$


### PR DESCRIPTION
Closes #35 (partially — implements proposals 1, 2, 4; skipping 3 per discussion).

## Summary

- Adds `COMMENT ON TABLE/COLUMN ash.sample` so `\d+ ash.sample` tells users the data column is packed and redirects them to `ash.samples()` / `ash.decode_sample()`.
- Adds `COMMENT ON FUNCTION` for `ash.samples`, `ash.samples_at`, and `ash.decode_sample`, documenting default parameter values (`p_interval='1 hour'`, `p_limit=100`) and the pg_stat_statements dependency.
- README gains a dedicated "Dump samples to CSV" section with worked `\copy` examples.

Skipping proposal 3 (`ash.samples_flat` view): `ash.samples()` uses its interval argument to prune partitions and limit index scans — a predicate-based view would likely defeat that pushdown and be slower. Better docs is the right fix, not a second API surface.

## Test plan

- [ ] CI green across PG 14–18
- [ ] `\d+ ash.sample` shows the table/column comments after install
- [ ] `\df+ ash.samples` shows the function comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)