### PR TITLE
fix(readers): clamp ts_from_timestamptz to int4 range; _at variants no longer overflow (#63)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1697,6 +1697,49 @@ jobs:
             assert v_count = 0,
               'event_queries(1000 years) should return 0 rows, got: ' || v_count;
 
+            -- === Absurd timestamps for _at variants (regression: #63) ===
+            -- Pre-epoch and post-2094-horizon timestamps would over/underflow
+            -- the int4 epoch offset in ash.ts_from_timestamptz. The helper
+            -- now clamps to [0, INT4_MAX] so every _at reader yields an empty
+            -- (or single-row placeholder for activity_summary-style readers)
+            -- result instead of raising integer-out-of-range.
+
+            -- Helper-level: pre-epoch -> 0, post-horizon -> INT4_MAX
+            assert ash.ts_from_timestamptz('1000-01-01'::timestamptz) = 0,
+              'ts_from_timestamptz(1000-01-01) should clamp to 0, got: ' ||
+              ash.ts_from_timestamptz('1000-01-01'::timestamptz);
+            assert ash.ts_from_timestamptz('3000-01-01'::timestamptz) = 2147483647,
+              'ts_from_timestamptz(3000-01-01) should clamp to INT4_MAX, got: ' ||
+              ash.ts_from_timestamptz('3000-01-01'::timestamptz);
+
+            -- Pre-epoch range -> empty
+            select count(*) into v_count from ash.top_waits_at(
+              '1000-01-01'::timestamptz, '1000-01-02'::timestamptz);
+            assert v_count = 0,
+              'top_waits_at(pre-epoch) should return 0 rows, got: ' || v_count;
+
+            -- Post-horizon range -> empty
+            select count(*) into v_count from ash.top_waits_at(
+              '3000-01-01'::timestamptz, '3000-01-02'::timestamptz);
+            assert v_count = 0,
+              'top_waits_at(post-horizon) should return 0 rows, got: ' || v_count;
+
+            -- Spot-check samples_at: same start/end after clamping yields empty
+            select count(*) into v_count from ash.samples_at(
+              '1000-01-01'::timestamptz, '1000-01-02'::timestamptz, 10);
+            assert v_count = 0,
+              'samples_at(pre-epoch) should return 0 rows, got: ' || v_count;
+            select count(*) into v_count from ash.samples_at(
+              '3000-01-01'::timestamptz, '3000-01-02'::timestamptz, 10);
+            assert v_count = 0,
+              'samples_at(post-horizon) should return 0 rows, got: ' || v_count;
+
+            -- Normal range still works (no regression in positive path)
+            select count(*) into v_count from ash.top_waits_at(
+              now() - interval '10 minutes', now());
+            assert v_count >= 0,
+              'top_waits_at(normal range) should not error, got: ' || v_count;
+
             -- === Non-existent queries ===
 
             select count(*) into v_count from ash.query_waits(999999999, '1 hour');

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1740,6 +1740,29 @@ jobs:
             assert v_count >= 0,
               'top_waits_at(normal range) should not error, got: ' || v_count;
 
+            -- Pin "all _at readers inherit the helper-level fix" claim:
+            -- spot-check the remaining _at signatures (rollup readers,
+            -- decode_sample_at, event_queries_at) on absurd timestamps.
+            select count(*) into v_count from ash.minute_waits_at(
+              '1000-01-01'::timestamptz, '1000-01-01 01:00'::timestamptz);
+            assert v_count = 0,
+              'minute_waits_at(pre-epoch) should return 0 rows, got: ' || v_count;
+
+            select count(*) into v_count from ash.hourly_queries_at(
+              '3000-01-01'::timestamptz, '3000-01-01 01:00'::timestamptz);
+            assert v_count = 0,
+              'hourly_queries_at(post-horizon) should return 0 rows, got: ' || v_count;
+
+            select count(*) into v_count from ash.decode_sample_at(
+              '1000-01-01'::timestamptz);
+            assert v_count = 0,
+              'decode_sample_at(pre-epoch) should return 0 rows, got: ' || v_count;
+
+            select count(*) into v_count from ash.event_queries_at(
+              'Lock:tuple', '1000-01-01'::timestamptz, '1000-01-01 01:00'::timestamptz);
+            assert v_count = 0,
+              'event_queries_at(pre-epoch) should return 0 rows, got: ' || v_count;
+
             -- === Non-existent queries ===
 
             select count(*) into v_count from ash.query_waits(999999999, '1 hour');

--- a/sql/ash-1.3-to-1.4.sql
+++ b/sql/ash-1.3-to-1.4.sql
@@ -45,4 +45,12 @@
 --     symmetric undo. (#52)
 --   - rebuild_partitions(p_num_partitions, p_confirm) — destructive, requires
 --     p_confirm = 'yes' to proceed; old (int) overload is dropped (#53).
+--   - ts_from_timestamptz() clamps to [0, INT4_MAX] so the _at reader family
+--     (top_waits_at / samples_at / query_waits_at / event_queries_at /
+--     timeline_chart_at / top_queries_at / wait_timeline_at / top_by_type_at /
+--     minute_waits_at / hourly_queries_at / daily_peak_backends_at) no longer
+--     raises `integer out of range` on absurd timestamps (pre-epoch or
+--     post-2094 horizon). Pre-epoch -> 0 and post-horizon -> INT4_MAX both
+--     fall outside any sample_ts window, yielding empty results — same class
+--     of fix as #51 (PR #57), centralized at the helper. (#63)
 \ir ash-install.sql

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -328,7 +328,15 @@ begin
   end if;
 end $$;
 
--- Convert timestamptz to int4 epoch offset
+-- Convert timestamptz to int4 epoch offset.
+--
+-- Clamp to [0, INT4_MAX] so absurd inputs (pre-epoch dates, post-2094-horizon
+-- dates) do not raise `integer out of range`. sample_ts is a non-negative int4
+-- by construction, so:
+--   * pre-epoch  -> 0           (no matching samples; readers return empty)
+--   * post-INT4  -> 2147483647  (no matching samples; readers return empty)
+-- This centralizes the same-class clamp pattern used by the interval readers
+-- (#51 / PR #57) so every _at variant inherits the safety net (#63).
 create or replace function ash.ts_from_timestamptz(p_ts timestamptz)
 returns int4
 language sql
@@ -336,7 +344,13 @@ immutable
 parallel safe
 set search_path = pg_catalog, ash
 as $$
-  select extract(epoch from p_ts - ash.epoch())::int4
+  select greatest(
+           least(
+             extract(epoch from p_ts - ash.epoch()),
+             2147483647  -- int4 max; sample_ts can't exceed this without overflow
+           ),
+           0             -- sample_ts can't be negative; pre-epoch -> 0
+         )::int4
 $$;
 
 -- Convert int4 epoch offset to timestamptz


### PR DESCRIPTION
## Summary

- Fixes #63: every `_at` reader (`top_waits_at`, `samples_at`, `query_waits_at`, `event_queries_at`, `timeline_chart_at`, `top_queries_at`, `wait_timeline_at`, `top_by_type_at`, `minute_waits_at`, `hourly_queries_at`, `daily_peak_backends_at`) raised `integer out of range` on absurd timestamps because `ash.ts_from_timestamptz(p_ts)` did `extract(epoch from p_ts - ash.epoch())::int4` with no clamp — pre-epoch inputs underflowed, post-2094-horizon inputs overflowed.
- Centralize the clamp at the helper to `[0, INT4_MAX]`. Pre-epoch -> `0`, post-horizon -> `2147483647`. `sample_ts` is a non-negative `int4` by construction, so both clamped endpoints fall outside the actual sample window and readers naturally yield empty results — no hard error.
- Sibling of merged #51 (PR #57), which clamped the interval-based readers; the `_at` variants were explicitly deferred during that PR's review. Same clamp pattern, just centralized one level deeper at the shared helper so every current and future `_at` caller inherits it.
- Mirror the changelog entry into `sql/ash-1.3-to-1.4.sql` per the install.sql lockstep policy. CI regression assertions added in `test.yml`: helper-level (`1000-01-01 -> 0`, `3000-01-01 -> INT4_MAX`), pre-epoch and post-horizon ranges yield empty `top_waits_at` / `samples_at`, plus a normal range still works.

## Test plan

- [x] Local: `psql -f sql/ash-install.sql` clean install on PG 18
- [x] Local: confirmed pre-fix body raises `integer out of range` for `'1000-01-01'::timestamptz`
- [x] Local: post-fix helper returns `0` for pre-epoch, `2147483647` for post-horizon
- [x] Local: all 11 `_at` readers return 0 rows (or non-error placeholder) for both pre-epoch and post-horizon ranges
- [x] Local: normal range (`now() - 10 min` .. `now()`) still works
- [ ] CI: fresh install, upgrade chain, schema equivalence, degraded mode (PG 14-18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)