### PR TITLE
fix: align sample_data_check constraint across upgrade paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2462,6 +2462,82 @@ jobs:
           select ash.uninstall('yes');
           EOF
 
+      - name: "Issue #49: sample_data_check tightened by upgrade chain from 1.0"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          # Regression for issue #49: v1.0 shipped `array_length(data, 1) >= 2`,
+          # v1.1+ requires `>= 3`. No legacy upgrade script rewrote the check,
+          # so installs that started at 1.0 carried the looser form forever.
+          # ash-install.sql now detects and rewrites it; assert that the full
+          # 1.0 -> 1.4 chain ends with the tightened constraint on both the
+          # partitioned parent and every partition.
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          \i sql/ash-1.0.sql
+
+          -- Sanity-check the precondition: 1.0 ships the looser form.
+          do $$
+          declare
+            v_def text;
+          begin
+            select pg_get_constraintdef(c.oid) into v_def
+            from pg_constraint c
+            where c.conrelid = 'ash.sample'::regclass
+              and c.conname  = 'sample_data_check';
+            assert v_def ~ 'array_length\(data, 1\) >= 2',
+              format('1.0 should ship `>= 2` form; got: %s', v_def);
+          end $$;
+
+          \i sql/ash-1.1.sql
+          \i sql/ash-1.1-to-1.2.sql
+          \i sql/ash-1.2-to-1.3.sql
+          \i sql/ash-1.3-to-1.4.sql
+
+          -- After full chain: parent + every partition must carry `>= 3`,
+          -- and none may carry the legacy `>= 2`.
+          do $$
+          declare
+            v_bad int;
+            v_parent_def text;
+          begin
+            select pg_get_constraintdef(c.oid) into v_parent_def
+            from pg_constraint c
+            where c.conrelid = 'ash.sample'::regclass
+              and c.conname  = 'sample_data_check';
+            assert v_parent_def ~ 'array_length\(data, 1\) >= 3',
+              format('parent constraint not tightened; got: %s', v_parent_def);
+
+            select count(*) into v_bad
+            from pg_constraint c
+            join pg_class    t on t.oid = c.conrelid
+            join pg_namespace n on n.oid = t.relnamespace
+            where n.nspname = 'ash'
+              and t.relname ~ '^sample(_[0-9]+)?$'
+              and c.contype = 'c'
+              and pg_get_constraintdef(c.oid) ~ 'array_length\(data, 1\) >= 2';
+            assert v_bad = 0,
+              format('%s ash.sample* check(s) still carry the legacy `>= 2` form', v_bad);
+
+            select count(*) into v_bad
+            from pg_inherits i
+            join pg_class    p on p.oid = i.inhrelid
+            join pg_namespace n on n.oid = p.relnamespace
+            left join pg_constraint c
+              on c.conrelid = p.oid
+             and c.contype  = 'c'
+             and pg_get_constraintdef(c.oid) ~ 'array_length\(data, 1\) >= 3'
+            where i.inhparent = 'ash.sample'::regclass
+              and n.nspname = 'ash'
+              and c.oid is null;
+            assert v_bad = 0,
+              format('%s partition(s) of ash.sample missing `>= 3` check', v_bad);
+
+            raise notice 'issue #49 regression PASSED: sample_data_check is `>= 3` everywhere';
+          end $$;
+
+          select ash.uninstall('yes');
+          EOF
+
       - name: "Upgrade path via documented wrappers + data preservation (issue #37 H-CI-1, H-CI-2)"
         env:
           PGPASSWORD: postgres

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -301,6 +301,32 @@ begin
   end loop;
 end $$;
 
+-- Migration (issue #49): align sample.data check across upgrade paths.
+-- v1.0 shipped `array_length(data, 1) >= 2`; v1.1 tightened it to `>= 3`,
+-- but no legacy upgrade script rewrote the constraint, so installs that
+-- started at 1.0 still carry the looser form. Detect and fix in place.
+-- Idempotent: only rewrites when the current definition is missing or
+-- the old `>= 2` form. Drops on the partitioned parent cascade to all
+-- partitions; ADD CONSTRAINT on the parent propagates back to children.
+do $$
+declare
+  v_def text;
+begin
+  select pg_get_constraintdef(c.oid) into v_def
+  from pg_constraint c
+  where c.conrelid = 'ash.sample'::regclass
+    and c.conname  = 'sample_data_check';
+
+  if v_def is null or v_def !~ 'array_length\(data, 1\) >= 3' then
+    if v_def is not null then
+      alter table ash.sample drop constraint sample_data_check;
+    end if;
+    alter table ash.sample
+      add constraint sample_data_check
+      check (data[1] < 0 and array_length(data, 1) >= 3);
+  end if;
+end $$;
+
 -- Convert timestamptz to int4 epoch offset
 create or replace function ash.ts_from_timestamptz(p_ts timestamptz)
 returns int4


### PR DESCRIPTION
## Summary

Fixes #49.

- v1.0 shipped `ash.sample` with `check (... and array_length(data, 1) >= 2)`. v1.1 tightened it to `>= 3`, but no legacy upgrade script (1.0->1.1, 1.1->1.2, 1.2->1.3) ever rewrote the constraint. Any install that started at 1.0 still carries the looser form, diverging from a fresh install at the same version.
- Adds an idempotent `DO` block to `sql/ash-install.sql` that inspects `pg_get_constraintdef` for `sample_data_check` on the partitioned parent and only rewrites it when it is missing or in the legacy `>= 2` form. The drop on the parent cascades to existing partitions; the re-add propagates the tightened check back to all partitions.
- `sql/ash-1.3-to-1.4.sql` is `\ir ash-install.sql`, so it inherits the fix automatically per the CLAUDE.md lockstep policy. Finalized legacy scripts (1.0, 1.1, 1.1->1.2, 1.2->1.3) are not touched.
- Adds a dedicated CI step that installs 1.0 (and asserts the legacy `>= 2` precondition holds), chains 1.0 -> 1.1 -> 1.2 -> 1.3 -> 1.4, and asserts every `ash.sample*` CHECK is the `>= 3` form on both the parent and every partition.

## Test plan

- [x] Fresh install of `ash-install.sql` produces `array_length(data, 1) >= 3` (verified locally on PG 18.3).
- [x] Re-applying `ash-install.sql` is a no-op for the constraint (idempotent guard).
- [x] Full 1.0 -> 1.4 upgrade chain ends with `>= 3` on the parent and all 3 partitions; no row carries the legacy `>= 2` form (new regression test, also runs locally).
- [ ] Existing `Schema equivalence` and full upgrade-chain CI jobs still pass on PG 14-18.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Closes #49