### PR TITLE
docs(claude): clarify upgrade-script policy to match test.yml reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,10 +11,10 @@ SQL style guide: https://gitlab.com/postgres-ai/rules/-/blob/main/rules/developm
 CI via GitHub Actions:
 
 - **test.yml**: runs on push and PRs — tests across PostgreSQL 14, 15, 16, 17, 18
-- Tests: fresh install, upgrade path (1.0→1.1→1.2→1.3), schema equivalence, degraded mode (no pgss/pg_cron)
+- Tests: fresh install, full upgrade chain up to the in-progress release (currently 1.0→…→1.4), schema equivalence between fresh install and upgrade chain, idempotent re-apply of each legacy upgrade script, degraded mode (no pgss/pg_cron)
 - Version schema: `vMAJOR.MINOR` (e.g. `v1.3`). Tag on main after all PRs merged.
 
-`ash-install.sql` is the source of truth. Upgrade scripts (`ash-X.Y-to-X.Z.sql`) are generated at release time, not in feature PRs.
+`ash-install.sql` is the source of truth. Upgrade scripts for the **in-progress** release (e.g. `ash-1.3-to-1.4.sql` while 1.4 is unreleased) must stay in lockstep with install.sql through the release cycle — any install.sql change that affects schema (new/modified function bodies, new columns, dropped objects) must be mirrored into the in-progress upgrade script. Schema-equivalence CI enforces this on every PR. **Finalized** legacy upgrade scripts (`ash-1.0-to-1.1.sql` through `ash-1.2-to-1.3.sql` today) are immutable: any signature-changing PR must avoid patterns that trip their idempotent re-apply, even if that means restructuring the fix (e.g. keeping an old function signature and using a new helper name instead of changing the return type).
 
 ## Code Review
 


### PR DESCRIPTION
## Summary

CLAUDE.md previously said upgrade scripts are "generated at release time, not in feature PRs" — but `test.yml` has always enforced schema equivalence against the full upgrade chain *including* the in-progress release. Multiple REV reviewers flagged the tension while reviewing PRs #31, #41, #43, #44.

This updates the policy to match the practice:

- **In-progress** upgrade script (e.g. \`ash-1.3-to-1.4.sql\` while 1.4 is unreleased) must stay in lockstep with install.sql. Schema-equivalence CI enforces on every PR.
- **Finalized** legacy upgrade scripts (today: \`ash-1.0-to-1.1.sql\` through \`ash-1.2-to-1.3.sql\`) are immutable. Signature-changing PRs must restructure around them (e.g. PR #31 switched from adding a new OUT column to \`decode_sample\` → rewriting the caller to walk \`data[]\` inline).

Also fixes the version list — the upgrade path now goes to 1.4, not 1.3.

## Test plan
- [ ] No code change; doc only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)