### PR TITLE
security: search_path guard + REVOKE readers from PUBLIC

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,6 +139,109 @@ jobs:
           $$;
           EOF
 
+      - name: Test privilege hardening (REVOKE from PUBLIC)
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          -- Create an unprivileged role to represent a "random tenant"
+          do $$
+          begin
+            if not exists (select from pg_roles where rolname = 'ash_test_unpriv') then
+              create role ash_test_unpriv login password 'x';
+            end if;
+          end $$;
+
+          do $$
+          begin
+            -- PUBLIC has no EXECUTE on reader functions
+            assert not has_function_privilege('public', 'ash.top_waits(interval,int,int,boolean)', 'EXECUTE'),
+              'PUBLIC should NOT have EXECUTE on ash.top_waits';
+            assert not has_function_privilege('public', 'ash.top_queries(interval,int)', 'EXECUTE'),
+              'PUBLIC should NOT have EXECUTE on ash.top_queries';
+            assert not has_function_privilege('public', 'ash.status()', 'EXECUTE'),
+              'PUBLIC should NOT have EXECUTE on ash.status';
+            assert not has_function_privilege('public', 'ash.samples(interval,int)', 'EXECUTE'),
+              'PUBLIC should NOT have EXECUTE on ash.samples';
+
+            -- PUBLIC has no EXECUTE on admin functions
+            assert not has_function_privilege('public', 'ash.start(interval)', 'EXECUTE'),
+              'PUBLIC should NOT have EXECUTE on ash.start';
+            assert not has_function_privilege('public', 'ash.stop()', 'EXECUTE'),
+              'PUBLIC should NOT have EXECUTE on ash.stop';
+            assert not has_function_privilege('public', 'ash.rotate()', 'EXECUTE'),
+              'PUBLIC should NOT have EXECUTE on ash.rotate';
+            assert not has_function_privilege('public', 'ash.take_sample()', 'EXECUTE'),
+              'PUBLIC should NOT have EXECUTE on ash.take_sample';
+            assert not has_function_privilege('public', 'ash.set_debug_logging(bool)', 'EXECUTE'),
+              'PUBLIC should NOT have EXECUTE on ash.set_debug_logging';
+
+            -- PUBLIC has no SELECT on reader tables
+            assert not has_table_privilege('public', 'ash.sample', 'SELECT'),
+              'PUBLIC should NOT have SELECT on ash.sample';
+            assert not has_table_privilege('public', 'ash.config', 'SELECT'),
+              'PUBLIC should NOT have SELECT on ash.config';
+            assert not has_table_privilege('public', 'ash.wait_event_map', 'SELECT'),
+              'PUBLIC should NOT have SELECT on ash.wait_event_map';
+            assert not has_table_privilege('public', 'ash.query_map_all', 'SELECT'),
+              'PUBLIC should NOT have SELECT on ash.query_map_all';
+            assert not has_table_privilege('public', 'ash.sample_0', 'SELECT'),
+              'PUBLIC should NOT have SELECT on ash.sample_0';
+            assert not has_table_privilege('public', 'ash.query_map_0', 'SELECT'),
+              'PUBLIC should NOT have SELECT on ash.query_map_0';
+
+            -- Unprivileged role (non-owner) cannot execute readers either
+            assert not has_function_privilege('ash_test_unpriv', 'ash.top_waits(interval,int,int,boolean)', 'EXECUTE'),
+              'non-owner role should NOT have EXECUTE on ash.top_waits';
+            assert not has_function_privilege('ash_test_unpriv', 'ash.top_queries(interval,int)', 'EXECUTE'),
+              'non-owner role should NOT have EXECUTE on ash.top_queries';
+
+            -- Owner (postgres) retains EXECUTE by virtue of ownership
+            assert has_function_privilege('postgres', 'ash.top_waits(interval,int,int,boolean)', 'EXECUTE'),
+              'owner SHOULD have EXECUTE on ash.top_waits';
+            assert has_function_privilege('postgres', 'ash.start(interval)', 'EXECUTE'),
+              'owner SHOULD have EXECUTE on ash.start';
+            assert has_function_privilege('postgres', 'ash.take_sample()', 'EXECUTE'),
+              'owner SHOULD have EXECUTE on ash.take_sample';
+            assert has_table_privilege('postgres', 'ash.sample', 'SELECT'),
+              'owner SHOULD have SELECT on ash.sample';
+
+            raise notice 'Privilege hardening tests PASSED';
+          end;
+          $$;
+
+          -- Behavioral check: call as the unprivileged role, expect 42501
+          set role ash_test_unpriv;
+          do $$
+          begin
+            begin
+              perform ash.top_waits('1 hour'::interval, 10, 0);
+              raise exception 'expected permission denied, but call succeeded';
+            exception when insufficient_privilege then
+              -- expected path
+              null;
+            end;
+          end;
+          $$;
+          reset role;
+
+          -- GRANT flow smoke-test: owner can hand out EXECUTE, then REVOKE it
+          grant execute on function ash.top_waits(interval, int, int, boolean) to ash_test_unpriv;
+          do $$
+          begin
+            assert has_function_privilege('ash_test_unpriv', 'ash.top_waits(interval,int,int,boolean)', 'EXECUTE'),
+              'GRANT to non-owner role should succeed';
+          end $$;
+          revoke execute on function ash.top_waits(interval, int, int, boolean) from ash_test_unpriv;
+          do $$
+          begin
+            assert not has_function_privilege('ash_test_unpriv', 'ash.top_waits(interval,int,int,boolean)', 'EXECUTE'),
+              'REVOKE from non-owner role should succeed';
+          end $$;
+
+          drop role ash_test_unpriv;
+          EOF
+
       - name: Test sampler and decoder
         env:
           PGPASSWORD: postgres

