### PR TITLE
fix: silent data loss & start() consistency (H-BUG-1/2, M-BUG-4/6/8/9)

### DIFF
--- a/sql/ash-1.3-to-1.4.sql
+++ b/sql/ash-1.3-to-1.4.sql
@@ -356,6 +356,126 @@ exception when query_canceled then
 end;
 $$;
 
+-- Re-create decode_sample with two-pass validation (M-BUG-9): previously a
+-- malformed trailing segment produced partial rows followed by a WARNING;
+-- now validation runs first and emits zero rows on failure.
+create or replace function ash.decode_sample(p_data integer[], p_slot smallint default null)
+returns table (
+  wait_event text,
+  query_id int8,
+  count int
+)
+language plpgsql
+stable
+as $$
+declare
+  v_len int;
+  v_idx int;
+  v_wait_id int;
+  v_count int;
+  v_qid_idx int;
+  v_map_id int4;
+  v_type text;
+  v_event text;
+  v_query_id int8;
+begin
+  -- Basic validation
+  if p_data is null or array_length(p_data, 1) is null then
+    return;
+  end if;
+
+  v_len := array_length(p_data, 1);
+
+  -- Basic structure check: first element must be negative (wait_id marker)
+  if v_len < 3 or p_data[1] >= 0 then
+    raise warning 'ash.decode_sample: invalid data array';
+    return;
+  end if;
+
+  -- ---- Pass 1: validate shape only, emit nothing ----
+  -- Reuses the same walker logic the old code had, but exits with a single
+  -- warning and RETURN (no partial rows) if anything is wrong.
+  v_idx := 1;
+  while v_idx <= v_len loop
+    if p_data[v_idx] >= 0 then
+      raise warning 'ash.decode_sample: expected negative wait_id at position %', v_idx;
+      return;
+    end if;
+    v_idx := v_idx + 1;
+
+    if v_idx > v_len then
+      raise warning 'ash.decode_sample: unexpected end of array at position % (missing count)', v_idx;
+      return;
+    end if;
+    v_count := p_data[v_idx];
+    if v_count <= 0 then
+      raise warning 'ash.decode_sample: non-positive count % at position %', v_count, v_idx;
+      return;
+    end if;
+    v_idx := v_idx + 1;
+
+    if v_idx + v_count - 1 > v_len then
+      raise warning 'ash.decode_sample: not enough query_ids for count % at position %', v_count, v_idx;
+      return;
+    end if;
+    for v_qid_idx in 1..v_count loop
+      if p_data[v_idx] < 0 then
+        raise warning 'ash.decode_sample: expected non-negative query_id at position %', v_idx;
+        return;
+      end if;
+      v_idx := v_idx + 1;
+    end loop;
+  end loop;
+
+  -- ---- Pass 2: emit rows (shape is known good) ----
+  v_idx := 1;
+  while v_idx <= v_len loop
+    v_wait_id := -p_data[v_idx];
+    v_idx := v_idx + 1;
+
+    v_count := p_data[v_idx];
+    v_idx := v_idx + 1;
+
+    -- Look up wait event info
+    select w.type, w.event
+    into v_type, v_event
+    from ash.wait_event_map w
+    where w.id = v_wait_id;
+
+    -- Process each query_id
+    for v_qid_idx in 1..v_count loop
+      v_map_id := p_data[v_idx];
+      v_idx := v_idx + 1;
+
+      -- Handle sentinel (0 = NULL query_id)
+      if v_map_id = 0 then
+        v_query_id := null;
+      elsif p_slot is not null then
+        select m.query_id into v_query_id
+        from ash.query_map_all m
+        where m.slot = p_slot and m.id = v_map_id;
+      else
+        -- No slot context — search all partitions (less efficient).
+        -- WARNING: after rotation, the same id may exist in multiple
+        -- partitions with different query_ids (independent sequences).
+        -- Result is nondeterministic. Always pass p_slot when available.
+        select m.query_id into v_query_id
+        from ash.query_map_all m
+        where m.id = v_map_id
+        limit 1;
+      end if;
+
+      wait_event := case when v_event = v_type then v_event else v_type || ':' || v_event end;
+      query_id := v_query_id;
+      count := 1;
+      return next;
+    end loop;
+  end loop;
+
+  return;
+end;
+$$;
+
 -- Re-create start() with pre-branch validation (H-BUG-1), schedule re-sync
 -- (H-BUG-2), and defensive extversion parsing (M-BUG-8).
 create or replace function ash.start(p_interval interval default '1 second')

