### PR TITLE
feat(security): add ash.grant_reader and ash.revoke_reader helpers (#52)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -372,6 +372,199 @@ jobs:
           drop role ash_test_unpriv;
           EOF
 
+      - name: Test ash.grant_reader / ash.revoke_reader helpers (#52)
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          -- Set up: a monitoring-style role with no privileges yet.
+          do $$
+          begin
+            if not exists (select from pg_roles where rolname = 'ash_grafana') then
+              create role ash_grafana login password 'x';
+            end if;
+          end $$;
+
+          -- Sanity: role cannot use schema ash before grant_reader.
+          do $$
+          begin
+            assert not has_schema_privilege('ash_grafana', 'ash', 'USAGE'),
+              'ash_grafana must NOT have USAGE on ash before grant_reader';
+            assert not has_function_privilege('ash_grafana', 'ash.top_waits(interval,int,int,boolean)', 'EXECUTE'),
+              'ash_grafana must NOT have EXECUTE on ash.top_waits before grant_reader';
+            assert not has_function_privilege('ash_grafana', 'ash.status()', 'EXECUTE'),
+              'ash_grafana must NOT have EXECUTE on ash.status before grant_reader';
+            assert not has_function_privilege('ash_grafana', 'ash.minute_waits(interval,int)', 'EXECUTE'),
+              'ash_grafana must NOT have EXECUTE on ash.minute_waits before grant_reader';
+            assert not has_table_privilege('ash_grafana', 'ash.sample', 'SELECT'),
+              'ash_grafana must NOT have SELECT on ash.sample before grant_reader';
+            assert not has_table_privilege('ash_grafana', 'ash.rollup_1m', 'SELECT'),
+              'ash_grafana must NOT have SELECT on ash.rollup_1m before grant_reader';
+            assert not has_table_privilege('ash_grafana', 'ash.sample_0', 'SELECT'),
+              'ash_grafana must NOT have SELECT on ash.sample_0 before grant_reader';
+          end $$;
+
+          -- Validation: non-existent role must raise a clear error and not partial-grant.
+          do $$
+          declare
+            v_succeeded bool := false;
+          begin
+            begin
+              perform ash.grant_reader('nope_does_not_exist');
+              v_succeeded := true;
+            exception when raise_exception then
+              null; -- expected: function raised because role missing
+            end;
+            assert not v_succeeded,
+              'grant_reader must reject non-existent role';
+          end $$;
+
+          -- GRANT: hand out the reader bundle.
+          select ash.grant_reader('ash_grafana');
+
+          -- Verify the granted set.
+          do $$
+          begin
+            assert has_schema_privilege('ash_grafana', 'ash', 'USAGE'),
+              'grant_reader: ash_grafana must have USAGE on ash';
+
+            -- Reader functions across the family
+            assert has_function_privilege('ash_grafana', 'ash.top_waits(interval,int,int,boolean)', 'EXECUTE'),
+              'grant_reader: ash.top_waits must be EXECUTE-able';
+            assert has_function_privilege('ash_grafana', 'ash.top_queries(interval,int)', 'EXECUTE'),
+              'grant_reader: ash.top_queries must be EXECUTE-able';
+            assert has_function_privilege('ash_grafana', 'ash.status()', 'EXECUTE'),
+              'grant_reader: ash.status must be EXECUTE-able';
+            assert has_function_privilege('ash_grafana', 'ash.samples(interval,int)', 'EXECUTE'),
+              'grant_reader: ash.samples must be EXECUTE-able';
+            assert has_function_privilege('ash_grafana', 'ash.minute_waits(interval,int)', 'EXECUTE'),
+              'grant_reader: ash.minute_waits must be EXECUTE-able';
+            assert has_function_privilege('ash_grafana', 'ash.hourly_queries(interval,int)', 'EXECUTE'),
+              'grant_reader: ash.hourly_queries must be EXECUTE-able';
+            assert has_function_privilege('ash_grafana', 'ash.daily_peak_backends(interval)', 'EXECUTE'),
+              'grant_reader: ash.daily_peak_backends must be EXECUTE-able';
+            assert has_function_privilege('ash_grafana', 'ash.activity_summary(interval)', 'EXECUTE'),
+              'grant_reader: ash.activity_summary must be EXECUTE-able';
+            assert has_function_privilege('ash_grafana', 'ash.timeline_chart(interval,interval,int,int,boolean)', 'EXECUTE'),
+              'grant_reader: ash.timeline_chart must be EXECUTE-able';
+
+            -- Reader-helpers the readers depend on
+            assert has_function_privilege('ash_grafana', 'ash._active_slots()', 'EXECUTE'),
+              'grant_reader: ash._active_slots must be EXECUTE-able';
+            assert has_function_privilege('ash_grafana', 'ash._wait_color(text,boolean)', 'EXECUTE'),
+              'grant_reader: ash._wait_color must be EXECUTE-able';
+            assert has_function_privilege('ash_grafana', 'ash.epoch()', 'EXECUTE'),
+              'grant_reader: ash.epoch must be EXECUTE-able';
+
+            -- Admin functions stay locked down
+            assert not has_function_privilege('ash_grafana', 'ash.start(interval)', 'EXECUTE'),
+              'grant_reader: ash.start must remain admin-only';
+            assert not has_function_privilege('ash_grafana', 'ash.stop()', 'EXECUTE'),
+              'grant_reader: ash.stop must remain admin-only';
+            assert not has_function_privilege('ash_grafana', 'ash.take_sample()', 'EXECUTE'),
+              'grant_reader: ash.take_sample must remain admin-only';
+            assert not has_function_privilege('ash_grafana', 'ash.rotate()', 'EXECUTE'),
+              'grant_reader: ash.rotate must remain admin-only';
+            assert not has_function_privilege('ash_grafana', 'ash.uninstall(text)', 'EXECUTE'),
+              'grant_reader: ash.uninstall must remain admin-only';
+            assert not has_function_privilege('ash_grafana', 'ash.set_debug_logging(bool)', 'EXECUTE'),
+              'grant_reader: ash.set_debug_logging must remain admin-only';
+            assert not has_function_privilege('ash_grafana', 'ash.rollup_minute(int)', 'EXECUTE'),
+              'grant_reader: ash.rollup_minute must remain admin-only';
+            assert not has_function_privilege('ash_grafana', 'ash.rollup_hour()', 'EXECUTE'),
+              'grant_reader: ash.rollup_hour must remain admin-only';
+            assert not has_function_privilege('ash_grafana', 'ash.rollup_cleanup()', 'EXECUTE'),
+              'grant_reader: ash.rollup_cleanup must remain admin-only';
+            -- The helpers themselves are admin-only too: a reader role
+            -- that could grant_reader/revoke_reader could escalate.
+            assert not has_function_privilege('ash_grafana', 'ash.grant_reader(name)', 'EXECUTE'),
+              'grant_reader: ash.grant_reader must remain admin-only';
+            assert not has_function_privilege('ash_grafana', 'ash.revoke_reader(name)', 'EXECUTE'),
+              'grant_reader: ash.revoke_reader must remain admin-only';
+
+            -- Reader tables
+            assert has_table_privilege('ash_grafana', 'ash.sample', 'SELECT'),
+              'grant_reader: SELECT on ash.sample';
+            assert has_table_privilege('ash_grafana', 'ash.query_map_all', 'SELECT'),
+              'grant_reader: SELECT on ash.query_map_all';
+            assert has_table_privilege('ash_grafana', 'ash.config', 'SELECT'),
+              'grant_reader: SELECT on ash.config';
+            assert has_table_privilege('ash_grafana', 'ash.wait_event_map', 'SELECT'),
+              'grant_reader: SELECT on ash.wait_event_map';
+            assert has_table_privilege('ash_grafana', 'ash.rollup_1m', 'SELECT'),
+              'grant_reader: SELECT on ash.rollup_1m';
+            assert has_table_privilege('ash_grafana', 'ash.rollup_1h', 'SELECT'),
+              'grant_reader: SELECT on ash.rollup_1h';
+
+            -- Per-slot partitions get SELECT (parent grants do not cascade in PG)
+            assert has_table_privilege('ash_grafana', 'ash.sample_0', 'SELECT'),
+              'grant_reader: SELECT on ash.sample_0 (partition)';
+            assert has_table_privilege('ash_grafana', 'ash.query_map_0', 'SELECT'),
+              'grant_reader: SELECT on ash.query_map_0 (dictionary)';
+
+            raise notice 'grant_reader granted set verified';
+          end $$;
+
+          -- Idempotency: second grant_reader is a no-op error-free.
+          select ash.grant_reader('ash_grafana');
+
+          -- Behavioral check: actually call a reader as the role.
+          -- Avoid ash.status() here: it reads cron.job when pg_cron is
+          -- loaded, which requires USAGE on schema cron — out of scope
+          -- for grant_reader (and a separate, pre-existing limitation).
+          set role ash_grafana;
+          select count(*) from ash.top_waits('1 hour'::interval, 5, 0);
+          select count(*) from ash.minute_waits('1 hour'::interval, 5);
+          -- direct table read works too
+          do $$ begin perform 1 from ash.sample limit 1; end $$;
+          reset role;
+
+          -- REVOKE: take everything back.
+          select ash.revoke_reader('ash_grafana');
+
+          do $$
+          begin
+            assert not has_schema_privilege('ash_grafana', 'ash', 'USAGE'),
+              'revoke_reader: USAGE on ash must be revoked';
+            assert not has_function_privilege('ash_grafana', 'ash.top_waits(interval,int,int,boolean)', 'EXECUTE'),
+              'revoke_reader: EXECUTE on ash.top_waits must be revoked';
+            assert not has_function_privilege('ash_grafana', 'ash.status()', 'EXECUTE'),
+              'revoke_reader: EXECUTE on ash.status must be revoked';
+            assert not has_function_privilege('ash_grafana', 'ash.minute_waits(interval,int)', 'EXECUTE'),
+              'revoke_reader: EXECUTE on ash.minute_waits must be revoked';
+            assert not has_table_privilege('ash_grafana', 'ash.sample', 'SELECT'),
+              'revoke_reader: SELECT on ash.sample must be revoked';
+            assert not has_table_privilege('ash_grafana', 'ash.rollup_1m', 'SELECT'),
+              'revoke_reader: SELECT on ash.rollup_1m must be revoked';
+            assert not has_table_privilege('ash_grafana', 'ash.sample_0', 'SELECT'),
+              'revoke_reader: SELECT on ash.sample_0 must be revoked';
+
+            raise notice 'revoke_reader fully removed reader privileges';
+          end $$;
+
+          -- After revoke, calling a reader as the role must fail with 42501.
+          set role ash_grafana;
+          do $$
+          declare
+            v_succeeded bool := false;
+          begin
+            begin
+              perform ash.top_waits('1 hour'::interval, 5, 0);
+              v_succeeded := true;
+            exception when insufficient_privilege then
+              null; -- expected: 42501 permission denied
+            end;
+            assert not v_succeeded,
+              'expected permission denied after revoke_reader, got success';
+          end $$;
+          reset role;
+
+          -- Idempotency: second revoke_reader is a no-op.
+          select ash.revoke_reader('ash_grafana');
+
+          drop role ash_grafana;
+          EOF
+
       - name: Test sampler and decoder
         env:
           PGPASSWORD: postgres

--- a/README.md
+++ b/README.md
@@ -884,7 +884,24 @@ Don't forget to also schedule rotation and rollups:
 
 pg_ash installs with a locked-down privilege model: admin functions (`ash.start()`, `ash.stop()`, `ash.rotate()`, `ash.take_sample()`, `ash.set_debug_logging()`, `ash.uninstall()`) are restricted to the schema owner, and EXECUTE on all reader functions plus SELECT on reader tables (`ash.sample`, `ash.query_map_all`, `ash.config`, `ash.wait_event_map`, and per-slot partitions) is revoked from `PUBLIC`. The installing role retains full access.
 
-Grant access to a monitoring or read-only role explicitly:
+Grant access to a monitoring or read-only role with the convenience helpers:
+
+```sql
+-- one call, minimum privileges: USAGE on schema ash, EXECUTE on every
+-- public reader function, SELECT on the tables readers depend on
+-- (sample + partitions, query_map_all + partitions, config, wait_event_map,
+-- rollup_1m, rollup_1h). Idempotent.
+create role grafana login password 'xxx';
+select ash.grant_reader('grafana');
+
+-- ...later, take it back. Symmetric undo of grant_reader().
+select ash.revoke_reader('grafana');
+```
+
+Both helpers are owner-only, validate the role exists in `pg_roles`,
+quote the role name, and emit a `RAISE NOTICE` summarizing what changed.
+
+If you prefer manual control, the equivalent explicit grants are:
 
 ```sql
 -- allow a monitoring role to call the readers

--- a/README.md
+++ b/README.md
@@ -901,6 +901,8 @@ select ash.revoke_reader('grafana');
 Both helpers are owner-only, validate the role exists in `pg_roles`,
 quote the role name, and emit a `RAISE NOTICE` summarizing what changed.
 
+**Note:** If you subsequently change the partition count via `ash.rebuild_partitions(N, 'yes')`, previously-granted reader roles will lose access to the new partition tables. Re-run `ash.grant_reader(...)` for each monitoring role after any `rebuild_partitions` call.
+
 If you prefer manual control, the equivalent explicit grants are:
 
 ```sql

--- a/sql/ash-1.3-to-1.4.sql
+++ b/sql/ash-1.3-to-1.4.sql
@@ -23,4 +23,8 @@
 --   - search_path guard on every ash.* function + pgss-schema-aware readers;
 --     REVOKE EXECUTE on all ash.* functions and SELECT on reader tables from
 --     PUBLIC (#45).
+--   - ash.grant_reader(role) / ash.revoke_reader(role) convenience helpers
+--     to provision a monitoring role (Grafana, Datadog, etc.) with the
+--     minimum privileges to call every public reader. Owner-only, idempotent
+--     symmetric undo. (#52)
 \ir ash-install.sql

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -4668,7 +4668,7 @@ end;
 $$;
 
 comment on function ash.grant_reader(name) is
-  'Grants the minimum privileges (USAGE on schema ash, EXECUTE on all reader functions, SELECT on reader tables incl. partitions) to a monitoring role. Idempotent. Inverse: ash.revoke_reader(name).';
+  'Grants the minimum privileges (USAGE on schema ash, EXECUTE on all reader functions, SELECT on reader tables incl. partitions) to a monitoring role. Idempotent. Inverse: ash.revoke_reader(name). Caveat: ash.rebuild_partitions(N, ''yes'') creates new partition tables that previously-granted readers cannot access; re-run ash.grant_reader() for each monitoring role after any rebuild_partitions() call.';
 
 create or replace function ash.revoke_reader(p_role name)
 returns void
@@ -4743,7 +4743,7 @@ end;
 $$;
 
 comment on function ash.revoke_reader(name) is
-  'Revokes the privileges granted by ash.grant_reader(): USAGE on schema ash, EXECUTE on all reader functions, SELECT on reader tables. Idempotent. Inverse: ash.grant_reader(name).';
+  'Revokes the privileges granted by ash.grant_reader(): USAGE on schema ash, EXECUTE on all reader functions, SELECT on reader tables. Idempotent. Inverse: ash.grant_reader(name). Caveat: ash.rebuild_partitions(N, ''yes'') creates new partition tables that previously-granted readers cannot access; re-run ash.grant_reader() for each monitoring role after any rebuild_partitions() call.';
 
 -- Lock down the helpers themselves: only the schema owner may hand out
 -- (or take back) privileges. PUBLIC must not be able to call them.

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -4557,3 +4557,202 @@ begin
     execute format('revoke select on ash.%I from public', r.relname);
   end loop;
 end $$;
+
+--------------------------------------------------------------------------------
+-- STEP 7: Convenience helpers for monitoring roles
+--------------------------------------------------------------------------------
+
+-- ash.grant_reader(role) / ash.revoke_reader(role)
+--
+-- Convenience helpers that hand a monitoring role (Grafana, Datadog, an
+-- on-call dashboard, etc.) the *minimum* privileges needed to invoke every
+-- public reader function and read from the tables the readers depend on.
+-- They are the inverse of the REVOKE-from-PUBLIC hardening above: instead
+-- of opening up the schema globally, the operator names a specific role.
+--
+-- Granted set:
+--   - USAGE on schema ash
+--   - EXECUTE on every ash.* function EXCEPT the admin set (start, stop,
+--     uninstall, rotate, take_sample, set_debug_logging, rebuild_partitions,
+--     rollup_minute, rollup_hour, rollup_cleanup, _drop_all_partitions,
+--     _rebuild_query_map_view, _merge_wait_counts, _merge_query_counts,
+--     _truncate_pairs, _int4_array_cat_agg, _int8_array_cat_agg). Defining
+--     "reader" by exclusion (rather than enumeration) keeps the helpers
+--     correct as new readers and reader-internal helpers are added.
+--   - SELECT on ash.sample (+ every sample_N partition), ash.query_map_all
+--     (+ every query_map_N partition), ash.config, ash.wait_event_map,
+--     ash.rollup_1m, ash.rollup_1h.
+--
+-- Both helpers are idempotent (safe to re-run), validate the role exists
+-- via pg_roles, quote_ident() the role name, and emit a RAISE NOTICE
+-- summarizing what was changed. revoke_reader() is the symmetric undo.
+create or replace function ash.grant_reader(p_role name)
+returns void
+language plpgsql
+set search_path = pg_catalog, ash
+as $$
+declare
+  r record;
+  v_role text;
+  v_admin_funcs constant text[] := array[
+    'start', 'stop', 'uninstall', 'rotate', 'take_sample',
+    'set_debug_logging', 'rebuild_partitions', 'rollup_minute',
+    'rollup_hour', 'rollup_cleanup', '_drop_all_partitions',
+    '_rebuild_query_map_view', '_merge_wait_counts', '_merge_query_counts',
+    '_truncate_pairs', '_int4_array_cat_agg', '_int8_array_cat_agg',
+    -- the helpers themselves: granting them to a reader role would let
+    -- that role hand out privileges. keep them admin-only.
+    'grant_reader', 'revoke_reader'
+  ];
+  v_func_count int := 0;
+  v_table_count int := 0;
+begin
+  if p_role is null or length(trim(p_role::text)) = 0 then
+    raise exception 'ash.grant_reader: role name must not be null or empty';
+  end if;
+
+  -- Validate role exists. quote_ident() defends against SQL injection in
+  -- the dynamic GRANT statements below, but a non-existent role would
+  -- raise a confusing "role does not exist" from inside the loop —
+  -- surface a clear error up front instead.
+  if not exists (select 1 from pg_catalog.pg_roles where rolname = p_role) then
+    raise exception 'ash.grant_reader: role % does not exist', quote_literal(p_role);
+  end if;
+
+  v_role := quote_ident(p_role);
+
+  execute format('grant usage on schema ash to %s', v_role);
+
+  -- EXECUTE on every reader function (= every ash.* function not in the
+  -- admin set). Signatures are resolved dynamically via pg_proc so default
+  -- arguments and future overloads do not cause drift.
+  for r in
+    select p.proname,
+           pg_catalog.pg_get_function_identity_arguments(p.oid) as args
+    from pg_catalog.pg_proc p
+    join pg_catalog.pg_namespace n on p.pronamespace = n.oid
+    where n.nspname = 'ash'
+      and p.prokind = 'f'
+      and p.proname::text <> all (v_admin_funcs)
+  loop
+    execute format('grant execute on function ash.%I(%s) to %s',
+                   r.proname, r.args, v_role);
+    v_func_count := v_func_count + 1;
+  end loop;
+
+  -- SELECT on reader tables. Partitioned-parent grants do not cascade to
+  -- partitions in PostgreSQL, so sample_N and query_map_N are enumerated.
+  execute format('grant select on table ash.sample to %s', v_role);
+  execute format('grant select on table ash.query_map_all to %s', v_role);
+  execute format('grant select on table ash.config to %s', v_role);
+  execute format('grant select on table ash.wait_event_map to %s', v_role);
+  execute format('grant select on table ash.rollup_1m to %s', v_role);
+  execute format('grant select on table ash.rollup_1h to %s', v_role);
+  v_table_count := v_table_count + 6;
+
+  for r in
+    select c.relname
+    from pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n on c.relnamespace = n.oid
+    where n.nspname = 'ash'
+      and c.relkind in ('r', 'p')
+      and (c.relname ~ '^query_map_[0-9]+$' or c.relname ~ '^sample_[0-9]+$')
+  loop
+    execute format('grant select on ash.%I to %s', r.relname, v_role);
+    v_table_count := v_table_count + 1;
+  end loop;
+
+  raise notice 'ash.grant_reader: granted USAGE on schema ash, EXECUTE on % reader function(s), SELECT on % table(s) to %',
+    v_func_count, v_table_count, v_role;
+end;
+$$;
+
+comment on function ash.grant_reader(name) is
+  'Grants the minimum privileges (USAGE on schema ash, EXECUTE on all reader functions, SELECT on reader tables incl. partitions) to a monitoring role. Idempotent. Inverse: ash.revoke_reader(name).';
+
+create or replace function ash.revoke_reader(p_role name)
+returns void
+language plpgsql
+set search_path = pg_catalog, ash
+as $$
+declare
+  r record;
+  v_role text;
+  v_admin_funcs constant text[] := array[
+    'start', 'stop', 'uninstall', 'rotate', 'take_sample',
+    'set_debug_logging', 'rebuild_partitions', 'rollup_minute',
+    'rollup_hour', 'rollup_cleanup', '_drop_all_partitions',
+    '_rebuild_query_map_view', '_merge_wait_counts', '_merge_query_counts',
+    '_truncate_pairs', '_int4_array_cat_agg', '_int8_array_cat_agg',
+    'grant_reader', 'revoke_reader'
+  ];
+  v_func_count int := 0;
+  v_table_count int := 0;
+begin
+  if p_role is null or length(trim(p_role::text)) = 0 then
+    raise exception 'ash.revoke_reader: role name must not be null or empty';
+  end if;
+
+  if not exists (select 1 from pg_catalog.pg_roles where rolname = p_role) then
+    raise exception 'ash.revoke_reader: role % does not exist', quote_literal(p_role);
+  end if;
+
+  v_role := quote_ident(p_role);
+
+  for r in
+    select p.proname,
+           pg_catalog.pg_get_function_identity_arguments(p.oid) as args
+    from pg_catalog.pg_proc p
+    join pg_catalog.pg_namespace n on p.pronamespace = n.oid
+    where n.nspname = 'ash'
+      and p.prokind = 'f'
+      and p.proname::text <> all (v_admin_funcs)
+  loop
+    execute format('revoke execute on function ash.%I(%s) from %s',
+                   r.proname, r.args, v_role);
+    v_func_count := v_func_count + 1;
+  end loop;
+
+  execute format('revoke select on table ash.sample from %s', v_role);
+  execute format('revoke select on table ash.query_map_all from %s', v_role);
+  execute format('revoke select on table ash.config from %s', v_role);
+  execute format('revoke select on table ash.wait_event_map from %s', v_role);
+  execute format('revoke select on table ash.rollup_1m from %s', v_role);
+  execute format('revoke select on table ash.rollup_1h from %s', v_role);
+  v_table_count := v_table_count + 6;
+
+  for r in
+    select c.relname
+    from pg_catalog.pg_class c
+    join pg_catalog.pg_namespace n on c.relnamespace = n.oid
+    where n.nspname = 'ash'
+      and c.relkind in ('r', 'p')
+      and (c.relname ~ '^query_map_[0-9]+$' or c.relname ~ '^sample_[0-9]+$')
+  loop
+    execute format('revoke select on ash.%I from %s', r.relname, v_role);
+    v_table_count := v_table_count + 1;
+  end loop;
+
+  -- USAGE last so the in-flight statements above can still resolve ash.*
+  -- by name even if the role had no other path to it. Idempotent.
+  execute format('revoke usage on schema ash from %s', v_role);
+
+  raise notice 'ash.revoke_reader: revoked USAGE on schema ash, EXECUTE on % reader function(s), SELECT on % table(s) from %',
+    v_func_count, v_table_count, v_role;
+end;
+$$;
+
+comment on function ash.revoke_reader(name) is
+  'Revokes the privileges granted by ash.grant_reader(): USAGE on schema ash, EXECUTE on all reader functions, SELECT on reader tables. Idempotent. Inverse: ash.grant_reader(name).';
+
+-- Lock down the helpers themselves: only the schema owner may hand out
+-- (or take back) privileges. PUBLIC must not be able to call them.
+do $$
+declare
+  v_owner text := (select nspowner::regrole::text from pg_namespace where nspname = 'ash');
+begin
+  execute format('revoke all on function ash.grant_reader(name) from public');
+  execute format('revoke all on function ash.revoke_reader(name) from public');
+  execute format('grant execute on function ash.grant_reader(name) to %I', v_owner);
+  execute format('grant execute on function ash.revoke_reader(name) to %I', v_owner);
+end $$;


### PR DESCRIPTION
Closes #52.

## Summary

- Adds `ash.grant_reader(p_role name)` and `ash.revoke_reader(p_role name)` — one-call provisioning of a monitoring role (Grafana, Datadog, on-call dashboard) with the **minimum** privileges needed to invoke every public reader.
- `grant_reader` hands out USAGE on schema ash, EXECUTE on every `ash.*` function NOT in the admin set (so future readers and reader-internal helpers are covered automatically by exclusion), and SELECT on the tables readers depend on (`ash.sample` + partitions, `ash.query_map_all` + partitions, `ash.config`, `ash.wait_event_map`, `ash.rollup_1m`, `ash.rollup_1h`).
- `revoke_reader` is the symmetric undo.
- Both helpers validate the role exists via `pg_roles`, `quote_ident()` the name, are idempotent, and emit a `RAISE NOTICE` summarizing what changed.
- The helpers are themselves admin-only (`REVOKE ALL ... FROM PUBLIC` + `GRANT EXECUTE ... TO <owner>`) so a reader role cannot escalate by re-invoking them.
- Mirrored into `sql/ash-1.3-to-1.4.sql` (the in-progress upgrade script `\ir`s `ash-install.sql` so the new functions are picked up automatically; the changelog comment is updated).
- README "Privileges" section gains the canonical usage example: `select ash.grant_reader('grafana')` / `select ash.revoke_reader('grafana')`. The pre-existing manual-grant recipe stays as a reference.

## Surprises encountered while writing the test

- `ash.status()` reads from `cron.job` when pg_cron is loaded, which fails with "permission denied for schema cron" for any non-superuser. That is a pre-existing limitation outside the scope of this PR; the new CI test exercises behavior with `top_waits` / `minute_waits` (which have no such cross-schema dependency) and adds a comment noting the rationale.

## Test plan

- [x] Local fresh install of `sql/ash-install.sql` on PG18 — clean.
- [x] Local re-install (idempotency) — clean.
- [x] Local end-to-end smoke: create role → grant_reader → has_function_privilege/has_table_privilege assertions → call `top_waits`/`minute_waits` as the role → idempotent re-grant → revoke_reader → assertions → call as role expecting `42501` → idempotent re-revoke → drop role. Reports 42 reader functions + 12 tables on default 3-partition install.
- [x] CI test step added to `.github/workflows/test.yml` ("Test ash.grant_reader / ash.revoke_reader helpers (#52)") covering the same flow on PG14–18, with and without pg_cron.
- [ ] CI green across the matrix.