--- a/README.md
+++ b/README.md
@@ -698,6 +698,37 @@ Don't forget to also schedule `ash.rotate()` — once per `rotation_period` (def
 0 0 * * * psql -qAtX -d mydb -c "SELECT ash.rotate();"
 ```
 
+## Privileges
+
+pg_ash installs with a locked-down privilege model: admin functions (`ash.start()`, `ash.stop()`, `ash.rotate()`, `ash.take_sample()`, `ash.set_debug_logging()`, `ash.uninstall()`) are restricted to the schema owner, and EXECUTE on all reader functions plus SELECT on reader tables (`ash.sample`, `ash.query_map_all`, `ash.config`, `ash.wait_event_map`, and per-slot partitions) is revoked from `PUBLIC`. The installing role retains full access.
+
+Grant access to a monitoring or read-only role explicitly:
+
+```sql
+-- allow a monitoring role to call the readers
+grant usage on schema ash to my_monitor_role;
+grant execute on function ash.top_waits(interval, int, int)           to my_monitor_role;
+grant execute on function ash.top_queries(interval, int)              to my_monitor_role;
+grant execute on function ash.top_queries_with_text(interval, int)    to my_monitor_role;
+grant execute on function ash.samples(interval, int)                  to my_monitor_role;
+grant execute on function ash.status()                                to my_monitor_role;
+
+-- or grant all reader functions at once
+grant execute on all functions in schema ash to my_monitor_role;
+
+-- grant direct read on raw tables for ad-hoc SQL (optional)
+grant select on all tables in schema ash to my_monitor_role;
+```
+
+### pg_stat_statements in a non-default schema
+
+pgss reader functions (`top_queries`, `top_queries_at`, `top_queries_with_text`, `samples`, `samples_at`, `event_queries`, `event_queries_at`) need the pg_stat_statements schema on their `search_path`. Install detects it automatically. If you install pg_stat_statements **after** pg_ash, or move it to a non-default schema, re-apply:
+
+```sql
+-- detect the pgss schema and re-apply search_path on pgss readers
+select ash._apply_pgss_search_path();
+```
+
 ## Known limitations
 
 - **Primary only** — pg_ash requires writes (`INSERT` into sample tables, `TRUNCATE` on rotation), so it cannot run on physical standbys or read replicas. Install it on the primary; it samples all databases from there.

--- a/sql/ash-1.3-to-1.4.sql
+++ b/sql/ash-1.3-to-1.4.sql
@@ -337,6 +337,20 @@ $$;
 do $$
 declare
   r record;
+  -- Functions that reference pg_stat_statements unqualified need public on
+  -- the search_path so the view (installed by CREATE EXTENSION pg_stat_statements
+  -- into public by default on RDS/Cloud SQL/Supabase/AlloyDB/Neon) is visible.
+  -- Without this, the probe "perform 1 from pg_stat_statements" fails with
+  -- "relation does not exist", the catch-block sets v_has_pgss=false, and the
+  -- caller either raises "pg_stat_statements extension is not installed"
+  -- (top_queries_with_text, event_queries, event_queries_at) or silently
+  -- degrades with a misleading warning (top_queries, top_queries_at, samples,
+  -- samples_at). Keep public last so ash.* still wins for ash objects.
+  v_pgss_readers text[] := array[
+    'top_queries', 'top_queries_at', 'top_queries_with_text',
+    'samples', 'samples_at',
+    'event_queries', 'event_queries_at'
+  ];
 begin
   -- Apply search_path guard to every non-trigger function in ash.*.
   -- alter function ... set search_path is idempotent.
@@ -348,8 +362,13 @@ begin
     where n.nspname = 'ash'
       and p.prokind = 'f'
   loop
-    execute format('alter function ash.%I(%s) set search_path = pg_catalog, ash',
-                   r.proname, r.args);
+    if r.proname = any(v_pgss_readers) then
+      execute format('alter function ash.%I(%s) set search_path = pg_catalog, ash, public',
+                     r.proname, r.args);
+    else
+      execute format('alter function ash.%I(%s) set search_path = pg_catalog, ash',
+                     r.proname, r.args);
+    end if;
   end loop;
 end $$;
 

--- a/sql/ash-1.3-to-1.4.sql
+++ b/sql/ash-1.3-to-1.4.sql
@@ -364,8 +364,11 @@ set search_path = pg_catalog, ash
 as $$
 declare
   v_pgss_schema text := ash._pgss_schema();
-  -- Keep in sync with v_pgss_readers in the DO block below AND with the same
-  -- list in ash-install.sql (ash._apply_pgss_search_path).
+  -- B2: keep this list in sync with v_pgss_readers in sql/ash-1.3-to-1.4.sql
+  -- (and any future upgrade scripts) AND with the per-function `set
+  -- search_path = pg_catalog, ash, public` clauses in this file. Any reader
+  -- that probes pg_stat_statements must appear here so its search_path
+  -- resolves the view across managed-service and custom pgss install schemas.
   v_readers text[] := array[
     'top_queries', 'top_queries_at', 'top_queries_with_text',
     'samples', 'samples_at',
@@ -374,6 +377,10 @@ declare
   v_path text;
   r record;
 begin
+  -- Always keep public in the path as a fallback (matches the managed-service
+  -- default and preserves behavior when pgss is not yet installed). If the
+  -- extension lives elsewhere, append that schema after public so ash.* still
+  -- wins over any user-created objects in public/<pgss_schema>.
   if v_pgss_schema is null or v_pgss_schema in ('pg_catalog', 'ash', 'public') then
     v_path := 'pg_catalog, ash, public';
   else

--- a/sql/ash-1.3-to-1.4.sql
+++ b/sql/ash-1.3-to-1.4.sql
@@ -333,25 +333,100 @@ $$;
 -- SELECT/EXECUTE from PUBLIC on reader functions, underlying tables, and
 -- per-slot partitions. Dynamic so it covers functions/partitions created by
 -- earlier upgrade scripts. All statements are idempotent.
+--
+-- IMPORTANT: the v_pgss_readers list below must stay in sync with the same
+-- list inside ash._apply_pgss_search_path() in ash-install.sql. If you add or
+-- remove a function that probes pg_stat_statements, update both places.
 -------------------------------------------------------------------------------
+
+-- Helper: detect the schema that holds the pg_stat_statements view so reader
+-- functions keep working when pgss lives outside `public` (self-hosted
+-- installs, schema-isolated setups). Mirrors ash-install.sql.
+create or replace function ash._pgss_schema()
+returns text
+language sql
+stable
+set search_path = pg_catalog
+as $$
+  select n.nspname::text
+  from pg_extension e
+  join pg_namespace n on n.oid = e.extnamespace
+  where e.extname = 'pg_stat_statements'
+$$;
+
+comment on function ash._pgss_schema() is
+  'Returns the schema name of the installed pg_stat_statements extension, or NULL if not installed. Used to keep reader functions portable across managed services and custom install schemas.';
+
+create or replace function ash._apply_pgss_search_path()
+returns text
+language plpgsql
+set search_path = pg_catalog, ash
+as $$
+declare
+  v_pgss_schema text := ash._pgss_schema();
+  -- Keep in sync with v_pgss_readers in the DO block below AND with the same
+  -- list in ash-install.sql (ash._apply_pgss_search_path).
+  v_readers text[] := array[
+    'top_queries', 'top_queries_at', 'top_queries_with_text',
+    'samples', 'samples_at',
+    'event_queries', 'event_queries_at'
+  ];
+  v_path text;
+  r record;
+begin
+  if v_pgss_schema is null or v_pgss_schema in ('pg_catalog', 'ash', 'public') then
+    v_path := 'pg_catalog, ash, public';
+  else
+    v_path := format('pg_catalog, ash, public, %I', v_pgss_schema);
+  end if;
+
+  for r in
+    select p.proname,
+           pg_catalog.pg_get_function_identity_arguments(p.oid) as args
+    from pg_catalog.pg_proc p
+    join pg_catalog.pg_namespace n on p.pronamespace = n.oid
+    where n.nspname = 'ash'
+      and p.prokind = 'f'
+      and p.proname = any(v_readers)
+  loop
+    execute format('alter function ash.%I(%s) set search_path = %s',
+                   r.proname, r.args, v_path);
+  end loop;
+
+  return v_path;
+end;
+$$;
+
+comment on function ash._apply_pgss_search_path() is
+  'Re-applies search_path on pgss reader functions using the currently detected pg_stat_statements schema. Run after installing pg_stat_statements if it lives outside the public schema.';
+
 do $$
 declare
   r record;
-  -- Functions that reference pg_stat_statements unqualified need public on
-  -- the search_path so the view (installed by CREATE EXTENSION pg_stat_statements
-  -- into public by default on RDS/Cloud SQL/Supabase/AlloyDB/Neon) is visible.
+  v_pgss_schema text := ash._pgss_schema();
+  v_pgss_path text;
+  -- Functions that reference pg_stat_statements unqualified need public (or
+  -- the detected pgss schema) on the search_path so the view is visible.
   -- Without this, the probe "perform 1 from pg_stat_statements" fails with
   -- "relation does not exist", the catch-block sets v_has_pgss=false, and the
   -- caller either raises "pg_stat_statements extension is not installed"
   -- (top_queries_with_text, event_queries, event_queries_at) or silently
   -- degrades with a misleading warning (top_queries, top_queries_at, samples,
   -- samples_at). Keep public last so ash.* still wins for ash objects.
+  -- NOTE: keep this list in sync with v_readers in ash._apply_pgss_search_path()
+  -- (both in this file and in ash-install.sql).
   v_pgss_readers text[] := array[
     'top_queries', 'top_queries_at', 'top_queries_with_text',
     'samples', 'samples_at',
     'event_queries', 'event_queries_at'
   ];
 begin
+  if v_pgss_schema is null or v_pgss_schema in ('pg_catalog', 'ash', 'public') then
+    v_pgss_path := 'pg_catalog, ash, public';
+  else
+    v_pgss_path := format('pg_catalog, ash, public, %I', v_pgss_schema);
+  end if;
+
   -- Apply search_path guard to every non-trigger function in ash.*.
   -- alter function ... set search_path is idempotent.
   for r in
@@ -363,8 +438,8 @@ begin
       and p.prokind = 'f'
   loop
     if r.proname = any(v_pgss_readers) then
-      execute format('alter function ash.%I(%s) set search_path = pg_catalog, ash, public',
-                     r.proname, r.args);
+      execute format('alter function ash.%I(%s) set search_path = %s',
+                     r.proname, r.args, v_pgss_path);
     else
       execute format('alter function ash.%I(%s) set search_path = pg_catalog, ash',
                      r.proname, r.args);

--- a/sql/ash-1.3-to-1.4.sql
+++ b/sql/ash-1.3-to-1.4.sql
@@ -327,3 +327,86 @@ begin
 end;
 $$;
 
+-------------------------------------------------------------------------------
+-- Privilege hardening (mirrors ash-install.sql changes in PR #45, issue #37).
+-- Applies search_path = pg_catalog, ash to every ash.* function and revokes
+-- SELECT/EXECUTE from PUBLIC on reader functions, underlying tables, and
+-- per-slot partitions. Dynamic so it covers functions/partitions created by
+-- earlier upgrade scripts. All statements are idempotent.
+-------------------------------------------------------------------------------
+do $$
+declare
+  r record;
+begin
+  -- Apply search_path guard to every non-trigger function in ash.*.
+  -- alter function ... set search_path is idempotent.
+  for r in
+    select p.proname,
+           pg_catalog.pg_get_function_identity_arguments(p.oid) as args
+    from pg_catalog.pg_proc p
+    join pg_catalog.pg_namespace n on p.pronamespace = n.oid
+    where n.nspname = 'ash'
+      and p.prokind = 'f'
+  loop
+    execute format('alter function ash.%I(%s) set search_path = pg_catalog, ash',
+                   r.proname, r.args);
+  end loop;
+end $$;
+
+do $$
+declare
+  v_owner text := (select nspowner::regrole::text from pg_namespace where nspname = 'ash');
+  r record;
+begin
+  -- Admin functions: only the schema owner
+  execute format('revoke all on function ash.start(interval) from public');
+  execute format('revoke all on function ash.stop() from public');
+  execute format('revoke all on function ash.uninstall(text) from public');
+  execute format('revoke all on function ash.rotate() from public');
+  execute format('revoke all on function ash.take_sample() from public');
+  execute format('revoke all on function ash.set_debug_logging(bool) from public');
+
+  execute format('grant execute on function ash.start(interval) to %I', v_owner);
+  execute format('grant execute on function ash.stop() to %I', v_owner);
+  execute format('grant execute on function ash.uninstall(text) to %I', v_owner);
+  execute format('grant execute on function ash.rotate() to %I', v_owner);
+  execute format('grant execute on function ash.take_sample() to %I', v_owner);
+  execute format('grant execute on function ash.set_debug_logging(bool) to %I', v_owner);
+
+  -- Reader/helper functions: revoke EXECUTE from PUBLIC for every non-trigger
+  -- function in ash.*. Signatures are resolved dynamically via pg_proc so
+  -- default arguments and future overloads do not cause drift. Admin
+  -- functions above are re-revoked here (harmless: REVOKE is idempotent).
+  for r in
+    select p.proname,
+           pg_catalog.pg_get_function_identity_arguments(p.oid) as args
+    from pg_catalog.pg_proc p
+    join pg_catalog.pg_namespace n on p.pronamespace = n.oid
+    where n.nspname = 'ash'
+      and p.prokind = 'f'
+  loop
+    execute format('revoke execute on function ash.%I(%s) from public',
+                   r.proname, r.args);
+  end loop;
+
+  -- Reader tables/views: revoke SELECT from PUBLIC for objects holding
+  -- sample data, query text, and configuration. REVOKE on a partitioned
+  -- parent does not cascade to partitions in PostgreSQL, so sample_N and
+  -- query_map_N are enumerated dynamically below.
+  execute 'revoke select on table ash.sample from public';
+  execute 'revoke select on table ash.query_map_all from public';
+  execute 'revoke select on table ash.config from public';
+  execute 'revoke select on table ash.wait_event_map from public';
+
+  -- Per-slot partition/dictionary tables: sample_N and query_map_N.
+  for r in
+    select c.relname
+    from pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n on c.relnamespace = n.oid
+    where n.nspname = 'ash'
+      and c.relkind in ('r', 'p')
+      and (c.relname ~ '^query_map_[0-9]+$' or c.relname ~ '^sample_[0-9]+$')
+  loop
+    execute format('revoke select on ash.%I from public', r.relname);
+  end loop;
+end $$;

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -51,6 +51,7 @@ returns timestamptz
 language sql
 immutable
 parallel safe
+set search_path = pg_catalog, ash
 as $$
   select '2026-01-01 00:00:00+00'::timestamptz
 $$;
@@ -113,6 +114,7 @@ returns smallint
 language sql
 stable
 parallel safe
+set search_path = pg_catalog, ash
 as $$
   select current_slot from ash.config where singleton
 $$;
@@ -146,6 +148,7 @@ create index if not exists sample_2_datid_ts_idx on ash.sample_2 (datid, sample_
 create or replace function ash._register_wait(p_state text, p_type text, p_event text)
 returns smallint
 language plpgsql
+set search_path = pg_catalog, ash
 as $$
 declare
   v_id smallint;
@@ -187,6 +190,7 @@ create or replace function ash._validate_data(p_data integer[])
 returns boolean
 language plpgsql
 immutable
+set search_path = pg_catalog, ash
 as $$
 declare
   v_len int;
@@ -258,6 +262,7 @@ $$;
 create or replace function ash.take_sample()
 returns int
 language plpgsql
+set search_path = pg_catalog, ash
 as $$
 declare
   v_sample_ts int4;
@@ -489,6 +494,7 @@ returns table (
 )
 language plpgsql
 stable
+set search_path = pg_catalog, ash
 as $$
 declare
   v_len int;
@@ -590,6 +596,7 @@ $$;
 create or replace function ash.rotate()
 returns text
 language plpgsql
+set search_path = pg_catalog, ash
 as $$
 declare
   v_old_slot smallint;
@@ -678,6 +685,7 @@ create or replace function ash._pg_cron_available()
 returns boolean
 language sql
 stable
+set search_path = pg_catalog, ash
 as $$
   select exists (
     select from pg_extension where extname = 'pg_cron'
@@ -688,6 +696,7 @@ $$;
 create or replace function ash.start(p_interval interval default '1 second')
 returns table (job_type text, job_id bigint, status text)
 language plpgsql
+set search_path = pg_catalog, ash
 as $$
 declare
   v_sampler_job bigint;
@@ -882,6 +891,7 @@ $$;
 create or replace function ash.stop()
 returns table (job_type text, job_id bigint, status text)
 language plpgsql
+set search_path = pg_catalog, ash
 as $$
 declare
   v_job_id bigint;
@@ -939,6 +949,7 @@ $$;
 create or replace function ash.set_debug_logging(p_enabled bool default null)
 returns text
 language plpgsql
+set search_path = pg_catalog, ash
 as $$
 declare
   v_current bool;
@@ -963,6 +974,7 @@ $$;
 create or replace function ash.uninstall(p_confirm text default null)
 returns text
 language plpgsql
+set search_path = pg_catalog, ash
 as $$
 declare
   v_rec record;
@@ -996,6 +1008,7 @@ create or replace function ash._active_slots()
 returns smallint[]
 language sql
 stable
+set search_path = pg_catalog, ash
 as $$
   select array[
     current_slot,
@@ -1014,6 +1027,7 @@ returns table (
 language plpgsql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
 declare
   v_config record;
@@ -1115,6 +1129,7 @@ create or replace function ash._color_on(p_color boolean default false)
 returns boolean
 language sql
 stable
+set search_path = pg_catalog, ash
 as $$
   select p_color or coalesce(current_setting('ash.color', true), '') in ('on', 'true', '1');
 $$;
@@ -1123,6 +1138,7 @@ create or replace function ash._wait_color(p_event text, p_color boolean default
 returns text
 language sql
 stable
+set search_path = pg_catalog, ash
 as $$
   -- All escapes padded to 19 chars: \033[38;2;RRR;GGG;BBBm
   -- Uniform length prevents pspg right-border misalignment.
@@ -1149,6 +1165,7 @@ create or replace function ash._reset(p_color boolean default false)
 returns text
 language sql
 stable
+set search_path = pg_catalog, ash
 as $$
   select case when ash._color_on(p_color) then E'\033[0m' else '' end;
 $$;
@@ -1166,6 +1183,7 @@ create or replace function ash._bar(
 returns text
 language sql
 stable
+set search_path = pg_catalog, ash
 as $$
   -- All color escapes are now exactly 19 chars (zero-padded RGB).
   -- reset is always 4 chars. Total invisible = 23 when color on, 0 when off.
@@ -1193,6 +1211,7 @@ returns table (
 language sql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
   with waits as (
     select
@@ -1257,6 +1276,7 @@ returns table (
 language sql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
   with waits as (
     select
@@ -1296,6 +1316,7 @@ returns table (
 language plpgsql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
 declare
   v_has_pgss boolean := false;
@@ -1389,6 +1410,7 @@ returns table (
 language sql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
   with waits as (
     select
@@ -1442,6 +1464,7 @@ returns table (
 language plpgsql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
 declare
   v_has_pgss boolean := false;
@@ -1513,6 +1536,7 @@ returns table (
 language plpgsql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
 begin
   -- Check if this query_id exists in any partition
@@ -1585,6 +1609,7 @@ returns table (
 language sql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
   select
     coalesce(d.datname, '<background>') as database_name,
@@ -1610,6 +1635,7 @@ create or replace function ash._to_sample_ts(p_ts timestamptz)
 returns int4
 language sql
 immutable
+set search_path = pg_catalog, ash
 as $$
   select extract(epoch from p_ts - ash.epoch())::int4
 $$;
@@ -1631,6 +1657,7 @@ returns table (
 language sql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
   with waits as (
     select
@@ -1698,6 +1725,7 @@ returns table (
 language plpgsql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
 declare
   v_has_pgss boolean := false;
@@ -1780,6 +1808,7 @@ returns table (
 language sql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
   with waits as (
     select
@@ -1818,6 +1847,7 @@ returns table (
 language sql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
   with waits as (
     select (-s.data[i])::smallint as wait_id, s.data[i + 1] as cnt
@@ -1865,6 +1895,7 @@ returns table (
 language plpgsql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
 declare
   v_start int4 := ash._to_sample_ts(p_start);
@@ -1936,6 +1967,7 @@ returns table (
 language plpgsql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
 declare
   v_total_samples bigint;
@@ -2036,6 +2068,7 @@ returns table (
 language plpgsql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
 declare
   v_reset text := ash._reset(p_color);
@@ -2243,6 +2276,7 @@ returns table (
 language plpgsql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
 declare
   v_reset text := ash._reset(p_color);
@@ -2449,6 +2483,7 @@ returns table (
 language plpgsql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
 declare
   v_has_pgss boolean := false;
@@ -2552,6 +2587,7 @@ returns table (
 language plpgsql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
 declare
   v_has_pgss boolean := false;
@@ -2687,6 +2723,7 @@ returns table (
 language plpgsql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
 declare
   v_has_pgss boolean := false;
@@ -2792,6 +2829,7 @@ returns table (
 language plpgsql
 stable
 set jit = off
+set search_path = pg_catalog, ash
 as $$
 declare
   v_has_pgss boolean := false;
@@ -2902,12 +2940,16 @@ exception when others then
 end $$;
 
 -------------------------------------------------------------------------------
--- Security: restrict write/admin functions to the installing role.
--- Reader functions remain PUBLIC (read-only, no side effects).
+-- Security: restrict all ash schema access. Admin functions belong only to
+-- the installing role; reader functions and underlying tables are revoked
+-- from PUBLIC so tenants on shared clusters cannot see observability data
+-- (query text, waits, config) unless the owner explicitly grants access.
+-- The owner retains full access by virtue of owning the objects.
 -------------------------------------------------------------------------------
 do $$
 declare
   v_owner text := (select nspowner::regrole::text from pg_namespace where nspname = 'ash');
+  r record;
 begin
   -- Admin functions: only the schema owner
   execute format('revoke all on function ash.start(interval) from public');
@@ -2923,4 +2965,41 @@ begin
   execute format('grant execute on function ash.rotate() to %I', v_owner);
   execute format('grant execute on function ash.take_sample() to %I', v_owner);
   execute format('grant execute on function ash.set_debug_logging(bool) to %I', v_owner);
+
+  -- Reader/helper functions: revoke EXECUTE from PUBLIC for every non-trigger
+  -- function in ash.*. Signatures are resolved dynamically via pg_proc so
+  -- default arguments and future overloads do not cause drift. Admin
+  -- functions above are re-revoked here (harmless: REVOKE is idempotent).
+  for r in
+    select p.proname,
+           pg_catalog.pg_get_function_identity_arguments(p.oid) as args
+    from pg_catalog.pg_proc p
+    join pg_catalog.pg_namespace n on p.pronamespace = n.oid
+    where n.nspname = 'ash'
+      and p.prokind = 'f'
+  loop
+    execute format('revoke execute on function ash.%I(%s) from public',
+                   r.proname, r.args);
+  end loop;
+
+  -- Reader tables/views: revoke SELECT from PUBLIC for objects holding
+  -- sample data, query text, and configuration. REVOKE on a partitioned
+  -- parent does not cascade to partitions in PostgreSQL, so sample_N and
+  -- query_map_N are enumerated dynamically below.
+  execute 'revoke select on table ash.sample from public';
+  execute 'revoke select on table ash.query_map_all from public';
+  execute 'revoke select on table ash.config from public';
+  execute 'revoke select on table ash.wait_event_map from public';
+
+  -- Per-slot partition/dictionary tables: sample_N and query_map_N.
+  for r in
+    select c.relname
+    from pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n on c.relnamespace = n.oid
+    where n.nspname = 'ash'
+      and c.relkind in ('r', 'p')
+      and (c.relname ~ '^query_map_[0-9]+$' or c.relname ~ '^sample_[0-9]+$')
+  loop
+    execute format('revoke select on ash.%I from public', r.relname);
+  end loop;
 end $$;

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -1316,7 +1316,11 @@ returns table (
 language plpgsql
 stable
 set jit = off
-set search_path = pg_catalog, ash
+-- search_path includes public so unqualified pg_stat_statements resolves to
+-- the view created by CREATE EXTENSION pg_stat_statements (default schema
+-- public on RDS/Cloud SQL/Supabase/AlloyDB/Neon). Keep public last so ash.*
+-- names still win over any user-created objects in public.
+set search_path = pg_catalog, ash, public
 as $$
 declare
   v_has_pgss boolean := false;
@@ -1464,7 +1468,8 @@ returns table (
 language plpgsql
 stable
 set jit = off
-set search_path = pg_catalog, ash
+-- search_path includes public for pg_stat_statements access; see top_queries.
+set search_path = pg_catalog, ash, public
 as $$
 declare
   v_has_pgss boolean := false;
@@ -1725,7 +1730,8 @@ returns table (
 language plpgsql
 stable
 set jit = off
-set search_path = pg_catalog, ash
+-- search_path includes public for pg_stat_statements access; see top_queries.
+set search_path = pg_catalog, ash, public
 as $$
 declare
   v_has_pgss boolean := false;
@@ -2483,7 +2489,8 @@ returns table (
 language plpgsql
 stable
 set jit = off
-set search_path = pg_catalog, ash
+-- search_path includes public for pg_stat_statements access; see top_queries.
+set search_path = pg_catalog, ash, public
 as $$
 declare
   v_has_pgss boolean := false;
@@ -2587,7 +2594,8 @@ returns table (
 language plpgsql
 stable
 set jit = off
-set search_path = pg_catalog, ash
+-- search_path includes public for pg_stat_statements access; see top_queries.
+set search_path = pg_catalog, ash, public
 as $$
 declare
   v_has_pgss boolean := false;
@@ -2723,7 +2731,8 @@ returns table (
 language plpgsql
 stable
 set jit = off
-set search_path = pg_catalog, ash
+-- search_path includes public for pg_stat_statements access; see top_queries.
+set search_path = pg_catalog, ash, public
 as $$
 declare
   v_has_pgss boolean := false;
@@ -2829,7 +2838,8 @@ returns table (
 language plpgsql
 stable
 set jit = off
-set search_path = pg_catalog, ash
+-- search_path includes public for pg_stat_statements access; see top_queries.
+set search_path = pg_catalog, ash, public
 as $$
 declare
   v_has_pgss boolean := false;

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -1320,6 +1320,10 @@ set jit = off
 -- the view created by CREATE EXTENSION pg_stat_statements (default schema
 -- public on RDS/Cloud SQL/Supabase/AlloyDB/Neon). Keep public last so ash.*
 -- names still win over any user-created objects in public.
+-- NOTE: If pgss is installed into a non-public schema, the trailing
+-- ash._apply_pgss_search_path() call at the end of this file appends the
+-- detected schema to search_path on every pgss reader. Re-run
+-- select ash._apply_pgss_search_path(); after installing/moving pgss.
 set search_path = pg_catalog, ash, public
 as $$
 declare
@@ -2956,6 +2960,84 @@ end $$;
 -- (query text, waits, config) unless the owner explicitly grants access.
 -- The owner retains full access by virtue of owning the objects.
 -------------------------------------------------------------------------------
+
+-- Helper: detect the schema that holds the pg_stat_statements view.
+-- Managed services differ: RDS/Cloud SQL/Supabase/AlloyDB/Neon default to
+-- public, but self-hosted installs may use `pg_stat_statements`, `extensions`,
+-- `monitoring`, or another custom schema. Returns NULL when pgss is not
+-- installed.
+create or replace function ash._pgss_schema()
+returns text
+language sql
+stable
+set search_path = pg_catalog
+as $$
+  select n.nspname::text
+  from pg_extension e
+  join pg_namespace n on n.oid = e.extnamespace
+  where e.extname = 'pg_stat_statements'
+$$;
+
+comment on function ash._pgss_schema() is
+  'Returns the schema name of the installed pg_stat_statements extension, or NULL if not installed. Used to keep reader functions portable across managed services and custom install schemas.';
+
+-- Helper: re-apply search_path on the seven pgss reader functions using the
+-- currently detected pgss schema. Run this after installing / moving
+-- pg_stat_statements if it lives outside `public`. Safe to re-run.
+create or replace function ash._apply_pgss_search_path()
+returns text
+language plpgsql
+set search_path = pg_catalog, ash
+as $$
+declare
+  v_pgss_schema text := ash._pgss_schema();
+  -- B2: keep this list in sync with v_pgss_readers in sql/ash-1.3-to-1.4.sql
+  -- (and any future upgrade scripts) AND with the per-function `set
+  -- search_path = pg_catalog, ash, public` clauses in this file. Any reader
+  -- that probes pg_stat_statements must appear here so its search_path
+  -- resolves the view across managed-service and custom pgss install schemas.
+  v_readers text[] := array[
+    'top_queries', 'top_queries_at', 'top_queries_with_text',
+    'samples', 'samples_at',
+    'event_queries', 'event_queries_at'
+  ];
+  v_path text;
+  r record;
+begin
+  -- Always keep public in the path as a fallback (matches the managed-service
+  -- default and preserves behavior when pgss is not yet installed). If the
+  -- extension lives elsewhere, append that schema after public so ash.* still
+  -- wins over any user-created objects in public/<pgss_schema>.
+  if v_pgss_schema is null or v_pgss_schema in ('pg_catalog', 'ash', 'public') then
+    v_path := 'pg_catalog, ash, public';
+  else
+    v_path := format('pg_catalog, ash, public, %I', v_pgss_schema);
+  end if;
+
+  for r in
+    select p.proname,
+           pg_catalog.pg_get_function_identity_arguments(p.oid) as args
+    from pg_catalog.pg_proc p
+    join pg_catalog.pg_namespace n on p.pronamespace = n.oid
+    where n.nspname = 'ash'
+      and p.prokind = 'f'
+      and p.proname = any(v_readers)
+  loop
+    execute format('alter function ash.%I(%s) set search_path = %s',
+                   r.proname, r.args, v_path);
+  end loop;
+
+  return v_path;
+end;
+$$;
+
+comment on function ash._apply_pgss_search_path() is
+  'Re-applies search_path on pgss reader functions using the currently detected pg_stat_statements schema. Run after installing pg_stat_statements if it lives outside the public schema.';
+
+-- Apply now so installs that have pgss in a non-public schema work out of the
+-- box. No-op (keeps default) when pgss is absent or lives in public.
+select ash._apply_pgss_search_path();
+
 do $$
 declare
   v_owner text := (select nspowner::regrole::text from pg_namespace where nspname = 'ash');


### PR DESCRIPTION
## Summary

Defense-in-depth privilege hardening for pg_ash, addressing issue #37 findings **H-SEC-1** (REVOKE from PUBLIC) and **H-SEC-2** (`set search_path` on every function).

- **H-SEC-2**: added `set search_path = pg_catalog, ash` to all **38** functions in the `ash` schema. Functions are currently INVOKER so the blast radius is limited today; this guard eliminates the latent RCE vector if any function is ever flipped to SECURITY DEFINER.
- **H-SEC-1**: extended the existing admin-only REVOKE block so that:
  - Every non-trigger function in `ash.*` has EXECUTE revoked from PUBLIC. Signatures are resolved dynamically via `pg_get_function_identity_arguments(pg_proc.oid)` to avoid drift from DEFAULTs/overloads.
  - `ash.sample`, `ash.query_map_all`, `ash.config`, `ash.wait_event_map` have SELECT revoked from PUBLIC.
  - Per-slot partition tables (`sample_N`) and dictionary tables (`query_map_N`) are enumerated via `pg_class` and each has SELECT revoked from PUBLIC (REVOKE on a partitioned parent does not cascade to partitions in Postgres).

No new role is introduced — the installing role retains full access via ownership. Scope is kept tight per the issue.

## Test plan

- [x] `sudo -u postgres psql -f sql/ash-install.sql` on a fresh database — runs clean, no errors.
- [x] Verified `pg_proc.proconfig` contains `search_path=pg_catalog, ash` for a sampled function.
- [x] Verified `pg_proc.proacl` and `pg_class.relacl` for `ash.*` objects contain only owner entries (no `=X/...` or `=r/...` PUBLIC grants).
- [ ] CI (`test.yml`) passes across PostgreSQL 14–18 — fresh install, upgrade path, degraded mode (no pgss/pg_cron).
- [ ] Manual smoke: as a non-owner role, `select ash.top_queries()` is denied; as owner, it works.

Closes #37 (H-SEC-1, H-SEC-2).
