### PR TITLE
feat: add decode_sample(int) and decode_sample(timestamptz) convenience overloads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1399,8 +1399,10 @@ jobs:
 
             -- === decode_sample corner cases ===
 
-            -- Empty/null data
-            select count(*) into v_count from ash.decode_sample(null);
+            -- Empty/null data (cast to integer[] to disambiguate from
+            -- the decode_sample(int4) overload, which would otherwise
+            -- both match an unknown-typed NULL literal).
+            select count(*) into v_count from ash.decode_sample(null::integer[]);
             assert v_count = 0, 'null decode should return 0 rows';
 
             select count(*) into v_count from ash.decode_sample('{}'::integer[]);

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -417,6 +417,121 @@ jobs:
           $$;
           EOF
 
+      - name: Test decode_sample convenience overloads (int4, timestamptz)
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          do $$
+          declare
+            v_sample_ts int4;
+            v_wait_id smallint;
+            v_qid_a int4;
+            v_qid_b int4;
+            v_decoded_int_count int;
+            v_decoded_ts_count int;
+            v_decoded_int_total int;
+            v_decoded_ts_total int;
+            v_packed_total int;
+            v_distinct_datids int;
+            v_ts timestamptz;
+            v_slot smallint;
+          begin
+            -- Run a real take_sample() first so the call path exercises the
+            -- live sampler at least once.
+            perform ash.take_sample();
+
+            -- Build a deterministic test sample_ts so the assertions don't
+            -- depend on whether the CI runner happens to have active
+            -- backends right now. Use a sample_ts in the future to avoid
+            -- colliding with anything take_sample() inserted.
+            v_sample_ts := ash.ts_from_timestamptz(now()) + 86400;
+            v_slot := ash.current_slot();
+
+            -- Ensure dictionary entries exist (may already exist from earlier
+            -- decoder test step; on conflict do nothing).
+            insert into ash.wait_event_map (state, type, event)
+            values ('active', 'CPU*', 'CPU*') on conflict do nothing;
+            select id into v_wait_id from ash.wait_event_map
+            where state = 'active' and type = 'CPU*' and event = 'CPU*';
+
+            insert into ash.query_map_0 (query_id) values (777001) on conflict do nothing;
+            insert into ash.query_map_0 (query_id) values (777002) on conflict do nothing;
+            select id into v_qid_a from ash.query_map_0 where query_id = 777001;
+            select id into v_qid_b from ash.query_map_0 where query_id = 777002;
+
+            -- Insert two synthetic ash.sample rows for the same sample_ts
+            -- but different datids, so the int4 overload has more than one
+            -- ash.sample row to walk and the datid column is exercised.
+            -- datid 1 = template1, 2 = postgres in most installs, but we
+            -- only need oid values that are distinct and stable.
+            insert into ash.sample (sample_ts, datid, active_count, data, slot)
+            values
+              (v_sample_ts, 1::oid, 2, array[-v_wait_id, 2, v_qid_a, v_qid_b]::integer[], v_slot),
+              (v_sample_ts, 2::oid, 1, array[-v_wait_id, 1, v_qid_a]::integer[], v_slot);
+
+            -- decode_sample(int4): expect 3 decoded rows (2 + 1 backends),
+            -- each with count=1 and a datid that matches one of the rows we
+            -- inserted.
+            select count(*), coalesce(sum(d.count), 0), count(distinct d.datid)
+              into v_decoded_int_count, v_decoded_int_total, v_distinct_datids
+            from ash.decode_sample(v_sample_ts) d;
+            assert v_decoded_int_count = 3,
+              'decode_sample(int4) row count expected 3, got ' || v_decoded_int_count;
+            assert v_decoded_int_total = 3,
+              'decode_sample(int4) sum(count) expected 3, got ' || v_decoded_int_total;
+            assert v_distinct_datids = 2,
+              'decode_sample(int4) distinct datids expected 2, got ' || v_distinct_datids;
+
+            -- Sanity vs. packed active_count.
+            select coalesce(sum(active_count), 0) into v_packed_total
+            from ash.sample where sample_ts = v_sample_ts;
+            assert v_decoded_int_count = v_packed_total,
+              'decoded rows ' || v_decoded_int_count
+              || ' != packed active_count total ' || v_packed_total;
+
+            -- Verify wait_event + query_id resolution is correct for each
+            -- decoded row (uses the row's slot internally, so query_ids are
+            -- unambiguous).
+            assert exists (
+              select 1 from ash.decode_sample(v_sample_ts) d
+              where d.datid = 1::oid and d.wait_event = 'CPU*' and d.query_id = 777001
+            ), 'decode_sample(int4) missing expected (datid=1, CPU*, 777001) row';
+            assert exists (
+              select 1 from ash.decode_sample(v_sample_ts) d
+              where d.datid = 1::oid and d.wait_event = 'CPU*' and d.query_id = 777002
+            ), 'decode_sample(int4) missing expected (datid=1, CPU*, 777002) row';
+            assert exists (
+              select 1 from ash.decode_sample(v_sample_ts) d
+              where d.datid = 2::oid and d.wait_event = 'CPU*' and d.query_id = 777001
+            ), 'decode_sample(int4) missing expected (datid=2, CPU*, 777001) row';
+
+            -- timestamptz overload: round-trip and confirm we get identical
+            -- decoded rows.
+            v_ts := ash.ts_to_timestamptz(v_sample_ts);
+            select count(*), coalesce(sum(d.count), 0)
+              into v_decoded_ts_count, v_decoded_ts_total
+            from ash.decode_sample(v_ts) d;
+            assert v_decoded_ts_count = v_decoded_int_count,
+              'decode_sample(timestamptz) row count ' || v_decoded_ts_count
+              || ' != decode_sample(int4) ' || v_decoded_int_count;
+            assert v_decoded_ts_total = v_decoded_int_total,
+              'decode_sample(timestamptz) sum(count) ' || v_decoded_ts_total
+              || ' != decode_sample(int4) ' || v_decoded_int_total;
+
+            -- Empty input: a sample_ts with no rows must return zero rows.
+            assert (select count(*) from ash.decode_sample(-1)) = 0,
+              'decode_sample(int4) on missing sample_ts should return 0 rows';
+
+            -- Clean up the synthetic rows so later steps see a normal table.
+            delete from ash.sample where sample_ts = v_sample_ts;
+            delete from ash.query_map_0 where query_id in (777001, 777002);
+
+            raise notice 'decode_sample overload tests PASSED';
+          end;
+          $$;
+          EOF
+
       - name: Test missed_samples counter (timeout catching)
         env:
           PGPASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -627,6 +627,7 @@ jobs:
             v_decoded_ts_total int;
             v_packed_total int;
             v_distinct_datids int;