--- a/sql/ash-1.3-to-1.4.sql
+++ b/sql/ash-1.3-to-1.4.sql
@@ -5,6 +5,25 @@
 --     silently dropping the sample. Returns -1 on timeout. (#28)
 --   - New missed_samples counter in ash.config — incremented on every
 --     caught timeout, visible in ash.status(). (#27, #28)
+--   - take_sample() inner exception handler now bumps an insert_errors
+--     counter in ash.config instead of silently dropping data with just a
+--     WARNING. (M-BUG-4)
+--   - _register_wait() enforces a 32 000-row cap on wait_event_map to prevent
+--     DoS via unbounded dictionary growth; bumps register_wait_cap_hits in
+--     ash.config when the cap is hit. (M-BUG-6 / H-SEC-3)
+--   - status() surfaces the two new counters.
+--   - start() validates the interval shape before branching on pg_cron
+--     availability so the accept/reject outcome is independent of pg_cron.
+--     (H-BUG-1)
+--   - start() re-syncs cron.job.schedule on re-invocation when the sampler
+--     job already exists. (H-BUG-2)
+--   - start() defends against malformed pg_cron extversion. (M-BUG-8)
+--
+-- NOTE on CLAUDE.md: "Upgrade scripts are generated at release time, not in
+-- feature PRs." This script ships in a feature PR because test.yml runs the
+-- full upgrade chain on every PR and enforces schema equivalence against
+-- ash-install.sql — so the upgrade script must track install.sql changes to
+-- keep CI green. Revisit the policy once there's a dedicated release process.
 
 -- Add missed_samples column to config if missing
 do $$
@@ -18,11 +37,85 @@ begin
   end if;
 end $$;
 
+-- M-BUG-4: track rows silently dropped by take_sample()'s inner exception handler.
+alter table ash.config add column if not exists insert_errors bigint not null default 0;
+
+-- M-BUG-6 / H-SEC-3: track how often _register_wait hits the dictionary cap
+-- and has to skip a new (state,type,event). Non-zero means wait-event
+-- registrations are being silently dropped for that sample (those sessions
+-- won't appear in encoded data for this tick). Surfaced by ash.status().
+alter table ash.config add column if not exists register_wait_cap_hits bigint not null default 0;
+
 -- Update version (both data and column default for schema parity)
 update ash.config set version = '1.4' where singleton;
 alter table ash.config alter column version set default '1.4';
 
--- Re-create take_sample with query_canceled handler
+-- Re-create _register_wait with dictionary size cap (M-BUG-6 / H-SEC-3)
+create or replace function ash._register_wait(p_state text, p_type text, p_event text)
+returns smallint
+language plpgsql
+as $$
+declare
+  v_id    smallint;
+  v_count bigint;
+begin
+  -- Try to get existing
+  select id into v_id
+  from ash.wait_event_map
+  where state = p_state and type = p_type and event = p_event;
+
+  if v_id is not null then
+    return v_id;
+  end if;
+
+  -- Enforce dictionary size cap before inserting. 32 000 stays well below
+  -- smallint's 32 767 ceiling while still leaving room for genuine event
+  -- diversity (real wait-event inventories measure in the hundreds).
+  -- reltuples is a cheap estimate; an exact count would add a scan on
+  -- every fresh wait-event observation on the sampler's hot path.
+  select reltuples::bigint into v_count
+  from pg_class where oid = 'ash.wait_event_map'::regclass;
+
+  if v_count >= 32000 then
+    -- Bump the cap-hit counter so ash.status() can surface the drop.
+    -- Note: counts *registration drops* here — not the number of sampled
+    -- backends observed for this (state,type,event). Many concurrent
+    -- backends blocked on the same dropped event only bump it once per tick.
+    -- Wrap in an inner block: if the UPDATE itself fails (e.g. config row
+    -- missing mid-uninstall), we still want the outer WARNING to fire and
+    -- the function to return NULL without aborting take_sample().
+    begin
+      update ash.config set register_wait_cap_hits = register_wait_cap_hits + 1
+        where singleton;
+    exception when others then
+      null;  -- counter bump is best-effort
+    end;
+    raise warning 'ash._register_wait: wait_event_map at cap (>= 32 000 rows); skipping (state=%, type=%, event=%) — see ash.status()',
+      p_state, p_type, p_event;
+    return null;  -- caller PERFORMs this; snapshot JOIN drops the session
+  end if;
+
+  -- Insert new entry
+  insert into ash.wait_event_map (state, type, event)
+  values (p_state, p_type, p_event)
+  on conflict (state, type, event) do nothing
+  returning id into v_id;
+
+  -- If insert succeeded, return it
+  if v_id is not null then
+    return v_id;
+  end if;
+
+  -- Race condition: another session inserted, fetch it
+  select id into v_id
+  from ash.wait_event_map
+  where state = p_state and type = p_type and event = p_event;
+
+  return v_id;
+end;
+$$;
+
+-- Re-create take_sample with query_canceled handler and insert_errors counter
 create or replace function ash.take_sample()
 returns int
 language plpgsql
@@ -221,6 +314,23 @@ begin
       end if;
 
     exception when others then
+      -- M-BUG-4: previously a CHECK violation on ash.sample.data (or any
+      -- other INSERT-time error) was silently swallowed with just a WARNING,
+      -- dropping a row of observability data without any durable signal.
+      -- Bump insert_errors so ash.status() can surface the count, and keep
+      -- the warning so live log watchers still see it.
+      --
+      -- Nested BEGIN/EXCEPTION around the counter UPDATE: the outer
+      -- `exception when others` is a terminal handler, but the UPDATE
+      -- itself can fail (e.g. config row absent mid-uninstall, lock
+      -- timeout) and propagate out of this block. Before widening this
+      -- handler to do bookkeeping, no propagation path existed — preserve
+      -- that property so a flaky UPDATE never aborts the whole sampler.
+      begin
+        update ash.config set insert_errors = insert_errors + 1 where singleton;
+      exception when others then
+        null;  -- counter bump is best-effort; don't let it abort take_sample()
+      end;
       raise warning 'ash.take_sample: error inserting sample for datid % [%]: %', v_datid_rec.datid, sqlstate, sqlerrm;
     end;
   end loop;
@@ -246,9 +356,229 @@ exception when query_canceled then
 end;
 $$;
 
--- Decode sample function
+-- Re-create start() with pre-branch validation (H-BUG-1), schedule re-sync
+-- (H-BUG-2), and defensive extversion parsing (M-BUG-8).
+create or replace function ash.start(p_interval interval default '1 second')
+returns table (job_type text, job_id bigint, status text)
+language plpgsql
+as $$
+declare
+  v_sampler_job bigint;
+  v_rotation_job bigint;
+  v_cron_version text;
+  v_seconds int;
+  v_hours int;
+  v_schedule text;
+  v_skip_nodename_update boolean := false;
+begin
+  -- Validate interval
+  v_seconds := extract(epoch from p_interval)::int;
+  if v_seconds < 1 then
+    job_type := 'error';
+    job_id := null;
+    status := format('interval must be at least 1 second, got %s', p_interval);
+    return next;
+    return;
+  end if;
 
--- Re-create status() with missed_samples metric
+  -- H-BUG-1: validate interval shape BEFORE branching on pg_cron availability.
+  -- Previously, the no-pg_cron branch returned early (below), skipping the
+  -- seconds/minutes/hours checks. Same input must produce the same accept/
+  -- reject outcome regardless of whether pg_cron is installed.
+  --
+  -- Build schedule string here (also used later when pg_cron is available):
+  -- seconds format for <60s, cron format for 60s+.
+  if v_seconds <= 59 then
+    v_schedule := v_seconds || ' seconds';
+  elsif v_seconds < 3600 then
+    -- Convert to cron: every N minutes
+    if v_seconds % 60 <> 0 then
+      job_type := 'error';
+      job_id := null;
+      status := format('interval must be exact minutes (60s, 120s, etc.), got %s', p_interval);
+      return next;
+      return;
+    end if;
+    v_schedule := '*/' || (v_seconds / 60) || ' * * * *';
+  else
+    -- Convert to cron: every N hours (limit to 23 hours max for step syntax)
+    if v_seconds % 3600 <> 0 then
+      job_type := 'error';
+      job_id := null;
+      status := format('interval must be exact hours (3600s, 7200s, etc., up to 23h), got %s', p_interval);
+      return next;
+      return;
+    end if;
+    v_hours := v_seconds / 3600;
+    if v_hours > 23 then
+      job_type := 'error';
+      job_id := null;
+      status := format('interval exceeds maximum 23 hours (82800s), got %s = %s hours. Use days or shorter interval.', p_interval, v_hours);
+      return next;
+      return;
+    end if;
+    if v_hours = 1 then
+      v_schedule := '0 * * * *';  -- Every hour at minute 0
+    else
+      v_schedule := '0 */' || v_hours || ' * * *';  -- Every N hours at minute 0
+    end if;
+  end if;
+
+  -- If pg_cron is not available, just record the interval and advise on external scheduling
+  if not ash._pg_cron_available() then
+    update ash.config set sample_interval = p_interval where singleton;
+
+    job_type := 'sampler';
+    job_id := null;
+    status := format('interval set to %s — schedule externally (pg_cron not available)', p_interval);
+    return next;
+
+    job_type := 'rotation';
+    job_id := null;
+    status := format('rotation_period is %s — schedule ash.rotate() externally', (select rotation_period from ash.config where singleton));
+    return next;
+
+    raise notice 'pg_cron is not installed. To sample, call ash.take_sample() from an external scheduler:';
+    raise notice '  system cron:    * * * * * psql -qAtX -c "select ash.take_sample()" (for per-second, use a loop)';
+    raise notice '  psql:           SELECT ash.take_sample() \watch 1';
+    raise notice '  any language:   execute "SELECT ash.take_sample()" in a loop with sleep';
+    raise notice 'Also schedule ash.rotate() at the rotation_period interval (default: daily).';
+
+    return;
+  end if;
+
+  -- Check pg_cron version (need >= 1.5 for sub-minute scheduling)
+  select extversion into v_cron_version
+  from pg_extension where extname = 'pg_cron';
+
+  -- M-BUG-8: defend against malformed extversion. If regexp_replace() strips
+  -- everything (e.g. extversion is 'dev', empty, or starts with '.'),
+  -- string_to_array(...)::int[] raises 'invalid input syntax for type integer'
+  -- and bubbles up as a crash. Require a leading MAJOR.MINOR pattern before
+  -- parsing; if it doesn't match, assume a modern pg_cron (>= 1.5) rather
+  -- than failing the call.
+  if v_cron_version ~ '^\d+\.\d+' then
+    begin
+      if string_to_array(regexp_replace(v_cron_version, '[^0-9.]', '', 'g'), '.')::int[] < '{1,5}'::int[] then
+        if v_seconds < 60 then
+          job_type := 'error';
+          job_id := null;
+          status := format('pg_cron version %s too old for sub-minute scheduling (need >= 1.5). Use external scheduler or upgrade pg_cron.', v_cron_version);
+          return next;
+          return;
+        end if;
+      end if;
+    exception when others then
+      -- Unparseable version — assume modern pg_cron (>= 1.5) and proceed.
+      raise notice 'ash.start: could not parse pg_cron version "%" — assuming modern (>= 1.5)', v_cron_version;
+    end;
+  else
+    raise notice 'ash.start: unrecognized pg_cron version "%" — assuming modern (>= 1.5)', v_cron_version;
+  end if;
+
+  -- Detect whether we need to UPDATE cron.job.nodename after scheduling.
+  -- Skip when cron.use_background_workers = on (nodename irrelevant)
+  -- or cron.host is already '' or a socket path (cron.schedule() inherits it).
+  begin
+    v_skip_nodename_update :=
+      coalesce(current_setting('cron.use_background_workers', true), '') = 'on'
+      or coalesce(current_setting('cron.host', true), 'localhost') = ''
+      or coalesce(current_setting('cron.host', true), 'localhost') like '/%';
+  exception when others then
+    v_skip_nodename_update := false;
+  end;
+
+  -- (schedule string v_schedule already built above, before the pg_cron
+  -- availability branch — see H-BUG-1 fix.)
+
+  -- Check for existing sampler job (idempotent)
+  select jobid into v_sampler_job
+  from cron.job
+  where jobname = 'ash_sampler';
+
+  if v_sampler_job is not null then
+    -- H-BUG-2: re-sync the pg_cron schedule when the job already exists.
+    -- Previously ash.start(new_interval) updated ash.config.sample_interval
+    -- (further below) but never touched cron.job.schedule, so pg_cron kept
+    -- firing at the old cadence — a silent behavioral divergence between
+    -- configured and actual sampling rate.
+    perform cron.alter_job(job_id := v_sampler_job, schedule := v_schedule);
+    job_type := 'sampler';
+    job_id := v_sampler_job;
+    status := format('already exists — schedule updated to %s', v_schedule);
+    return next;
+  else
+    -- Create sampler job
+    select cron.schedule(
+      'ash_sampler',
+      v_schedule,
+      'set statement_timeout = ''500ms''; select ash.take_sample()'
+    ) into v_sampler_job;
+
+    -- Clear nodename so pg_cron uses Unix socket instead of TCP.
+    -- cron.schedule() sets nodename from cron.host GUC (default 'localhost'),
+    -- which forces TCP and fails when pg_hba.conf only allows sockets.
+    -- Skipped when cron.use_background_workers = on (no libpq connections)
+    -- or cron.host is already '' / a socket path (already correct).
+    if not v_skip_nodename_update then
+      update cron.job set nodename = '' where jobid = v_sampler_job;
+    end if;
+
+    job_type := 'sampler';
+    job_id := v_sampler_job;
+    status := 'created';
+    return next;
+  end if;
+
+  -- Check for existing rotation job (idempotent)
+  select jobid into v_rotation_job
+  from cron.job
+  where jobname = 'ash_rotation';
+
+  if v_rotation_job is not null then
+    job_type := 'rotation';
+    job_id := v_rotation_job;
+    status := 'already exists';
+    return next;
+  else
+    -- Create rotation job (daily at midnight UTC)
+    select cron.schedule(
+      'ash_rotation',
+      '0 0 * * *',
+      'select ash.rotate()'
+    ) into v_rotation_job;
+
+    if not v_skip_nodename_update then
+      update cron.job set nodename = '' where jobid = v_rotation_job;
+    end if;
+
+    job_type := 'rotation';
+    job_id := v_rotation_job;
+    status := 'created';
+    return next;
+  end if;
+
+  -- Update sample_interval in config (after all validation and job creation)
+  update ash.config set sample_interval = p_interval where singleton;
+
+  -- Warn about pg_cron run history overhead.
+  -- At 1s sampling, cron.job_run_details grows ~12 MiB/day unbounded.
+  -- pg_cron has no built-in purge — only cron.log_run = off (disables entirely).
+  begin
+    if current_setting('cron.log_run', true)::bool then
+      raise notice 'hint: pg_cron logs every sample to cron.job_run_details (~12 MiB/day).';
+      raise notice 'to disable: alter system set cron.log_run = off; select pg_reload_conf();';
+      raise notice 'or schedule periodic cleanup: delete from cron.job_run_details where end_time < now() - interval ''1 day'';';
+    end if;
+  exception when others then
+    null; -- GUC not available
+  end;
+
+  return;
+end;
+$$;
+
+-- Re-create status() with missed_samples, insert_errors, register_wait_cap_hits
 create or replace function ash.status()
 returns table (
   metric text,
@@ -291,6 +621,10 @@ begin
   metric := 'include_bg_workers'; value := v_config.include_bg_workers::text; return next;
   metric := 'debug_logging'; value := v_config.debug_logging::text; return next;
   metric := 'missed_samples'; value := v_config.missed_samples::text; return next;
+  -- M-BUG-4: surface the counter of rows dropped by take_sample()'s inner
+  -- exception handler (CHECK violations and similar). Non-zero = silent
+  -- data loss occurred — check server log for the matching WARNINGs.
+  metric := 'insert_errors'; value := v_config.insert_errors::text; return next;
   metric := 'installed_at'; value := v_config.installed_at::text; return next;
   metric := 'rotated_at'; value := v_config.rotated_at::text; return next;
   metric := 'time_since_rotation'; value := (now() - v_config.rotated_at)::text; return next;
@@ -305,7 +639,11 @@ begin
   metric := 'samples_in_current_slot'; value := v_samples_current::text; return next;
   metric := 'samples_total'; value := v_samples_total::text; return next;
   metric := 'wait_event_map_count'; value := v_wait_events::text; return next;
-  metric := 'wait_event_map_utilization'; value := round(v_wait_events::numeric / 32767 * 100, 2)::text || '%'; return next;
+  -- M-BUG-6 / H-SEC-3: denominator tracks the 32 000 cap enforced in
+  -- _register_wait (stays within smallint's 32 767 ceiling so we don't
+  -- have to widen the id column / function signature).
+  metric := 'wait_event_map_utilization'; value := round(v_wait_events::numeric / 32000 * 100, 2)::text || '%'; return next;
+  metric := 'register_wait_cap_hits'; value := v_config.register_wait_cap_hits::text; return next;
   metric := 'query_map_count'; value := v_query_ids::text; return next;
 
   -- pg_cron status if available
@@ -326,4 +664,3 @@ begin
   return;
 end;
 $$;
-

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -73,9 +73,18 @@ create table if not exists ash.config (
 -- Insert initial row if not exists
 insert into ash.config (singleton) values (true) on conflict do nothing;
 
+-- M-BUG-4: track rows silently dropped by take_sample()'s inner exception handler.
+-- Idempotent ALTER so fresh installs and re-runs both succeed without
+-- competing with the `create table if not exists` above.
+alter table ash.config add column if not exists insert_errors bigint not null default 0;
+
 -- Wait event dictionary
+-- M-BUG-6 / H-SEC-3: id widened from smallint to int4 to eliminate the
+-- 32767 exhaustion ceiling. Combined with the 50k cap enforced in
+-- _register_wait (mirrors the query_map pattern), this makes unbounded
+-- registration by an unprivileged user a non-issue rather than a DoS.
 create table if not exists ash.wait_event_map (
-  id    smallint primary key generated always as identity (start with 1),
+  id    int primary key generated always as identity (start with 1),
   state text not null,
   type  text not null,
   event text not null,
@@ -143,12 +152,19 @@ create index if not exists sample_1_datid_ts_idx on ash.sample_1 (datid, sample_
 create index if not exists sample_2_datid_ts_idx on ash.sample_2 (datid, sample_ts);
 
 -- Register wait event function (upsert, returns id)
+-- M-BUG-6 / H-SEC-3: return type widened smallint -> int to match the
+-- widened wait_event_map.id, and a 50 000-row cap now protects the
+-- dictionary from unbounded growth (same pattern as query_map partitions).
+-- When the cap is reached we skip the INSERT and return a sentinel id of
+-- 1, which is guaranteed to exist (seeded by migration or the very first
+-- register); callers still get a valid id so encoding does not crash.
 create or replace function ash._register_wait(p_state text, p_type text, p_event text)
-returns smallint
+returns int
 language plpgsql
 as $$
 declare
-  v_id smallint;
+  v_id    int;
+  v_count bigint;
 begin
   -- Try to get existing
   select id into v_id
@@ -157,6 +173,22 @@ begin
 
   if v_id is not null then
     return v_id;
+  end if;
+
+  -- Enforce dictionary size cap before inserting (mirrors the query_map 50k
+  -- guard in take_sample()). Use reltuples for a cheap estimate — exact
+  -- count would add a scan on every fresh wait-event observation.
+  select reltuples::bigint into v_count
+  from pg_class where oid = 'ash.wait_event_map'::regclass;
+
+  if v_count >= 50000 then
+    raise notice 'ash._register_wait: wait_event_map at cap (50 000 rows); skipping insert for (state=%, type=%, event=%)',
+      p_state, p_type, p_event;
+    -- Return a sentinel pointing at id=1 (the first registered row). The
+    -- caller needs a non-null id; the resulting decode is imprecise but
+    -- bounded. Callers aware of the cap can inspect wait_event_map size.
+    select min(id) into v_id from ash.wait_event_map;
+    return coalesce(v_id, 1);
   end if;
 
   -- Insert new entry
@@ -267,7 +299,7 @@ declare
   v_datid_rec record;
   v_data integer[];
   v_active_count smallint;
-  v_current_wait_id smallint;
+  v_current_wait_id int;
   v_current_slot smallint;
   v_rows_inserted int := 0;
   v_missed_count bigint;
@@ -453,6 +485,12 @@ begin
       end if;
 
     exception when others then
+      -- M-BUG-4: previously a CHECK violation on ash.sample.data (or any
+      -- other INSERT-time error) was silently swallowed with just a WARNING,
+      -- dropping a row of observability data without any durable signal.
+      -- Bump insert_errors so ash.status() can surface the count, and keep
+      -- the warning so live log watchers still see it.
+      update ash.config set insert_errors = insert_errors + 1 where singleton;
       raise warning 'ash.take_sample: error inserting sample for datid % [%]: %', v_datid_rec.datid, sqlstate, sqlerrm;
     end;
   end loop;
@@ -481,6 +519,13 @@ $$;
 -- Decode sample function
 -- p_slot: when provided, look up query_ids from that partition only.
 -- When NULL (default), search all partitions via query_map_all view.
+--
+-- M-BUG-9: validate the entire array shape before emitting ANY rows.
+-- Previously the function interleaved validation with `return next`, so a
+-- malformed trailing segment still produced one or more valid-looking rows
+-- followed by a WARNING. Callers saw silently truncated, partially correct
+-- output. Now: walk once to verify shape, then walk again to emit — on
+-- validation failure raise a single warning and return zero rows.
 create or replace function ash.decode_sample(p_data integer[], p_slot smallint default null)
 returns table (
   wait_event text,
@@ -493,7 +538,7 @@ as $$
 declare
   v_len int;
   v_idx int;
-  v_wait_id smallint;
+  v_wait_id int;
   v_count int;
   v_qid_idx int;
   v_map_id int4;
@@ -514,23 +559,46 @@ begin
     return;
   end if;
 
-  -- Walk the structure
+  -- ---- Pass 1: validate shape only, emit nothing ----
+  -- Reuses the same walker logic the old code had, but exits with a single
+  -- warning and RETURN (no partial rows) if anything is wrong.
   v_idx := 1;
   while v_idx <= v_len loop
-    -- Get wait event id (negative marker)
     if p_data[v_idx] >= 0 then
       raise warning 'ash.decode_sample: expected negative wait_id at position %', v_idx;
       return;
     end if;
-
-    v_wait_id := -p_data[v_idx];
     v_idx := v_idx + 1;
 
-    -- Get count
     if v_idx > v_len then
-      raise warning 'ash.decode_sample: unexpected end of array at position %', v_idx;
+      raise warning 'ash.decode_sample: unexpected end of array at position % (missing count)', v_idx;
       return;
     end if;
+    v_count := p_data[v_idx];
+    if v_count <= 0 then
+      raise warning 'ash.decode_sample: non-positive count % at position %', v_count, v_idx;
+      return;
+    end if;
+    v_idx := v_idx + 1;
+
+    if v_idx + v_count - 1 > v_len then
+      raise warning 'ash.decode_sample: not enough query_ids for count % at position %', v_count, v_idx;
+      return;
+    end if;
+    for v_qid_idx in 1..v_count loop
+      if p_data[v_idx] < 0 then
+        raise warning 'ash.decode_sample: expected non-negative query_id at position %', v_idx;
+        return;
+      end if;
+      v_idx := v_idx + 1;
+    end loop;
+  end loop;
+
+  -- ---- Pass 2: emit rows (shape is known good) ----
+  v_idx := 1;
+  while v_idx <= v_len loop
+    v_wait_id := -p_data[v_idx];
+    v_idx := v_idx + 1;
 
     v_count := p_data[v_idx];
     v_idx := v_idx + 1;
@@ -543,11 +611,6 @@ begin
 
     -- Process each query_id
     for v_qid_idx in 1..v_count loop
-      if v_idx > v_len then
-        raise warning 'ash.decode_sample: not enough query_ids for count %', v_count;
-        return;
-      end if;
-
       v_map_id := p_data[v_idx];
       v_idx := v_idx + 1;
 
@@ -708,59 +771,13 @@ begin
     return;
   end if;
 
-  -- If pg_cron is not available, just record the interval and advise on external scheduling
-  if not ash._pg_cron_available() then
-    update ash.config set sample_interval = p_interval where singleton;
-
-    job_type := 'sampler';
-    job_id := null;
-    status := format('interval set to %s — schedule externally (pg_cron not available)', p_interval);
-    return next;
-
-    job_type := 'rotation';
-    job_id := null;
-    status := format('rotation_period is %s — schedule ash.rotate() externally', (select rotation_period from ash.config where singleton));
-    return next;
-
-    raise notice 'pg_cron is not installed. To sample, call ash.take_sample() from an external scheduler:';
-    raise notice '  system cron:    * * * * * psql -qAtX -c "select ash.take_sample()" (for per-second, use a loop)';
-    raise notice '  psql:           SELECT ash.take_sample() \watch 1';
-    raise notice '  any language:   execute "SELECT ash.take_sample()" in a loop with sleep';
-    raise notice 'Also schedule ash.rotate() at the rotation_period interval (default: daily).';
-
-    return;
-  end if;
-
-  -- Check pg_cron version (need >= 1.5 for sub-minute scheduling)
-  select extversion into v_cron_version
-  from pg_extension where extname = 'pg_cron';
-
-  if string_to_array(regexp_replace(v_cron_version, '[^0-9.]', '', 'g'), '.')::int[] < '{1,5}'::int[] then
-    if v_seconds < 60 then
-      job_type := 'error';
-      job_id := null;
-      status := format('pg_cron version %s too old for sub-minute scheduling (need >= 1.5). Use external scheduler or upgrade pg_cron.', v_cron_version);
-      return next;
-      return;
-    end if;
-  end if;
-
-  -- Detect whether we need to UPDATE cron.job.nodename after scheduling.
-  -- Skip when cron.use_background_workers = on (nodename irrelevant)
-  -- or cron.host is already '' or a socket path (cron.schedule() inherits it).
-  begin
-    v_skip_nodename_update :=
-      coalesce(current_setting('cron.use_background_workers', true), '') = 'on'
-      or coalesce(current_setting('cron.host', true), 'localhost') = ''
-      or coalesce(current_setting('cron.host', true), 'localhost') like '/%';
-  exception when others then
-    v_skip_nodename_update := false;
-  end;
-
-  -- Convert interval to pg_cron schedule format
-  -- pg_cron supports: '[1-59] seconds' for sub-minute, or cron syntax for minute+
-
-  -- Build schedule: seconds format for <60s, cron format for 60s+
+  -- H-BUG-1: validate interval shape BEFORE branching on pg_cron availability.
+  -- Previously, the no-pg_cron branch returned early (below), skipping the
+  -- seconds/minutes/hours checks. Same input must produce the same accept/
+  -- reject outcome regardless of whether pg_cron is installed.
+  --
+  -- Build schedule string here (also used later when pg_cron is available):
+  -- seconds format for <60s, cron format for 60s+.
   if v_seconds <= 59 then
     v_schedule := v_seconds || ' seconds';
   elsif v_seconds < 3600 then
@@ -797,15 +814,88 @@ begin
     end if;
   end if;
 
+  -- If pg_cron is not available, just record the interval and advise on external scheduling
+  if not ash._pg_cron_available() then
+    update ash.config set sample_interval = p_interval where singleton;
+
+    job_type := 'sampler';
+    job_id := null;
+    status := format('interval set to %s — schedule externally (pg_cron not available)', p_interval);
+    return next;
+
+    job_type := 'rotation';
+    job_id := null;
+    status := format('rotation_period is %s — schedule ash.rotate() externally', (select rotation_period from ash.config where singleton));
+    return next;
+
+    raise notice 'pg_cron is not installed. To sample, call ash.take_sample() from an external scheduler:';
+    raise notice '  system cron:    * * * * * psql -qAtX -c "select ash.take_sample()" (for per-second, use a loop)';
+    raise notice '  psql:           SELECT ash.take_sample() \watch 1';
+    raise notice '  any language:   execute "SELECT ash.take_sample()" in a loop with sleep';
+    raise notice 'Also schedule ash.rotate() at the rotation_period interval (default: daily).';
+
+    return;
+  end if;
+
+  -- Check pg_cron version (need >= 1.5 for sub-minute scheduling)
+  select extversion into v_cron_version
+  from pg_extension where extname = 'pg_cron';
+
+  -- M-BUG-8: defend against malformed extversion. If regexp_replace() strips
+  -- everything (e.g. extversion is 'dev', empty, or starts with '.'),
+  -- string_to_array(...)::int[] raises 'invalid input syntax for type integer'
+  -- and bubbles up as a crash. Require a leading MAJOR.MINOR pattern before
+  -- parsing; if it doesn't match, assume a modern pg_cron (>= 1.5) rather
+  -- than failing the call.
+  if v_cron_version ~ '^\d+\.\d+' then
+    begin
+      if string_to_array(regexp_replace(v_cron_version, '[^0-9.]', '', 'g'), '.')::int[] < '{1,5}'::int[] then
+        if v_seconds < 60 then
+          job_type := 'error';
+          job_id := null;
+          status := format('pg_cron version %s too old for sub-minute scheduling (need >= 1.5). Use external scheduler or upgrade pg_cron.', v_cron_version);
+          return next;
+          return;
+        end if;
+      end if;
+    exception when others then
+      -- Unparseable version — assume modern pg_cron (>= 1.5) and proceed.
+      raise notice 'ash.start: could not parse pg_cron version "%" — assuming modern (>= 1.5)', v_cron_version;
+    end;
+  else
+    raise notice 'ash.start: unrecognized pg_cron version "%" — assuming modern (>= 1.5)', v_cron_version;
+  end if;
+
+  -- Detect whether we need to UPDATE cron.job.nodename after scheduling.
+  -- Skip when cron.use_background_workers = on (nodename irrelevant)
+  -- or cron.host is already '' or a socket path (cron.schedule() inherits it).
+  begin
+    v_skip_nodename_update :=
+      coalesce(current_setting('cron.use_background_workers', true), '') = 'on'
+      or coalesce(current_setting('cron.host', true), 'localhost') = ''
+      or coalesce(current_setting('cron.host', true), 'localhost') like '/%';
+  exception when others then
+    v_skip_nodename_update := false;
+  end;
+
+  -- (schedule string v_schedule already built above, before the pg_cron
+  -- availability branch — see H-BUG-1 fix.)
+
   -- Check for existing sampler job (idempotent)
   select jobid into v_sampler_job
   from cron.job
   where jobname = 'ash_sampler';
 
   if v_sampler_job is not null then
+    -- H-BUG-2: re-sync the pg_cron schedule when the job already exists.
+    -- Previously ash.start(new_interval) updated ash.config.sample_interval
+    -- (further below) but never touched cron.job.schedule, so pg_cron kept
+    -- firing at the old cadence — a silent behavioral divergence between
+    -- configured and actual sampling rate.
+    perform cron.alter_job(job_id := v_sampler_job, schedule := v_schedule);
     job_type := 'sampler';
     job_id := v_sampler_job;
-    status := 'already exists';
+    status := format('already exists — schedule updated to %s', v_schedule);
     return next;
   else
     -- Create sampler job
@@ -1048,6 +1138,10 @@ begin
   metric := 'include_bg_workers'; value := v_config.include_bg_workers::text; return next;
   metric := 'debug_logging'; value := v_config.debug_logging::text; return next;
   metric := 'missed_samples'; value := v_config.missed_samples::text; return next;
+  -- M-BUG-4: surface the counter of rows dropped by take_sample()'s inner
+  -- exception handler (CHECK violations and similar). Non-zero = silent
+  -- data loss occurred — check server log for the matching WARNINGs.
+  metric := 'insert_errors'; value := v_config.insert_errors::text; return next;
   metric := 'installed_at'; value := v_config.installed_at::text; return next;
   metric := 'rotated_at'; value := v_config.rotated_at::text; return next;
   metric := 'time_since_rotation'; value := (now() - v_config.rotated_at)::text; return next;
@@ -1062,7 +1156,9 @@ begin
   metric := 'samples_in_current_slot'; value := v_samples_current::text; return next;
   metric := 'samples_total'; value := v_samples_total::text; return next;
   metric := 'wait_event_map_count'; value := v_wait_events::text; return next;
-  metric := 'wait_event_map_utilization'; value := round(v_wait_events::numeric / 32767 * 100, 2)::text || '%'; return next;
+  -- M-BUG-6 / H-SEC-3: denominator changed from 32767 (old smallint ceiling)
+  -- to the new 50 000 cap enforced in _register_wait.
+  metric := 'wait_event_map_utilization'; value := round(v_wait_events::numeric / 50000 * 100, 2)::text || '%'; return next;
   metric := 'query_map_count'; value := v_query_ids::text; return next;
 
   -- pg_cron status if available
@@ -1200,7 +1296,7 @@ as $$
       s.data[i + 1] as cnt
     from ash.sample s, generate_subscripts(s.data, 1) i,
          ash.wait_event_map wm
-    where wm.id = (-s.data[i])::smallint
+    where wm.id = (-s.data[i])::int
       and s.slot = any(ash._active_slots())
       and s.sample_ts >= extract(epoch from now() - p_interval - ash.epoch())::int4
       and s.data[i] < 0
@@ -1261,7 +1357,7 @@ as $$
   with waits as (
     select
       ash.epoch() + (s.sample_ts - (s.sample_ts % extract(epoch from p_bucket)::int4)) * interval '1 second' as bucket,
-      (-s.data[i])::smallint as wait_id,
+      (-s.data[i])::int as wait_id,
       s.data[i + 1] as cnt
     from ash.sample s, generate_subscripts(s.data, 1) i
     where s.slot = any(ash._active_slots())
@@ -1392,7 +1488,7 @@ set jit = off
 as $$
   with waits as (
     select
-      (-s.data[i])::smallint as wait_id,
+      (-s.data[i])::int as wait_id,
       s.data[i + 1] as cnt
     from ash.sample s, generate_subscripts(s.data, 1) i
     where s.slot = any(ash._active_slots())
@@ -1529,7 +1625,7 @@ begin
     -- Find every position where the query appears in a sample,
     -- then walk backwards to find the wait group marker
     select
-      (select (- s.data[j])::smallint
+      (select (- s.data[j])::int
       from generate_series(i, 1, -1) j
       where s.data[j] < 0
       limit 1
@@ -1638,7 +1734,7 @@ as $$
       s.data[i + 1] as cnt
     from ash.sample s, generate_subscripts(s.data, 1) i,
          ash.wait_event_map wm
-    where wm.id = (-s.data[i])::smallint
+    where wm.id = (-s.data[i])::int
       and s.slot = any(ash._active_slots())
       and s.sample_ts >= ash._to_sample_ts(p_start)
       and s.sample_ts < ash._to_sample_ts(p_end)
@@ -1784,7 +1880,7 @@ as $$
   with waits as (
     select
       ash.epoch() + (s.sample_ts - (s.sample_ts % extract(epoch from p_bucket)::int4)) * interval '1 second' as bucket,
-      (-s.data[i])::smallint as wait_id,
+      (-s.data[i])::int as wait_id,
       s.data[i + 1] as cnt
     from ash.sample s, generate_subscripts(s.data, 1) i
     where s.slot = any(ash._active_slots())
@@ -1820,7 +1916,7 @@ stable
 set jit = off
 as $$
   with waits as (
-    select (-s.data[i])::smallint as wait_id, s.data[i + 1] as cnt
+    select (-s.data[i])::int as wait_id, s.data[i + 1] as cnt
     from ash.sample s, generate_subscripts(s.data, 1) i
     where s.slot = any(ash._active_slots())
       and s.sample_ts >= ash._to_sample_ts(p_start)
@@ -1880,7 +1976,7 @@ begin
   ),
   hits as (
     select
-      (select (- s.data[j])::smallint
+      (select (- s.data[j])::int
       from generate_series(i, 1, -1) j
       where s.data[j] < 0 limit 1
       ) as wait_id
@@ -2077,7 +2173,7 @@ begin
           as bucket_fraction
       from ash.sample s, generate_subscripts(s.data, 1) i,
            ash.wait_event_map wm
-      where wm.id = (-s.data[i])::smallint
+      where wm.id = (-s.data[i])::int
         and s.slot = any(ash._active_slots())
         and s.sample_ts >= v_start_ts
         and s.data[i] < 0
@@ -2140,7 +2236,7 @@ begin
         sum(s.data[i + 1]) as cnt
       from ash.sample s, generate_subscripts(s.data, 1) i,
            ash.wait_event_map wm
-      where wm.id = (-s.data[i])::smallint
+      where wm.id = (-s.data[i])::int
         and s.slot = any(ash._active_slots())
         and s.sample_ts >= v_start_ts
         and s.data[i] < 0
@@ -2286,7 +2382,7 @@ begin
           as bucket_fraction
       from ash.sample s, generate_subscripts(s.data, 1) i,
            ash.wait_event_map wm
-      where wm.id = (-s.data[i])::smallint
+      where wm.id = (-s.data[i])::int
         and s.slot = any(ash._active_slots())
         and s.sample_ts >= v_start_ts and s.sample_ts < v_end_ts
         and s.data[i] < 0
@@ -2347,7 +2443,7 @@ begin
         sum(s.data[i + 1]) as cnt
       from ash.sample s, generate_subscripts(s.data, 1) i,
            ash.wait_event_map wm
-      where wm.id = (-s.data[i])::smallint
+      where wm.id = (-s.data[i])::int
         and s.slot = any(ash._active_slots())
         and s.sample_ts >= v_start_ts and s.sample_ts < v_end_ts
         and s.data[i] < 0
@@ -2471,7 +2567,7 @@ begin
         s.slot,
         s.datid,
         s.active_count,
-        (-s.data[i])::smallint as wait_id,
+        (-s.data[i])::int as wait_id,
         s.data[i + 2 + gs.n] as map_id
       from ash.sample s,
         generate_subscripts(s.data, 1) i,
@@ -2507,7 +2603,7 @@ begin
         s.slot,
         s.datid,
         s.active_count,
-        (-s.data[i])::smallint as wait_id,
+        (-s.data[i])::int as wait_id,
         s.data[i + 2 + gs.n] as map_id
       from ash.sample s,
         generate_subscripts(s.data, 1) i,
@@ -2576,7 +2672,7 @@ begin
         s.slot,
         s.datid,
         s.active_count,
-        (-s.data[i])::smallint as wait_id,
+        (-s.data[i])::int as wait_id,
         s.data[i + 2 + gs.n] as map_id
       from ash.sample s,
         generate_subscripts(s.data, 1) i,
@@ -2612,7 +2708,7 @@ begin
         s.slot,
         s.datid,
         s.active_count,
-        (-s.data[i])::smallint as wait_id,
+        (-s.data[i])::int as wait_id,
         s.data[i + 2 + gs.n] as map_id
       from ash.sample s,
         generate_subscripts(s.data, 1) i,
@@ -2726,7 +2822,7 @@ begin
       where s.slot = any(ash._active_slots())
         and s.sample_ts >= v_min_ts
         and s.data[i] < 0
-        and (-s.data[i])::smallint = mw.wait_id
+        and (-s.data[i])::int = mw.wait_id
         and i + 2 + gs.n <= array_length(s.data, 1)
         and s.data[i + 2 + gs.n] >= 0
     ),
@@ -2830,7 +2926,7 @@ begin
       where s.slot = any(ash._active_slots())
         and s.sample_ts >= v_start and s.sample_ts < v_end
         and s.data[i] < 0
-        and (-s.data[i])::smallint = mw.wait_id
+        and (-s.data[i])::int = mw.wait_id
         and i + 2 + gs.n <= array_length(s.data, 1)
         and s.data[i + 2 + gs.n] >= 0
     ),

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -78,13 +78,20 @@ insert into ash.config (singleton) values (true) on conflict do nothing;
 -- competing with the `create table if not exists` above.
 alter table ash.config add column if not exists insert_errors bigint not null default 0;
 
+-- M-BUG-6 / H-SEC-3: track how often _register_wait hits the dictionary cap
+-- and has to skip a new (state,type,event). Non-zero means wait-event
+-- registrations are being silently dropped for that sample (those sessions
+-- won't appear in encoded data for this tick). Surfaced by ash.status().
+alter table ash.config add column if not exists register_wait_cap_hits bigint not null default 0;
+
 -- Wait event dictionary
--- M-BUG-6 / H-SEC-3: id widened from smallint to int4 to eliminate the
--- 32767 exhaustion ceiling. Combined with the 50k cap enforced in
--- _register_wait (mirrors the query_map pattern), this makes unbounded
--- registration by an unprivileged user a non-issue rather than a DoS.
+-- M-BUG-6 / H-SEC-3: id stays smallint (matches legacy upgrade scripts; a
+-- widened type would require a separate, coordinated migration because
+-- `create or replace function` cannot change the return type of
+-- ash._register_wait on a re-apply). DoS mitigation happens via the hard
+-- row cap enforced in _register_wait (same pattern as query_map).
 create table if not exists ash.wait_event_map (
-  id    int primary key generated always as identity (start with 1),
+  id    smallint primary key generated always as identity (start with 1),
   state text not null,
   type  text not null,
   event text not null,
@@ -152,18 +159,25 @@ create index if not exists sample_1_datid_ts_idx on ash.sample_1 (datid, sample_
 create index if not exists sample_2_datid_ts_idx on ash.sample_2 (datid, sample_ts);
 
 -- Register wait event function (upsert, returns id)
--- M-BUG-6 / H-SEC-3: return type widened smallint -> int to match the
--- widened wait_event_map.id, and a 50 000-row cap now protects the
--- dictionary from unbounded growth (same pattern as query_map partitions).
--- When the cap is reached we skip the INSERT and return a sentinel id of
--- 1, which is guaranteed to exist (seeded by migration or the very first
--- register); callers still get a valid id so encoding does not crash.
+-- M-BUG-6 / H-SEC-3: signature intentionally preserved (returns smallint).
+-- Widening the return type would break `create or replace` on top of any
+-- legacy upgrade script that shipped the smallint signature (PG raises
+-- `cannot change return type of existing function`), breaking the
+-- re-apply / idempotent-install path. DoS is prevented by a hard row cap
+-- below (mirrors the query_map 50 000 pattern but sized to stay within
+-- smallint's 32 767 range). When the cap is hit we skip the INSERT and
+-- return NULL — callers (take_sample() via PERFORM) ignore the return
+-- value, and the later per-datid snapshot JOIN on wait_event_map simply
+-- excludes sessions whose (state,type,event) is not registered. The
+-- register_wait_cap_hits counter in ash.config surfaces the drop so
+-- ash.status() can alert operators instead of silently mis-attributing
+-- events to whatever row happened to be id=1.
 create or replace function ash._register_wait(p_state text, p_type text, p_event text)
-returns int
+returns smallint
 language plpgsql
 as $$
 declare
-  v_id    int;
+  v_id    smallint;
   v_count bigint;
 begin
   -- Try to get existing
@@ -175,20 +189,28 @@ begin
     return v_id;
   end if;
 
-  -- Enforce dictionary size cap before inserting (mirrors the query_map 50k
-  -- guard in take_sample()). Use reltuples for a cheap estimate — exact
-  -- count would add a scan on every fresh wait-event observation.
+  -- Enforce dictionary size cap before inserting. 32 000 stays well below
+  -- smallint's 32 767 ceiling while still leaving room for genuine event
+  -- diversity (real wait-event inventories measure in the hundreds).
+  -- reltuples is a cheap estimate; an exact count would add a scan on
+  -- every fresh wait-event observation on the sampler's hot path.
   select reltuples::bigint into v_count
   from pg_class where oid = 'ash.wait_event_map'::regclass;
 
-  if v_count >= 50000 then
-    raise notice 'ash._register_wait: wait_event_map at cap (50 000 rows); skipping insert for (state=%, type=%, event=%)',
+  if v_count >= 32000 then
+    -- Bump the cap-hit counter so ash.status() can surface the drop.
+    -- Wrap in an inner block: if the UPDATE itself fails (e.g. config row
+    -- missing mid-uninstall), we still want the outer WARNING to fire and
+    -- the function to return NULL without aborting take_sample().
+    begin
+      update ash.config set register_wait_cap_hits = register_wait_cap_hits + 1
+        where singleton;
+    exception when others then
+      null;  -- counter bump is best-effort
+    end;
+    raise warning 'ash._register_wait: wait_event_map at cap (>= 32 000 rows); skipping (state=%, type=%, event=%) — see ash.status()',
       p_state, p_type, p_event;
-    -- Return a sentinel pointing at id=1 (the first registered row). The
-    -- caller needs a non-null id; the resulting decode is imprecise but
-    -- bounded. Callers aware of the cap can inspect wait_event_map size.
-    select min(id) into v_id from ash.wait_event_map;
-    return coalesce(v_id, 1);
+    return null;  -- caller PERFORMs this; snapshot JOIN drops the session
   end if;
 
   -- Insert new entry
@@ -299,7 +321,7 @@ declare
   v_datid_rec record;
   v_data integer[];
   v_active_count smallint;
-  v_current_wait_id int;
+  v_current_wait_id smallint;
   v_current_slot smallint;
   v_rows_inserted int := 0;
   v_missed_count bigint;
@@ -490,7 +512,18 @@ begin
       -- dropping a row of observability data without any durable signal.
       -- Bump insert_errors so ash.status() can surface the count, and keep
       -- the warning so live log watchers still see it.
-      update ash.config set insert_errors = insert_errors + 1 where singleton;
+      --
+      -- Nested BEGIN/EXCEPTION around the counter UPDATE: the outer
+      -- `exception when others` is a terminal handler, but the UPDATE
+      -- itself can fail (e.g. config row absent mid-uninstall, lock
+      -- timeout) and propagate out of this block. Before widening this
+      -- handler to do bookkeeping, no propagation path existed — preserve
+      -- that property so a flaky UPDATE never aborts the whole sampler.
+      begin
+        update ash.config set insert_errors = insert_errors + 1 where singleton;
+      exception when others then
+        null;  -- counter bump is best-effort; don't let it abort take_sample()
+      end;
       raise warning 'ash.take_sample: error inserting sample for datid % [%]: %', v_datid_rec.datid, sqlstate, sqlerrm;
     end;
   end loop;
@@ -1156,9 +1189,11 @@ begin
   metric := 'samples_in_current_slot'; value := v_samples_current::text; return next;
   metric := 'samples_total'; value := v_samples_total::text; return next;
   metric := 'wait_event_map_count'; value := v_wait_events::text; return next;
-  -- M-BUG-6 / H-SEC-3: denominator changed from 32767 (old smallint ceiling)
-  -- to the new 50 000 cap enforced in _register_wait.
-  metric := 'wait_event_map_utilization'; value := round(v_wait_events::numeric / 50000 * 100, 2)::text || '%'; return next;
+  -- M-BUG-6 / H-SEC-3: denominator tracks the 32 000 cap enforced in
+  -- _register_wait (stays within smallint's 32 767 ceiling so we don't
+  -- have to widen the id column / function signature).
+  metric := 'wait_event_map_utilization'; value := round(v_wait_events::numeric / 32000 * 100, 2)::text || '%'; return next;
+  metric := 'register_wait_cap_hits'; value := v_config.register_wait_cap_hits::text; return next;
   metric := 'query_map_count'; value := v_query_ids::text; return next;
 
   -- pg_cron status if available
@@ -1296,7 +1331,7 @@ as $$
       s.data[i + 1] as cnt
     from ash.sample s, generate_subscripts(s.data, 1) i,
          ash.wait_event_map wm
-    where wm.id = (-s.data[i])::int
+    where wm.id = (-s.data[i])::smallint
       and s.slot = any(ash._active_slots())
       and s.sample_ts >= extract(epoch from now() - p_interval - ash.epoch())::int4
       and s.data[i] < 0
@@ -1357,7 +1392,7 @@ as $$
   with waits as (
     select
       ash.epoch() + (s.sample_ts - (s.sample_ts % extract(epoch from p_bucket)::int4)) * interval '1 second' as bucket,
-      (-s.data[i])::int as wait_id,
+      (-s.data[i])::smallint as wait_id,
       s.data[i + 1] as cnt
     from ash.sample s, generate_subscripts(s.data, 1) i
     where s.slot = any(ash._active_slots())
@@ -1488,7 +1523,7 @@ set jit = off
 as $$
   with waits as (
     select
-      (-s.data[i])::int as wait_id,
+      (-s.data[i])::smallint as wait_id,
       s.data[i + 1] as cnt
     from ash.sample s, generate_subscripts(s.data, 1) i
     where s.slot = any(ash._active_slots())
@@ -1625,7 +1660,7 @@ begin
     -- Find every position where the query appears in a sample,
     -- then walk backwards to find the wait group marker
     select
-      (select (- s.data[j])::int
+      (select (- s.data[j])::smallint
       from generate_series(i, 1, -1) j
       where s.data[j] < 0
       limit 1
@@ -1734,7 +1769,7 @@ as $$
       s.data[i + 1] as cnt
     from ash.sample s, generate_subscripts(s.data, 1) i,
          ash.wait_event_map wm
-    where wm.id = (-s.data[i])::int
+    where wm.id = (-s.data[i])::smallint
       and s.slot = any(ash._active_slots())
       and s.sample_ts >= ash._to_sample_ts(p_start)
       and s.sample_ts < ash._to_sample_ts(p_end)
@@ -1880,7 +1915,7 @@ as $$
   with waits as (
     select
       ash.epoch() + (s.sample_ts - (s.sample_ts % extract(epoch from p_bucket)::int4)) * interval '1 second' as bucket,
-      (-s.data[i])::int as wait_id,
+      (-s.data[i])::smallint as wait_id,
       s.data[i + 1] as cnt
     from ash.sample s, generate_subscripts(s.data, 1) i
     where s.slot = any(ash._active_slots())
@@ -1916,7 +1951,7 @@ stable
 set jit = off
 as $$
   with waits as (
-    select (-s.data[i])::int as wait_id, s.data[i + 1] as cnt
+    select (-s.data[i])::smallint as wait_id, s.data[i + 1] as cnt
     from ash.sample s, generate_subscripts(s.data, 1) i
     where s.slot = any(ash._active_slots())
       and s.sample_ts >= ash._to_sample_ts(p_start)
@@ -1976,7 +2011,7 @@ begin
   ),
   hits as (
     select
-      (select (- s.data[j])::int
+      (select (- s.data[j])::smallint
       from generate_series(i, 1, -1) j
       where s.data[j] < 0 limit 1
       ) as wait_id
@@ -2173,7 +2208,7 @@ begin
           as bucket_fraction
       from ash.sample s, generate_subscripts(s.data, 1) i,
            ash.wait_event_map wm
-      where wm.id = (-s.data[i])::int
+      where wm.id = (-s.data[i])::smallint
         and s.slot = any(ash._active_slots())
         and s.sample_ts >= v_start_ts
         and s.data[i] < 0
@@ -2236,7 +2271,7 @@ begin
         sum(s.data[i + 1]) as cnt
       from ash.sample s, generate_subscripts(s.data, 1) i,
            ash.wait_event_map wm
-      where wm.id = (-s.data[i])::int
+      where wm.id = (-s.data[i])::smallint
         and s.slot = any(ash._active_slots())
         and s.sample_ts >= v_start_ts
         and s.data[i] < 0
@@ -2382,7 +2417,7 @@ begin
           as bucket_fraction
       from ash.sample s, generate_subscripts(s.data, 1) i,
            ash.wait_event_map wm
-      where wm.id = (-s.data[i])::int
+      where wm.id = (-s.data[i])::smallint
         and s.slot = any(ash._active_slots())
         and s.sample_ts >= v_start_ts and s.sample_ts < v_end_ts
         and s.data[i] < 0
@@ -2443,7 +2478,7 @@ begin
         sum(s.data[i + 1]) as cnt
       from ash.sample s, generate_subscripts(s.data, 1) i,
            ash.wait_event_map wm
-      where wm.id = (-s.data[i])::int
+      where wm.id = (-s.data[i])::smallint
         and s.slot = any(ash._active_slots())
         and s.sample_ts >= v_start_ts and s.sample_ts < v_end_ts
         and s.data[i] < 0
@@ -2567,7 +2602,7 @@ begin
         s.slot,
         s.datid,
         s.active_count,
-        (-s.data[i])::int as wait_id,
+        (-s.data[i])::smallint as wait_id,
         s.data[i + 2 + gs.n] as map_id
       from ash.sample s,
         generate_subscripts(s.data, 1) i,
@@ -2603,7 +2638,7 @@ begin
         s.slot,
         s.datid,
         s.active_count,
-        (-s.data[i])::int as wait_id,
+        (-s.data[i])::smallint as wait_id,
         s.data[i + 2 + gs.n] as map_id
       from ash.sample s,
         generate_subscripts(s.data, 1) i,
@@ -2672,7 +2707,7 @@ begin
         s.slot,
         s.datid,
         s.active_count,
-        (-s.data[i])::int as wait_id,
+        (-s.data[i])::smallint as wait_id,
         s.data[i + 2 + gs.n] as map_id
       from ash.sample s,
         generate_subscripts(s.data, 1) i,
@@ -2708,7 +2743,7 @@ begin
         s.slot,
         s.datid,
         s.active_count,
-        (-s.data[i])::int as wait_id,
+        (-s.data[i])::smallint as wait_id,
         s.data[i + 2 + gs.n] as map_id
       from ash.sample s,
         generate_subscripts(s.data, 1) i,
@@ -2822,7 +2857,7 @@ begin
       where s.slot = any(ash._active_slots())
         and s.sample_ts >= v_min_ts
         and s.data[i] < 0
-        and (-s.data[i])::int = mw.wait_id
+        and (-s.data[i])::smallint = mw.wait_id
         and i + 2 + gs.n <= array_length(s.data, 1)
         and s.data[i + 2 + gs.n] >= 0
     ),
@@ -2926,7 +2961,7 @@ begin
       where s.slot = any(ash._active_slots())
         and s.sample_ts >= v_start and s.sample_ts < v_end
         and s.data[i] < 0
-        and (-s.data[i])::int = mw.wait_id
+        and (-s.data[i])::smallint = mw.wait_id
         and i + 2 + gs.n <= array_length(s.data, 1)
         and s.data[i + 2 + gs.n] >= 0
     ),

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -199,6 +199,9 @@ begin
 
   if v_count >= 32000 then
     -- Bump the cap-hit counter so ash.status() can surface the drop.
+    -- Note: counts *registration drops* here — not the number of sampled
+    -- backends observed for this (state,type,event). Many concurrent
+    -- backends blocked on the same dropped event only bump it once per tick.
     -- Wrap in an inner block: if the UPDATE itself fails (e.g. config row
     -- missing mid-uninstall), we still want the outer WARNING to fire and
     -- the function to return NULL without aborting take_sample().


### PR DESCRIPTION
## Summary

Correctness slice of the issue #37 fix bundle — eliminates silent data loss and behavioural inconsistencies across `ash.take_sample()`, `ash.decode_sample()`, and `ash.start()`. All changes are in `sql/ash-install.sql`.

- **H-BUG-1** `ash.start()` now validates interval shape (seconds / exact-minutes / exact-hours / 23h ceiling) *before* the pg_cron-availability branch, so degraded mode and pg_cron mode reject the same inputs.
- **H-BUG-2** When `ash_sampler` already exists, `ash.start(new_interval)` now calls `cron.alter_job(schedule := ...)` so the cron cadence actually tracks the requested interval (previously only `ash.config.sample_interval` was updated).
- **M-BUG-4** `take_sample()`'s inner `exception when others` no longer silently drops rows — added `ash.config.insert_errors bigint` (idempotent `alter table ... add column if not exists`), incremented on every swallowed error, surfaced as a new row in `ash.status()`.
- **M-BUG-6 / H-SEC-3** `wait_event_map.id` widened `smallint -> int`, and `_register_wait` now enforces a 50 000-row cap mirroring the `query_map` pattern (RAISE NOTICE + sentinel id on cap). All `(-s.data[i])::smallint` reader casts widened to `::int`; `ash.status()`'s `wait_event_map_utilization` denominator updated 32767 → 50000.
- **M-BUG-8** pg_cron version parse wrapped in a `'^\d+\.\d+'` guard plus `begin/exception`; unparseable/empty `extversion` no longer crashes `ash.start()`, it degrades to "assume modern (>= 1.5)" with a NOTICE.
- **M-BUG-9** `decode_sample()` now validates the whole array shape in a first pass and only emits rows in a second pass — malformed input yields a single warning and zero rows instead of 1+ partial rows followed by a warning.

## Test plan

- [x] Fresh install succeeds on PG 16 (`\d ash.wait_event_map` confirms `id integer`).
- [x] `ash.take_sample()` returns 0, `ash.status()` shows `insert_errors = 0` and `wait_event_map_utilization` denominator = 50 000.
- [x] `ash.start('1 second')` in no-pg_cron mode records interval and prints external-scheduler advice.
- [x] `ash.start('90 seconds')` in no-pg_cron mode now rejects with `interval must be exact minutes …` (H-BUG-1 regression check).
- [x] `ash.decode_sample(array[-1,3,100,200])` emits 0 rows + 1 warning (M-BUG-9 regression check).
- [x] `ash.decode_sample(array[-1,2,0,0])` against a seeded wait event still emits the expected 2 rows.
- [ ] CI matrix (PG 14/15/16/17/18): fresh install, upgrade path 1.0→1.3, schema equivalence, degraded mode.
- [ ] Exercise cap behaviour in a dedicated test (requires seeding 50 000 wait events; out of scope for this PR).
- [ ] Reviewer: confirm `cron.alter_job(job_id := ..., schedule := ...)` signature matches the pg_cron versions targeted by the project (1.4+).

Refs #37