### PR TITLE
docs: 1.4 release (header, README, RELEASE_NOTES)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ select ash.uninstall('yes');
 -- from 1.2 to 1.3
 \i sql/ash-1.2-to-1.3.sql
 
+-- from 1.3 to 1.4
+\i sql/ash-1.3-to-1.4.sql
+
 -- check version
 select * from ash.status();
 ```
@@ -144,7 +147,7 @@ select * from ash.status();
 ```
            metric           |             value
 ----------------------------+-------------------------------
- version                    | 1.3
+ version                    | 1.4
  color                      | off
  current_slot               | 0
  sample_interval            | 00:00:01

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,32 @@
+# pg_ash 1.4 release notes
+
+Upgrade from 1.3: `\i sql/ash-1.3-to-1.4.sql`. Fresh install or upgrade from any version: `\i sql/ash-install.sql`. The upgrade script is idempotent and safe to re-run.
+
+## What changed
+
+### Fixed: take_sample() no longer silently drops samples on statement_timeout
+
+`take_sample()` now catches `query_canceled` (raised by `statement_timeout`, and also by `pg_cancel_backend()`) instead of letting the exception propagate and leave the sample unrecorded. When the sampler is interrupted, it emits a `WARNING` and returns `-1` so the caller (pg_cron or external scheduler) can observe the miss. Use `pg_terminate_backend()` if you need to hard-cancel a running sampler. (#28)
+
+### New: missed_samples counter
+
+`ash.config` gains a `missed_samples bigint not null default 0` column. Every caught `query_canceled` in `take_sample()` increments it atomically. The new value is surfaced in `ash.status()` as the `missed_samples` metric, making sampler starvation easy to spot without digging through server logs. (#27, #28)
+
+### Improved: ash.status() output
+
+`status()` now emits a `missed_samples` row alongside the existing configuration and sampling metrics. All other columns and ordering are unchanged.
+
+## Functions
+
+| Function | Description |
+|---|---|
+| `take_sample()` | **Enhanced** — catches `query_canceled`, increments `missed_samples`, returns `-1` on miss |
+| `status()` | **Enhanced** — reports the new `missed_samples` metric |
+
+All other functions unchanged from 1.3. See README for the full reference.
+
+---
+
 # pg_ash 1.3 release notes
 
 32 commits since v1.2. Upgrade from 1.2: `\i sql/ash-1.2-to-1.3.sql`. Fresh install or upgrade from any version: `\i sql/ash-install.sql`.

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -1,9 +1,10 @@
 -- pg_ash: Active Session History for Postgres
--- Version: 1.3 (latest)
+-- Version: 1.4 (latest)
 -- Fresh install: \i sql/ash-install.sql
--- Upgrade from 1.0: \i sql/ash-1.0-to-1.1.sql, then \i sql/ash-1.1-to-1.2.sql, then \i sql/ash-1.2-to-1.3.sql
--- Upgrade from 1.1: \i sql/ash-1.1-to-1.2.sql, then \i sql/ash-1.2-to-1.3.sql
--- Upgrade from 1.2: \i sql/ash-1.2-to-1.3.sql
+-- Upgrade from 1.0: \i sql/ash-1.0-to-1.1.sql, then \i sql/ash-1.1-to-1.2.sql, then \i sql/ash-1.2-to-1.3.sql, then \i sql/ash-1.3-to-1.4.sql
+-- Upgrade from 1.1: \i sql/ash-1.1-to-1.2.sql, then \i sql/ash-1.2-to-1.3.sql, then \i sql/ash-1.3-to-1.4.sql
+-- Upgrade from 1.2: \i sql/ash-1.2-to-1.3.sql, then \i sql/ash-1.3-to-1.4.sql
+-- Upgrade from 1.3: \i sql/ash-1.3-to-1.4.sql
 
 
 -- Drop functions removed or changed in 1.1 (handled by DO block below)


### PR DESCRIPTION
## Summary

Documentation-only updates that ship the 1.4 release. No SQL behavior is changed; the `sql/ash-1.3-to-1.4.sql` migration file already exists on `main`.

- `sql/ash-install.sql` header: bump `Version: 1.3 (latest)` to `1.4 (latest)`, and add `1.3 -> 1.4` to the upgrade directions (extending the existing 1.0/1.1/1.2 upgrade paths to end at 1.4). (H-REL-1)
- `README.md`: add a `1.3 to 1.4` step in the Upgrade section referencing `sql/ash-1.3-to-1.4.sql`, and update the `ash.status()` example output from `version | 1.3` to `version | 1.4`. (H-REL-2)
- `RELEASE_NOTES.md`: prepend a `# pg_ash 1.4 release notes` section summarizing the two user-visible changes in `sql/ash-1.3-to-1.4.sql` — the new `query_canceled` / `statement_timeout` handler in `take_sample()` (returns `-1`, emits WARNING) and the new `missed_samples` counter in `ash.config` / `ash.status()`. (H-REL-3)

## Test plan

- [ ] `grep -n "1.3 (latest)" sql/ash-install.sql` returns nothing; `grep -n "1.4 (latest)"` finds the header line
- [ ] `grep -n "1.3-to-1.4" sql/ash-install.sql README.md` shows the new upgrade lines
- [ ] `grep -n "version                    | 1.4" README.md` matches the status example
- [ ] `head -1 RELEASE_NOTES.md` shows `# pg_ash 1.4 release notes`
- [ ] CI (test.yml) passes on PG14-18 — docs-only change, so fresh install, upgrade path, schema equivalence, and degraded-mode suites should all remain green

Closes findings H-REL-1, H-REL-2, H-REL-3 of #37.