+            v_diff_count int;
             v_ts timestamptz;
             v_slot smallint;
           begin
@@ -648,10 +649,25 @@ jobs:
             select id into v_wait_id from ash.wait_event_map
             where state = 'active' and type = 'CPU*' and event = 'CPU*';
 
-            insert into ash.query_map_0 (query_id) values (777001) on conflict do nothing;
-            insert into ash.query_map_0 (query_id) values (777002) on conflict do nothing;
-            select id into v_qid_a from ash.query_map_0 where query_id = 777001;
-            select id into v_qid_b from ash.query_map_0 where query_id = 777002;
+            -- Read the active slot's query_map dynamically so this test
+            -- stays correct after re-ordering of CI steps and across any
+            -- future change to num_partitions.
+            execute format(
+              'insert into ash.query_map_%s (query_id) values (777001) on conflict do nothing',
+              v_slot
+            );
+            execute format(
+              'insert into ash.query_map_%s (query_id) values (777002) on conflict do nothing',
+              v_slot
+            );
+            execute format(
+              'select id from ash.query_map_%s where query_id = 777001',
+              v_slot
+            ) into v_qid_a;
+            execute format(
+              'select id from ash.query_map_%s where query_id = 777002',
+              v_slot
+            ) into v_qid_b;
 
             -- Insert two synthetic ash.sample rows for the same sample_ts
             -- but different datids, so the int4 overload has more than one
@@ -712,21 +728,58 @@ jobs:
               'decode_sample_at(timestamptz) sum(count) ' || v_decoded_ts_total
               || ' != decode_sample(int4) ' || v_decoded_int_total;
 
