### PR TITLE
safety: rebuild_partitions requires 'yes' confirmation token (#53)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1550,8 +1550,33 @@ jobs:
             v_result text;
             v_slot smallint;
           begin
+            -- === Confirmation token required (issue #53) ===
+            -- Without 'yes': raises and leaves state untouched.
+            begin
+              perform ash.rebuild_partitions(4);
+              assert false,
+                'rebuild_partitions(4) without confirm should raise';
+            exception when others then
+              null; -- expected
+            end;
+            -- Sampling must still be enabled (no destructive side effects).
+            assert (select sampling_enabled from ash.config where singleton) = true,
+              'rebuild_partitions without confirm must not change sampling_enabled';
+            -- num_partitions must still be 3 (no partitions dropped).
+            assert (select num_partitions from ash.config where singleton) = 3,
+              'rebuild_partitions without confirm must not change num_partitions';
+
+            -- With 'yes': proceeds.
+            select ash.rebuild_partitions(4, 'yes') into v_result;
+            assert v_result like 'rebuilt: 3 -> 4%',
+              'rebuild_partitions(4, ''yes'') should succeed, got: ' || v_result;
+            -- Reset to baseline 3 for the rest of this test block.
+            update ash.config set sampling_enabled = true where singleton;
+            select ash.rebuild_partitions(3, 'yes') into v_result;
+            update ash.config set sampling_enabled = true where singleton;
+
             -- === Rebuild to 5 partitions ===
-            select ash.rebuild_partitions(5) into v_result;
+            select ash.rebuild_partitions(5, 'yes') into v_result;
             assert v_result like 'rebuilt: 3 -> 5%',
               'rebuild should report 3 -> 5, got: ' || v_result;
 
@@ -1608,7 +1633,7 @@ jobs:
             assert v_count = 0, 'sample_2 should be empty after rotation';
 
             -- === Rebuild back to 3 ===
-            select ash.rebuild_partitions(3) into v_result;
+            select ash.rebuild_partitions(3, 'yes') into v_result;
             assert v_result like 'rebuilt: 5 -> 3%',
               'rebuild should report 5 -> 3';
 
@@ -1622,14 +1647,14 @@ jobs:
 
             -- === Edge case: rebuild with invalid N ===
             begin
-              perform ash.rebuild_partitions(2);
+              perform ash.rebuild_partitions(2, 'yes');
               assert false, 'should reject N=2';
             exception when others then
               null; -- expected
             end;
 
             begin
-              perform ash.rebuild_partitions(33);
+              perform ash.rebuild_partitions(33, 'yes');
               assert false, 'should reject N=33';
             exception when others then
               null; -- expected
@@ -2199,7 +2224,7 @@ jobs:
           begin
             -- rebuild_partitions should be denied
             begin
-              perform ash.rebuild_partitions(3);
+              perform ash.rebuild_partitions(3, 'yes');
               assert false, 'rebuild_partitions should be denied for unprivileged user';
             exception when insufficient_privilege then
               null; -- expected

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ select * from ash.status();
 | `ash.status()` | Sampling status, version, partition info, rollup metrics, debug_logging state |
 | `ash.take_sample()` | Take one sample manually (called automatically by the scheduler) |
 | `ash.rotate()` | Rotate sample partitions (called automatically, or manually for external schedulers). Runs pre-truncation rollup to prevent data loss |
-| `ash.rebuild_partitions(N)` | Change partition count (3–32). **Destructive** — all raw sample data is lost. Rollup tables survive. Call `ash.start()` after to resume |
+| `ash.rebuild_partitions(N, 'yes')` | Change partition count (3–32). **Destructive** — all raw sample data is lost; requires `'yes'` confirmation token. Rollup tables survive. Call `ash.start()` after to resume |
 | `ash.rollup_minute([batch])` | Aggregate raw samples into per-minute rollups. Watermark-based with catch-up. Default batch: 60 minutes |
 | `ash.rollup_hour()` | Aggregate minute rollups into hourly rollups. Watermark-based |
 | `ash.rollup_cleanup()` | Delete expired rollup rows per retention config |
@@ -599,7 +599,7 @@ Encoding version is tracked in `ash.config.encoding_version`, not in the array i
 
 ### Rotation
 
-Skytools PGQ-style N-partition ring buffer (default N=3, configurable 3–32 via `ash.rebuild_partitions(N)`). Physical tables (`sample_0` through `sample_{N-1}`) rotate at `rotation_period` intervals. TRUNCATE replaces the oldest partition — zero dead tuples, zero bloat, no VACUUM needed for sample tables.
+Skytools PGQ-style N-partition ring buffer (default N=3, configurable 3–32 via `ash.rebuild_partitions(N, 'yes')`). Physical tables (`sample_0` through `sample_{N-1}`) rotate at `rotation_period` intervals. TRUNCATE replaces the oldest partition — zero dead tuples, zero bloat, no VACUUM needed for sample tables.
 
 N-1 partitions hold data at any time. One is always empty, ready for the next rotation. Before truncation, `rotate()` calls `rollup_minute()` to aggregate endangered samples into rollup tables.
 
@@ -703,7 +703,8 @@ By default, pg_ash uses 3 partitions (1 day of history + current partial). To ke
 
 ```sql
 -- keep 7 days of raw samples (9 partitions × 1-day rotation = 7 readable days + current)
-select ash.rebuild_partitions(9);
+-- 'yes' is required because the call drops all raw sample data
+select ash.rebuild_partitions(9, 'yes');
 
 -- resume sampling after rebuild
 select ash.start();
@@ -716,7 +717,7 @@ select * from ash.status();
 
 The retention formula is `(N - 2) × rotation_period`. The minimum is 3 (current + previous + one being truncated), the maximum is 32.
 
-`rebuild_partitions()` is **destructive** — all raw samples are lost. Rollup tables survive. You must call `ash.start()` afterward to resume sampling.
+`rebuild_partitions()` is **destructive** — all raw samples are lost. To prevent accidents, the call requires a `'yes'` confirmation token (e.g. `ash.rebuild_partitions(9, 'yes')`); calling it without `'yes'` raises an error and changes nothing. Rollup tables survive. You must call `ash.start()` afterward to resume sampling.
 
 ### Rollup tables for long-term trends
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,25 @@
+# pg_ash — Unreleased (since 1.4)
+
+## Breaking changes
+
+### `rebuild_partitions()` now requires a `'yes'` confirmation token
+
+`ash.rebuild_partitions(N)` drops every raw sample partition and is irreversible. To prevent accidental data loss, the function now takes a second argument and refuses to proceed unless it equals `'yes'`. Wording mirrors `ash.uninstall('yes')`.
+
+```sql
+-- before (1.4): silently destructive
+select ash.rebuild_partitions(9);
+
+-- now: explicit confirmation required
+select ash.rebuild_partitions(9, 'yes');
+```
+
+Calling `ash.rebuild_partitions(N)` without the `'yes'` token raises an error and changes nothing — `sampling_enabled`, pg_cron jobs, and partition tables are all left untouched. The argument-validation runs before any destructive action. (#53)
+
+The `(int)` overload is dropped on upgrade. Existing callers (scripts, runbooks) must be updated to pass `'yes'`.
+
+---
+
 # pg_ash 1.4 release notes
 
 Upgrade from 1.3: `\i sql/ash-1.3-to-1.4.sql`. Fresh install or upgrade from any version: `\i sql/ash-install.sql`. The upgrade script is idempotent and safe to re-run.

--- a/sql/ash-1.3-to-1.4.sql
+++ b/sql/ash-1.3-to-1.4.sql
@@ -23,4 +23,6 @@
 --   - search_path guard on every ash.* function + pgss-schema-aware readers;
 --     REVOKE EXECUTE on all ash.* functions and SELECT on reader tables from
 --     PUBLIC (#45).
+--   - rebuild_partitions(p_num_partitions, p_confirm) — destructive, requires
+--     p_confirm = 'yes' to proceed; old (int) overload is dropped (#53).
 \ir ash-install.sql

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -31,7 +31,8 @@ begin
         'top_queries_with_text',
         '_validate_data',
         'uninstall',
-        'debug_logging'
+        'debug_logging',
+        'rebuild_partitions'
       )
   loop
     execute 'drop function if exists ' || r.sig;
@@ -883,7 +884,10 @@ $$;
 -- All raw sample data is lost. Rollup tables survive.
 -- WARNING: failure after acquiring lock leaves sampling_enabled = false.
 -- Manual recovery: UPDATE ash.config SET sampling_enabled = true; SELECT ash.start();
-create or replace function ash.rebuild_partitions(p_num int default null)
+create or replace function ash.rebuild_partitions(
+  p_num_partitions int,
+  p_confirm text default null
+)
 returns text
 language plpgsql
 set search_path = pg_catalog, ash
@@ -892,8 +896,16 @@ declare
   v_old_n int;
   v_new_n int;
 begin
+  -- Destructive: drops all raw sample partitions. Require explicit confirmation
+  -- BEFORE touching any state (sampling_enabled, pg_cron jobs, partitions).
+  if p_confirm is distinct from 'yes' then
+    raise exception 'rebuild_partitions is destructive — all raw sample data '
+      'will be lost. To proceed, call: '
+      'select ash.rebuild_partitions(%, ''yes'')', p_num_partitions;
+  end if;
+
   select num_partitions into v_old_n from ash.config where singleton;
-  v_new_n := coalesce(p_num, v_old_n);
+  v_new_n := coalesce(p_num_partitions, v_old_n);
 
   if v_new_n < 3 or v_new_n > 32 then
     raise exception 'num_partitions must be between 3 and 32, got: %', v_new_n;
@@ -4476,7 +4488,7 @@ begin
   execute format('revoke all on function ash.rotate() from public');
   execute format('revoke all on function ash.take_sample() from public');
   execute format('revoke all on function ash.set_debug_logging(bool) from public');
-  execute format('revoke all on function ash.rebuild_partitions(int) from public');
+  execute format('revoke all on function ash.rebuild_partitions(int, text) from public');
   execute format('revoke all on function ash._drop_all_partitions() from public');
   execute format('revoke all on function ash._rebuild_query_map_view() from public');
   execute format('revoke all on function ash.rollup_minute(int) from public');
@@ -4494,7 +4506,7 @@ begin
   execute format('grant execute on function ash.rotate() to %I', v_owner);
   execute format('grant execute on function ash.take_sample() to %I', v_owner);
   execute format('grant execute on function ash.set_debug_logging(bool) to %I', v_owner);
-  execute format('grant execute on function ash.rebuild_partitions(int) to %I', v_owner);
+  execute format('grant execute on function ash.rebuild_partitions(int, text) to %I', v_owner);
   execute format('grant execute on function ash._drop_all_partitions() to %I', v_owner);
   execute format('grant execute on function ash._rebuild_query_map_view() to %I', v_owner);
   execute format('grant execute on function ash.rollup_minute(int) to %I', v_owner);


### PR DESCRIPTION
## Summary

- `ash.rebuild_partitions(N)` is destructive (drops all raw sample partitions). Adopt the same confirmation pattern as `ash.uninstall('yes')`: signature is now `ash.rebuild_partitions(p_num_partitions int, p_confirm text default null)`, and without `p_confirm = 'yes'` the call raises `EXCEPTION` and leaves `sampling_enabled`, pg_cron jobs, and partition tables untouched. The check runs before any state mutation.
- Old `(int)` overload is dropped on install/upgrade (added to the existing stale-overload sweep in `ash-install.sql`). Mirrored into `sql/ash-1.3-to-1.4.sql` per CLAUDE.md.
- README + RELEASE_NOTES.md updated; tests updated to pass `'yes'`; new CI assertions cover both paths (no confirm → raises and changes nothing; with `'yes'` → succeeds).

## Breaking change

Callers must update `rebuild_partitions(N)` → `rebuild_partitions(N, 'yes')`. Noted under "Unreleased (since 1.4)" in `RELEASE_NOTES.md`.

Closes #53.

## Test plan

- [x] Verified locally (PG18): without confirm → raises `rebuild_partitions is destructive — ... select ash.rebuild_partitions(4, 'yes')`; `sampling_enabled` and `num_partitions` unchanged.
- [x] Verified locally: `rebuild_partitions(4, 'yes')` succeeds; partition count moves 3→4 then back.
- [x] Verified locally: invalid N (`2`, `33`) still rejected after `'yes'`.
- [ ] CI matrix (PG14–18) green.
- [ ] Schema-equivalence test green (fresh install vs upgrade chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)