+            -- Row-level equality: every (datid, wait_event, query_id, count)
+            -- tuple from decode_sample_at(timestamptz) must match
+            -- decode_sample(int4) exactly, in both directions.
+            select count(*) into v_diff_count from (
+              select datid, wait_event, query_id, count
+              from ash.decode_sample_at(v_ts)
+              except
+              select datid, wait_event, query_id, count
+              from ash.decode_sample(v_sample_ts)
+            ) d;
+            assert v_diff_count = 0,
+              'decode_sample_at(timestamptz) has rows not in decode_sample(int4): '
+              || v_diff_count;
+            select count(*) into v_diff_count from (
+              select datid, wait_event, query_id, count
+              from ash.decode_sample(v_sample_ts)
+              except
+              select datid, wait_event, query_id, count
+              from ash.decode_sample_at(v_ts)
+            ) d;
+            assert v_diff_count = 0,
+              'decode_sample(int4) has rows not in decode_sample_at(timestamptz): '
+              || v_diff_count;
+
             -- Empty input: a sample_ts with no rows must return zero rows.
             assert (select count(*) from ash.decode_sample(-1)) = 0,
               'decode_sample(int4) on missing sample_ts should return 0 rows';
 
+            -- NULL input: NULL-as-int4 should return zero rows (not error).
+            -- The 1-arg unknown-NULL case is covered by the existing
+            -- decoder corner-cases step via ::integer[] cast; here we
+            -- verify the int4 overload behaves the same.
+            assert (select count(*) from ash.decode_sample(null::int4)) = 0,
+              'decode_sample(null::int4) should return 0 rows';
+            assert (select count(*) from ash.decode_sample_at(null::timestamptz)) = 0,
+              'decode_sample_at(null::timestamptz) should return 0 rows';
+
             -- Regression for #54: an unadorned integer literal must resolve
-            -- unambiguously to decode_sample(int4). If a second overload on
-            -- another type with implicit conversion from unknown is ever
-            -- re-introduced, this call would error with
-            --   "function ash.decode_sample(unknown) is not unique".
-            assert (select count(*) from ash.decode_sample(0)) >= 0,
-              'decode_sample(<unadorned literal>) must resolve to int4 overload';
+            -- unambiguously to decode_sample(int4). 0 is the epoch boundary,
+            -- which has no rows in CI -- so a successful overload bind
+            -- returns exactly 0 rows. If the call ever errors with
+            -- "function ash.decode_sample(unknown) is not unique", or if it
+            -- mis-binds and returns rows from another partition, this fails.
+            assert (select count(*) from ash.decode_sample(0)) = 0,
+              'decode_sample(<unadorned literal>) must resolve to int4 overload and return 0 rows at epoch';
 
             -- Clean up the synthetic rows so later steps see a normal table.
             delete from ash.sample where sample_ts = v_sample_ts;
-            delete from ash.query_map_0 where query_id in (777001, 777002);
+            execute format(
+              'delete from ash.query_map_%s where query_id in (777001, 777002)',
+              v_slot
+            );
 
             raise notice 'decode_sample(int4) / decode_sample_at(timestamptz) tests PASSED';
           end;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -417,7 +417,7 @@ jobs:
           $$;
           EOF
 
-      - name: Test decode_sample convenience overloads (int4, timestamptz)
+      - name: Test decode_sample(int4) and decode_sample_at(timestamptz) convenience
         env:
           PGPASSWORD: postgres
         run: |
@@ -506,28 +506,36 @@ jobs:
               where d.datid = 2::oid and d.wait_event = 'CPU*' and d.query_id = 777001
             ), 'decode_sample(int4) missing expected (datid=2, CPU*, 777001) row';
 
-            -- timestamptz overload: round-trip and confirm we get identical
-            -- decoded rows.
+            -- decode_sample_at(timestamptz): round-trip and confirm we get
+            -- identical decoded rows.
             v_ts := ash.ts_to_timestamptz(v_sample_ts);
             select count(*), coalesce(sum(d.count), 0)
               into v_decoded_ts_count, v_decoded_ts_total
-            from ash.decode_sample(v_ts) d;
+            from ash.decode_sample_at(v_ts) d;
             assert v_decoded_ts_count = v_decoded_int_count,
-              'decode_sample(timestamptz) row count ' || v_decoded_ts_count
+              'decode_sample_at(timestamptz) row count ' || v_decoded_ts_count
               || ' != decode_sample(int4) ' || v_decoded_int_count;
             assert v_decoded_ts_total = v_decoded_int_total,
-              'decode_sample(timestamptz) sum(count) ' || v_decoded_ts_total
+              'decode_sample_at(timestamptz) sum(count) ' || v_decoded_ts_total
               || ' != decode_sample(int4) ' || v_decoded_int_total;
 
             -- Empty input: a sample_ts with no rows must return zero rows.
             assert (select count(*) from ash.decode_sample(-1)) = 0,
               'decode_sample(int4) on missing sample_ts should return 0 rows';
 
+            -- Regression for #54: an unadorned integer literal must resolve
+            -- unambiguously to decode_sample(int4). If a second overload on
+            -- another type with implicit conversion from unknown is ever
+            -- re-introduced, this call would error with
+            --   "function ash.decode_sample(unknown) is not unique".
+            assert (select count(*) from ash.decode_sample(0)) >= 0,
+              'decode_sample(<unadorned literal>) must resolve to int4 overload';
+
             -- Clean up the synthetic rows so later steps see a normal table.
             delete from ash.sample where sample_ts = v_sample_ts;
             delete from ash.query_map_0 where query_id in (777001, 777002);
 
-            raise notice 'decode_sample overload tests PASSED';
+            raise notice 'decode_sample(int4) / decode_sample_at(timestamptz) tests PASSED';
           end;
           $$;
           EOF

--- a/README.md
+++ b/README.md
@@ -186,6 +186,21 @@ Rollup readers query `rollup_1m` / `rollup_1h` tables — they work even after r
 |----------|-------------|
 | `ash.ts_from_timestamptz(timestamptz)` | Convert timestamptz to internal int4 epoch offset (useful for querying rollup tables directly) |
 | `ash.ts_to_timestamptz(int4)` | Convert int4 epoch offset back to timestamptz |
+| `ash.decode_sample(integer[], smallint)` | Decode a single packed `ash.sample.data` array. Pass `slot` for unambiguous query_id resolution |
+| `ash.decode_sample(int4)` | Convenience: decode every `ash.sample` row at the given `sample_ts` (across all datids/slots). Returns `(datid, wait_event, query_id, count)` |
+| `ash.decode_sample(timestamptz)` | Same as above but accepts `timestamptz` (converted via `ts_from_timestamptz`) |
+
+`decode_sample` overloads have `EXECUTE` revoked from `PUBLIC` (per the privilege hardening in #45). Grant explicitly to roles that need them, e.g. `grant execute on function ash.decode_sample(int4) to my_reader;`.
+
+#### Example
+
+```sql
+-- All decoded backends recorded at a specific moment, by database:
+select db.datname, d.wait_event, d.query_id, d.count
+from ash.decode_sample('2026-04-19 14:30:00+00'::timestamptz) d
+join pg_database db on db.oid = d.datid
+order by db.datname, d.wait_event;
+```
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -188,16 +188,16 @@ Rollup readers query `rollup_1m` / `rollup_1h` tables — they work even after r
 | `ash.ts_to_timestamptz(int4)` | Convert int4 epoch offset back to timestamptz |
 | `ash.decode_sample(integer[], smallint)` | Decode a single packed `ash.sample.data` array. Pass `slot` for unambiguous query_id resolution |
 | `ash.decode_sample(int4)` | Convenience: decode every `ash.sample` row at the given `sample_ts` (across all datids/slots). Returns `(datid, wait_event, query_id, count)` |
-| `ash.decode_sample(timestamptz)` | Same as above but accepts `timestamptz` (converted via `ts_from_timestamptz`) |
+| `ash.decode_sample_at(timestamptz)` | Same as above but accepts `timestamptz` (converted via `ts_from_timestamptz`). Named with the `_at` suffix (consistent with `samples_at` / `top_waits_at`) to avoid `decode_sample(unknown)` overload ambiguity |
 
-`decode_sample` overloads have `EXECUTE` revoked from `PUBLIC` (per the privilege hardening in #45). Grant explicitly to roles that need them, e.g. `grant execute on function ash.decode_sample(int4) to my_reader;`.
+`decode_sample` / `decode_sample_at` have `EXECUTE` revoked from `PUBLIC` (per the privilege hardening in #45). Grant explicitly to roles that need them, e.g. `grant execute on function ash.decode_sample(int4) to my_reader;`.
 
 #### Example
 
 ```sql
 -- All decoded backends recorded at a specific moment, by database:
 select db.datname, d.wait_event, d.query_id, d.count
-from ash.decode_sample('2026-04-19 14:30:00+00'::timestamptz) d
+from ash.decode_sample_at('2026-04-19 14:30:00+00'::timestamptz) d
 join pg_database db on db.oid = d.datid
 order by db.datname, d.wait_event;
 ```

--- a/sql/ash-1.3-to-1.4.sql
+++ b/sql/ash-1.3-to-1.4.sql
@@ -23,4 +23,9 @@
 --   - search_path guard on every ash.* function + pgss-schema-aware readers;
 --     REVOKE EXECUTE on all ash.* functions and SELECT on reader tables from
 --     PUBLIC (#45).
+--   - decode_sample(int4) and decode_sample(timestamptz) convenience
+--     overloads: walk every ash.sample row matching a given sample_ts (or
+--     the timestamptz-derived sample_ts) and return decoded rows annotated
+--     with datid. Existing decode_sample(integer[], smallint) is unchanged.
+--     (#54)
 \ir ash-install.sql

--- a/sql/ash-1.3-to-1.4.sql
+++ b/sql/ash-1.3-to-1.4.sql
@@ -23,9 +23,10 @@
 --   - search_path guard on every ash.* function + pgss-schema-aware readers;
 --     REVOKE EXECUTE on all ash.* functions and SELECT on reader tables from
 --     PUBLIC (#45).
---   - decode_sample(int4) and decode_sample(timestamptz) convenience
---     overloads: walk every ash.sample row matching a given sample_ts (or
+--   - decode_sample(int4) and decode_sample_at(timestamptz) convenience
+--     functions: walk every ash.sample row matching a given sample_ts (or
 --     the timestamptz-derived sample_ts) and return decoded rows annotated
 --     with datid. Existing decode_sample(integer[], smallint) is unchanged.
---     (#54)
+--     decode_sample_at() (rather than a third decode_sample overload) is
+--     used to avoid a decode_sample(unknown-typed literal) ambiguity. (#54)
 \ir ash-install.sql

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -809,9 +809,12 @@ as $$
   where s.sample_ts = p_sample_ts
 $$;
 
--- Convenience overload: convert timestamptz to the matching sample_ts via
--- ts_from_timestamptz() and delegate to the int4 overload. Same return shape.
-create or replace function ash.decode_sample(p_ts timestamptz)
+-- Wall-clock convenience: convert timestamptz to the matching sample_ts via
+-- ts_from_timestamptz() and delegate to decode_sample(int4). Same return
+-- shape. Named decode_sample_at() (matching the samples_at / top_waits_at
+-- naming convention) so we don't create a decode_sample(unknown) ambiguity
+-- between int4 and timestamptz overloads.
+create or replace function ash.decode_sample_at(p_ts timestamptz)
 returns table (
   datid      oid,
   wait_event text,
@@ -4156,8 +4159,8 @@ $$Decodes a single ash.sample.data array into (wait_event, query_id, count) rows
 comment on function ash.decode_sample(int4) is
 $$Convenience overload: decodes every ash.sample row whose sample_ts equals p_sample_ts (across all datids/slots) and returns (datid, wait_event, query_id, count). Internally calls decode_sample(data, slot) with the row's slot, so query_id resolution is unambiguous.$$;
 
-comment on function ash.decode_sample(timestamptz) is
-$$Convenience overload: same as decode_sample(int4) but accepts timestamptz, converting via ts_from_timestamptz() to find the matching sample_ts.$$;
+comment on function ash.decode_sample_at(timestamptz) is
+$$Wall-clock convenience: same as decode_sample(int4) but accepts timestamptz, converting via ts_from_timestamptz() to find the matching sample_ts. Named with the _at suffix (consistent with samples_at, top_waits_at) to avoid an unknown-typed decode_sample(123) literal matching both the int4 and timestamptz overloads.$$;
 
 -- Migration: add version column if upgrading from older version
 do $$

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -786,6 +786,46 @@ begin
 end;
 $$;
 
+-- Convenience overload: decode every ash.sample row whose sample_ts matches.
+-- Walks all datids/slots and returns decoded rows annotated with datid so the
+-- caller can distinguish them. Implemented as a SQL LATERAL JOIN over the
+-- 2-arg decode_sample(data, slot) SRF (passes slot for unambiguous lookup,
+-- avoiding the "search-all-partitions" branch that can return stale ids
+-- after rotation).
+create or replace function ash.decode_sample(p_sample_ts int4)
+returns table (
+  datid      oid,
+  wait_event text,
+  query_id   int8,
+  count      int
+)
+language sql
+stable
+set search_path = pg_catalog, ash
+as $$
+  select s.datid, d.wait_event, d.query_id, d.count
+  from ash.sample s,
+       lateral ash.decode_sample(s.data, s.slot) d
+  where s.sample_ts = p_sample_ts
+$$;
+
+-- Convenience overload: convert timestamptz to the matching sample_ts via
+-- ts_from_timestamptz() and delegate to the int4 overload. Same return shape.
+create or replace function ash.decode_sample(p_ts timestamptz)
+returns table (
+  datid      oid,
+  wait_event text,
+  query_id   int8,
+  count      int
+)
+language sql
+stable
+set search_path = pg_catalog, ash
+as $$
+  select d.datid, d.wait_event, d.query_id, d.count
+  from ash.decode_sample(ash.ts_from_timestamptz(p_ts)) d
+$$;
+
 
 --------------------------------------------------------------------------------
 -- STEP 3: Rotation function
@@ -4112,6 +4152,12 @@ $$Decoded wait-event samples between p_start and p_end, newest first, up to p_li
 
 comment on function ash.decode_sample(integer[], smallint) is
 $$Decodes a single ash.sample.data array into (wait_event, query_id, count) rows. Pass p_slot (ash.sample.slot) to resolve query_ids unambiguously; omitting it searches all query_map partitions and may return a stale id after rotation.$$;
+
+comment on function ash.decode_sample(int4) is
+$$Convenience overload: decodes every ash.sample row whose sample_ts equals p_sample_ts (across all datids/slots) and returns (datid, wait_event, query_id, count). Internally calls decode_sample(data, slot) with the row's slot, so query_id resolution is unambiguous.$$;
+
+comment on function ash.decode_sample(timestamptz) is
+$$Convenience overload: same as decode_sample(int4) but accepts timestamptz, converting via ts_from_timestamptz() to find the matching sample_ts.$$;
 
 -- Migration: add version column if upgrading from older version
 do $$


### PR DESCRIPTION
Closes #54.

## Summary
- Adds `ash.decode_sample(p_sample_ts int4)`: walks every `ash.sample` row whose `sample_ts` matches and returns `(datid oid, wait_event text, query_id bigint, count int)` so callers can distinguish per-database results.
- Adds `ash.decode_sample(p_ts timestamptz)`: converts to `sample_ts` via `ash.ts_from_timestamptz()` and delegates to the int4 overload. Same return shape.
- Both new overloads are `language sql` `STABLE` and use `LATERAL JOIN` over the existing 2-arg SRF, passing each row's `slot` for unambiguous `query_id` resolution (avoids the "search all partitions" branch that can return stale ids after rotation).
- The original `decode_sample(integer[], smallint)` signature is unchanged.

## Privileges
`PUBLIC EXECUTE` is revoked by the existing dynamic hardening loop (#45) — admins/readers need explicit grants. README documents this.

## Mirroring
`sql/ash-1.3-to-1.4.sql` `\ir`'s `ash-install.sql`, so the new functions ship automatically with the in-progress 1.4 upgrade. The header changelog was updated per CLAUDE.md.

## Tests
New CI step `Test decode_sample convenience overloads (int4, timestamptz)` exercises both overloads against synthetic `ash.sample` rows spanning two `datid`s. Asserts:
- Row count matches `sum(active_count)` of source rows
- `sum(d.count)` matches the same total
- Distinct `datid` count is correct
- Each expected `(datid, wait_event, query_id)` triple is present
- The `timestamptz` overload returns identical rows to the int4 overload after a `ts_to_timestamptz` round-trip
- Empty input (`-1`) returns zero rows

Existing decoder tests (2-arg call patterns) untouched and still pass locally on PG 18.

## Test plan
- [ ] CI passes on PG 14 / 15 / 16 / 17 / 18
- [ ] Schema-equivalence test (fresh install vs. upgrade chain) passes
- [ ] Existing `decode_sample(integer[], smallint)` callers still resolve correctly (overload resolution check)