### PR TITLE
docs: fix v1.4 release gate findings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,29 @@ permissions:
   contents: read
 
 jobs:
+
+  docs-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Guard docs against stale privilege and reader names
+        run: |
+          set -euo pipefail
+
+          if grep -RIn "grant execute on all functions in schema ash" README.md RELEASE_NOTES.md docs; then
+            echo "Do not recommend blanket EXECUTE on ash.*; use ash.grant_reader() or explicit minimal grants." >&2
+            exit 1
+          fi
+
+          if grep -RIn "waits_by_type" README.md docs | grep -v "Renamed"; then
+            echo "Stale waits_by_type reference found; use top_by_type/top_by_type_at." >&2
+            exit 1
+          fi
+
+          grep -q "ash.grant_reader" README.md
+          grep -q "SECURITY.md#advisory-lock-squat-dos" README.md
+          grep -q "SECURITY.md#advisory-lock-squat-dos" RELEASE_NOTES.md
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/README.md
+++ b/README.md
@@ -126,17 +126,18 @@ select * from ash.status();
 
 | Function | Description |
 |----------|-------------|
-| `ash.start(interval)` | Start sampling (default: `'1 second'`). Uses pg_cron if available, otherwise prints external scheduling instructions. Also schedules rollup jobs |
-| `ash.stop()` | Stop sampling and rollups (removes pg_cron jobs, sets `sampling_enabled = false`) |
-| `ash.status()` | Sampling status, version, partition info, rollup metrics, debug_logging state |
-| `ash.take_sample()` | Take one sample manually (called automatically by the scheduler) |
-| `ash.rotate()` | Rotate sample partitions (called automatically, or manually for external schedulers). Runs pre-truncation rollup to prevent data loss |
-| `ash.rebuild_partitions(N, 'yes')` | Change partition count (3–32). **Destructive** — all raw sample data is lost; requires `'yes'` confirmation token. Rollup tables survive. Call `ash.start()` after to resume |
-| `ash.rollup_minute([batch])` | Aggregate raw samples into per-minute rollups. Watermark-based with catch-up. Default batch: 60 minutes |
-| `ash.rollup_hour()` | Aggregate minute rollups into hourly rollups. Watermark-based |
-| `ash.rollup_cleanup()` | Delete expired rollup rows per retention config |
-| `ash.set_debug_logging([bool])` | Enable/disable per-session RAISE LOG in `take_sample()` for diagnostics. Call with no argument to check current state |
-| `ash.uninstall('yes')` | Drop the ash schema and remove pg_cron jobs |
+| `ash.start(interval)` | Start sampling (default: `'1 second'`). Uses pg_cron if available, otherwise prints external scheduling instructions. Also schedules rollup jobs. **Admin-only** |
+| `ash.stop()` | Stop sampling and rollups (removes pg_cron jobs, sets `sampling_enabled = false`). **Admin-only** |
+| `ash.status()` | Sampling status, version, partition info, rollup metrics, debug_logging state. Reader-safe |
+| `ash.take_sample()` | Take one sample manually (called automatically by the scheduler). Writes to raw sample/query-map partitions and updates counters. **Admin-only** |
+| `ash.rotate()` | Rotate sample partitions (called automatically, or manually for external schedulers). Runs pre-truncation rollup, then truncates the retired raw sample/query-map slot. **Admin-only** |
+| `ash.rebuild_partitions(N, 'yes')` | Change partition count (3–32). **Admin-only and destructive** — all raw sample and query-map partition data is lost; requires the exact `'yes'` confirmation token. Rollup tables survive. Call `ash.start()` after to resume |
+| `ash.rollup_minute([batch])` | Aggregate raw samples into per-minute rollups. Watermark-based with catch-up. Default batch: 60 minutes. **Admin-only** |
+| `ash.rollup_hour()` | Aggregate minute rollups into hourly rollups. Watermark-based. **Admin-only** |
+| `ash.rollup_cleanup()` | Delete expired rollup rows per retention config. **Admin-only** |
+| `ash.set_debug_logging([bool])` | Enable/disable per-session RAISE LOG in `take_sample()` for diagnostics. Call with no argument to check current state. **Admin-only** |
+| `ash.grant_reader(role)` / `ash.revoke_reader(role)` | Grant/revoke the minimum monitoring-reader privilege bundle. **Admin-only** |
+| `ash.uninstall('yes')` | Drop the `ash` schema and remove pg_cron jobs. **Admin-only and destructive**; requires the exact `'yes'` confirmation token |
 
 ### Relative time (last N hours)
 
@@ -902,7 +903,7 @@ Don't forget to also schedule rotation and rollups:
 
 ## Privileges
 
-pg_ash installs with a locked-down privilege model: admin functions (`ash.start()`, `ash.stop()`, `ash.rotate()`, `ash.take_sample()`, `ash.set_debug_logging()`, `ash.uninstall()`) are restricted to the schema owner, and EXECUTE on all reader functions plus SELECT on reader tables (`ash.sample`, `ash.query_map_all`, `ash.config`, `ash.wait_event_map`, and per-slot partitions) is revoked from `PUBLIC`. The installing role retains full access.
+pg_ash installs with a locked-down privilege model: admin functions (`ash.start()`, `ash.stop()`, `ash.rotate()`, `ash.take_sample()`, `ash.set_debug_logging()`, `ash.rebuild_partitions()`, `ash.rollup_minute()`, `ash.rollup_hour()`, `ash.rollup_cleanup()`, `ash.grant_reader()`, `ash.revoke_reader()`, `ash.uninstall()`, and internal maintenance helpers) are restricted to the schema owner, and `EXECUTE` on reader functions plus `SELECT` on reader tables (`ash.sample`, `ash.query_map_all`, `ash.config`, `ash.wait_event_map`, rollup tables, and per-slot partitions) is revoked from `PUBLIC`. The installing role retains full access.
 
 Grant access to a monitoring or read-only role with the convenience helpers:
 
@@ -925,23 +926,30 @@ quote the role name, and emit a `RAISE NOTICE` summarizing what changed.
 
 **Note on pg_cron visibility:** `ash.grant_reader()` does **not** grant `USAGE ON SCHEMA cron`, since pg_cron is not an `ash` object. When pg_cron is loaded but the monitoring role lacks USAGE on schema `cron`, `ash.status()` emits a single fallback row of the form `cron_jobs = '<no cron.job access; grant USAGE ON SCHEMA cron TO <role>>'` instead of per-job `cron_job_*` rows. To surface real cron job details, either run `grant usage on schema cron to <role>` (and `grant select on cron.job to <role>`) once, or simply ignore the row.
 
-If you prefer manual control, the equivalent explicit grants are:
+Prefer `ash.grant_reader()` for full monitoring access. If you need manual control, grant only the specific readers and tables the role actually needs — do **not** use blanket `EXECUTE` grants on the whole `ash` schema, because that can include owner-only maintenance helpers now or after future upgrades.
+
+Minimal example for a dashboard that only calls `ash.status()` and `ash.top_waits()`:
 
 ```sql
--- allow a monitoring role to call the readers
 grant usage on schema ash to my_monitor_role;
-grant execute on function ash.top_waits(interval, int, int)           to my_monitor_role;
-grant execute on function ash.top_queries(interval, int)              to my_monitor_role;
-grant execute on function ash.top_queries_with_text(interval, int)    to my_monitor_role;
-grant execute on function ash.samples(interval, int)                  to my_monitor_role;
-grant execute on function ash.status()                                to my_monitor_role;
+grant execute on function ash.status() to my_monitor_role;
+grant execute on function ash.top_waits(interval, int, int, boolean) to my_monitor_role;
 
--- or grant all reader functions at once
-grant execute on all functions in schema ash to my_monitor_role;
-
--- grant direct read on raw tables for ad-hoc SQL (optional)
-grant select on all tables in schema ash to my_monitor_role;
+grant select on table
+  ash.config,
+  ash.sample,
+  ash.sample_0,
+  ash.sample_1,
+  ash.sample_2,
+  ash.wait_event_map,
+  ash.query_map_all,
+  ash.query_map_0,
+  ash.query_map_1,
+  ash.query_map_2
+  to my_monitor_role;
 ```
+
+For all public readers, use `select ash.grant_reader('my_monitor_role');`; it computes the current safe reader set and deliberately excludes admin/destructive functions.
 
 ### pg_stat_statements in a non-default schema
 
@@ -960,10 +968,11 @@ select ash._apply_pgss_search_path();
 - **24-hour raw sample queries are slow** (~6s for full-day scan) — use rollup reader functions (`ash.minute_waits`, `ash.hourly_queries`, `ash.daily_peak_backends`) for queries over long time ranges.
 - **JIT protection built in** — all reader functions use `SET jit = off` to prevent JIT compilation overhead (which can be 10-750x slower depending on Postgres version and dataset size). No global configuration needed.
 - **Single-database install** — pg_ash installs in one database and samples all databases from there. Per-database filtering works via the `datid` column.
-- **query_map hard cap at 50k entries** — on Postgres 14-15, volatile SQL comments (e.g., `marginalia`, `sqlcommenter` with session IDs or timestamps) produce unique `query_id` values that are not normalized. This can flood the query_map partitions. A hard cap of 50,000 entries per partition prevents unbounded growth — queries beyond the cap are tracked as "unknown." PG16+ normalizes comments, so this is rarely hit. Check `query_map_count` in `ash.status()` to monitor.
+- **query_map hard cap at 50k entries per slot** — on Postgres 14-15, volatile SQL comments (e.g., `marginalia`, `sqlcommenter` with session IDs or timestamps) produce unique `query_id` values that are not normalized. Each query-map partition is truncated in lockstep with its matching sample partition during `ash.rotate()`; there is no background garbage collector. The 50,000-entry per-slot cap prevents unbounded growth between rotations — queries beyond the cap are tracked as `unknown`. PG16+ normalizes comments, so this is rarely hit. Check `query_map_count` in `ash.status()` to monitor.
 - **Parallel query workers counted individually** — parallel workers share the same `query_id` as the leader but are counted as separate backends. This inflates the apparent "weight" of parallel queries in `top_queries()`. `leader_pid` grouping is not yet implemented.
 - **WAL overhead** — 1-second sampling generates ~29 KiB WAL per sample (~2.4 GiB/day), dominated by `full_page_writes`. This is significant for WAL-sensitive replication setups. Consider 5-second or 10-second sampling intervals (`ash.start('5 seconds')`) if WAL volume is a concern. The overhead scales linearly with sampling frequency.
 - **Epoch overflow horizon (~2094)** — `sample_ts` is stored as `int4` seconds since 2026-01-01 UTC and `int4` is exhausted around 2094-01-19. Past that point, the `::int4` cast in `ash.take_sample()` raises `ERROR: integer out of range` and sampling hard-fails (it does NOT silently wrap). `ash.status()` exposes `epoch_seconds_remaining` so operators can plan a `bigint` migration of the column well before the horizon. See issue [#37](https://github.com/NikolayS/pg_ash/issues/37).
+- **Advisory-lock squat DoS** — pg_ash coordination locks use deterministic advisory-lock keys. A role that can call Postgres advisory-lock builtins can intentionally hold the same keys and stall sampling, rotation, rollups, or partition rebuilds for the duration of its transaction. See [SECURITY.md](SECURITY.md#advisory-lock-squat-dos) for mitigation guidance.
 
 ## License
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,8 @@
 # pg_ash 1.4 release notes
 
-Upgrade from 1.3: `\i sql/ash-1.3-to-1.4.sql`. Fresh install or upgrade from any version: `\i sql/ash-install.sql`. The upgrade script is idempotent and safe to re-run.
+38 commits since v1.3. Upgrade from 1.3: `\i sql/ash-1.3-to-1.4.sql`. Fresh install or upgrade from any version: `\i sql/ash-install.sql`. The upgrade script is idempotent and safe to re-run.
+
+Reference style: bare issue refs are written as `issue #N`; implementation PR refs are written as `PR #N` and linked where a separate PR exists. Consolidation happened in [PR #76](https://github.com/NikolayS/pg_ash/pull/76).
 
 ## Breaking changes
 
@@ -16,7 +18,7 @@ select ash.rebuild_partitions(9);
 select ash.rebuild_partitions(9, 'yes');
 ```
 
-Calling `ash.rebuild_partitions(N)` without the `'yes'` token raises an error and changes nothing — `sampling_enabled`, pg_cron jobs, and partition tables are all left untouched. The argument-validation runs before any destructive action. (#53)
+Calling `ash.rebuild_partitions(N)` without the `'yes'` token raises an error and changes nothing — `sampling_enabled`, pg_cron jobs, and partition tables are all left untouched. The argument-validation runs before any destructive action. (issue #53; [PR #59](https://github.com/NikolayS/pg_ash/pull/59))
 
 ## What's new
 
@@ -38,11 +40,11 @@ New rollup readers expose the data: `ash.minute_waits`, `ash.minute_waits_at`, `
 
 ### Privilege hardening (REVOKE from PUBLIC)
 
-Every reader function gets a `SET search_path = pg_catalog, ash, public[, <pgss_schema>]` guard that resists shadow attacks via session search_path. Every `ash.*` function has `EXECUTE` revoked from `PUBLIC`; every reader table has `SELECT` revoked. Helpers `ash._pgss_schema()` and `ash._apply_pgss_search_path()` detect the schema where `pg_stat_statements` lives and fold it into the search_path of pgss-aware readers. Hardcoded utilities (`ash.epoch()`, `ash.ts_from_timestamptz()`, `ash.ts_to_timestamptz()`) are re-granted to `PUBLIC` since they don't access sample data. (#45)
+Every reader function gets a `SET search_path = pg_catalog, ash, public[, <pgss_schema>]` guard that resists shadow attacks via session search_path. Every `ash.*` function has `EXECUTE` revoked from `PUBLIC`; every reader table has `SELECT` revoked. Helpers `ash._pgss_schema()` and `ash._apply_pgss_search_path()` detect the schema where `pg_stat_statements` lives and fold it into the search_path of pgss-aware readers. Hardcoded utilities (`ash.epoch()`, `ash.ts_from_timestamptz()`, `ash.ts_to_timestamptz()`) are re-granted to `PUBLIC` since they don't access sample data. ([PR #45](https://github.com/NikolayS/pg_ash/pull/45))
 
 #### Privilege provisioning helpers
 
-`ash.grant_reader(role)` and `ash.revoke_reader(role)` provision a monitoring role (Grafana, Datadog, etc.) with the minimum privileges to call every public reader. Owner-only, idempotent, symmetric undo. (#52)
+`ash.grant_reader(role)` and `ash.revoke_reader(role)` provision a monitoring role (Grafana, Datadog, etc.) with the minimum privileges to call every public reader. Owner-only, idempotent, symmetric undo. (issue #52; [PR #60](https://github.com/NikolayS/pg_ash/pull/60))
 
 ```sql
 create role grafana login;
@@ -51,30 +53,30 @@ select ash.grant_reader('grafana');
 select ash.revoke_reader('grafana');
 ```
 
-The admin function set is centralized in `ash._admin_funcs()` — a single source of truth for the REVOKE-from-PUBLIC hardening block and the grant/revoke helpers. (#67)
+The admin function set is centralized in `ash._admin_funcs()` — a single source of truth for the REVOKE-from-PUBLIC hardening block and the grant/revoke helpers. (issue #67; [PR #71](https://github.com/NikolayS/pg_ash/pull/71))
 
 > **Note:** After `ash.rebuild_partitions(N, 'yes')`, previously-granted reader roles lose access to the new partition tables. Re-run `ash.grant_reader(...)` for each monitoring role.
 
 ### Decoded-sample convenience overloads
 
-`ash.decode_sample(p_sample_ts int4)` and `ash.decode_sample_at(p_ts timestamptz)` decode every row at a given timestamp without requiring the caller to fetch the packed `data` array first. The original `decode_sample(integer[], smallint)` is unchanged. (#54)
+`ash.decode_sample(p_sample_ts int4)` and `ash.decode_sample_at(p_ts timestamptz)` decode every row at a given timestamp without requiring the caller to fetch the packed `data` array first. The original `decode_sample(integer[], smallint)` is unchanged. (issue #54; [PR #58](https://github.com/NikolayS/pg_ash/pull/58))
 
 ### NOTICE on out-of-window queries (relative AND absolute)
 
 When the requested time range falls outside the retained window (older than `2 * rotation_period`, or in the future), readers emit a `NOTICE` and return empty:
 
 - Relative-interval readers (`top_waits`, `top_queries`, etc.) — via `ash._active_slots_for(p_interval)`
-- Absolute-time `_at` readers (`top_waits_at`, `samples_at`, etc.) — via the new `ash._active_slots_for_at(p_start, p_end)` helper, mirroring the relative-interval behavior. (#69)
+- Absolute-time `_at` readers (`top_waits_at`, `samples_at`, etc.) — via the new `ash._active_slots_for_at(p_start, p_end)` helper, mirroring the relative-interval behavior. (issue #69; [PR #72](https://github.com/NikolayS/pg_ash/pull/72))
 
 ### New observability counters
 
 Three new bigint columns on `ash.config`, all surfaced by `ash.status()`:
 
-- `missed_samples` — bumped when `take_sample()` catches `query_canceled` (statement_timeout or pg_cancel_backend). The sampler emits a `WARNING` and returns `-1` so callers can observe the miss. (#27, #28)
+- `missed_samples` — bumped when `take_sample()` catches `query_canceled` (statement_timeout or pg_cancel_backend). The sampler emits a `WARNING` and returns `-1` so callers can observe the miss. (issues #27 and #28; [PR #41](https://github.com/NikolayS/pg_ash/pull/41))
 - `insert_errors` — bumped when `take_sample()`'s inner `EXCEPTION WHEN OTHERS` swallows a non-cancel insert error instead of silently dropping data. (M-BUG-4)
 - `register_wait_cap_hits` — bumped when `_register_wait` skips a new `(state, type, event)` because `wait_event_map` has hit its 32 000-row cap. Counter reveals silently-dropped wait registrations. (M-BUG-6 / H-SEC-3)
 
-`status()` also reports `epoch_seconds_remaining` and the year-2094 horizon when `sample_ts` (int4 epoch offset) overflows — sampling hard-fails with `integer out of range` past that point, NOT silently wraps. (#37)
+`status()` also reports `epoch_seconds_remaining` and the year-2094 horizon when `sample_ts` (int4 epoch offset) overflows — sampling hard-fails with `integer out of range` past that point, NOT silently wraps. (issue #37)
 
 ### Misc
 
@@ -83,23 +85,24 @@ Three new bigint columns on `ash.config`, all surfaced by `ash.status()`:
 - `start()` validates the interval shape before branching on pg_cron availability, re-syncs `cron.job.schedule` on re-invocation, and defends against malformed `pg_cron` extversion strings (H-BUG-1, H-BUG-2, M-BUG-8)
 - Pre-truncation rollup in `rotate()` so the slot we're about to discard contributes to `rollup_1m` first
 - Advisory lock protocol around `take_sample()` ↔ `rotate()` to prevent overlapping samples landing in a slot mid-rotation
+- Documented the advisory-lock squat DoS limitation and mitigation in [SECURITY.md](SECURITY.md#advisory-lock-squat-dos)
 
 ## Fixes
 
-- **No more `integer out of range` on absurd reader inputs.** Both the relative-interval readers (`top_waits('1000 years')`, etc.) and the absolute-timestamp `_at` readers (`top_waits_at('1000-01-01', …)`, etc.) now return empty rows cleanly via clamps in the readers and in `ts_from_timestamptz`. (#51, #63)
-- **`sample_data_check` constraint aligned across upgrade paths.** Installs upgraded from 1.0 had a looser `array_length(data, 1) >= 2` check that 1.1 silently failed to tighten because of `create table if not exists`. An idempotent DO block in install.sql now drops + re-adds the `>= 3` form. (#49)
-- **`ash.status()` no longer errors for non-superuser monitoring roles when pg_cron is loaded.** A nested `EXCEPTION WHEN insufficient_privilege` substitutes a fallback row pointing at the missing `GRANT USAGE ON SCHEMA cron`. (#61)
+- **No more `integer out of range` on absurd reader inputs.** Both the relative-interval readers (`top_waits('1000 years')`, etc.) and the absolute-timestamp `_at` readers (`top_waits_at('1000-01-01', …)`, etc.) now return empty rows cleanly via clamps in the readers and in `ts_from_timestamptz`. (issues #51 and #63; [PR #57](https://github.com/NikolayS/pg_ash/pull/57), [PR #65](https://github.com/NikolayS/pg_ash/pull/65))
+- **`sample_data_check` constraint aligned across upgrade paths.** Installs upgraded from 1.0 had a looser `array_length(data, 1) >= 2` check that 1.1 silently failed to tighten because of `create table if not exists`. An idempotent DO block in install.sql now drops + re-adds the `>= 3` form. (issue #49; [PR #56](https://github.com/NikolayS/pg_ash/pull/56))
+- **`ash.status()` no longer errors for non-superuser monitoring roles when pg_cron is loaded.** A nested `EXCEPTION WHEN insufficient_privilege` substitutes a fallback row pointing at the missing `GRANT USAGE ON SCHEMA cron`. (issue #61; [PR #62](https://github.com/NikolayS/pg_ash/pull/62))
 
 ## CI / infra
 
-- End-to-end pg_cron firing test passes on every PG 14–18 cron-enabled job. Provisions a `root` PG role + database to satisfy peer auth in the GHA service container; asserts via `ash.sample` row growth with a real `pg_sleep` workload. (#46)
-- Schema-equivalence CI now diffs `pg_constraint` between fresh-install and chain-upgrade snapshots — catches the class of divergence behind #49. (#66)
-- **Hot-path perf** improvements in `query_waits` / `query_waits_at` (window-based dedup via `named_hits` CTE), `rotate()` (single-statement `truncate ash.sample_N, ash.query_map_N restart identity`), and the `_register_wait` cap probe (`offset 49999 limit 1` replacing stale `pg_class.reltuples`). (#42)
-- **Supply-chain hardening** for CI: third-party actions pinned to 40-char commit SHAs and least-privilege `permissions:` blocks. (#40)
+- End-to-end pg_cron firing test passes on every PG 14–18 cron-enabled job. Provisions a `root` PG role + database to satisfy peer auth in the GHA service container; asserts via `ash.sample` row growth with a real `pg_sleep` workload. (issue #46; [PR #73](https://github.com/NikolayS/pg_ash/pull/73))
+- Schema-equivalence CI now diffs `pg_constraint` between fresh-install and chain-upgrade snapshots — catches the class of divergence behind issue #49. (issue #66; [PR #70](https://github.com/NikolayS/pg_ash/pull/70))
+- **Hot-path perf** improvements in `query_waits` / `query_waits_at` (window-based dedup via `named_hits` CTE), `rotate()` (single-statement `truncate ash.sample_N, ash.query_map_N restart identity`), and the `_register_wait` cap probe (`offset 49999 limit 1` replacing stale `pg_class.reltuples`). ([PR #42](https://github.com/NikolayS/pg_ash/pull/42))
+- **Supply-chain hardening** for CI: third-party actions pinned to 40-char commit SHAs and least-privilege `permissions:` blocks. ([PR #40](https://github.com/NikolayS/pg_ash/pull/40))
 
 ## Demo
 
-README's hero visual is a [short animated GIF](demos/) of pg_ash investigating a row-lock spike on Postgres 18. Reproducible via `make -C demos record`. Human-paced typing, colored bar charts, vanilla psql in tmux. (PRs #64, #68)
+README's hero visual is a [short animated GIF](demos/) of pg_ash investigating a row-lock spike on Postgres 18. Reproducible via `make -C demos record`. Human-paced typing, colored bar charts, vanilla psql in tmux. ([PR #64](https://github.com/NikolayS/pg_ash/pull/64), [PR #68](https://github.com/NikolayS/pg_ash/pull/68))
 
 ## Functions
 

--- a/docs/COLOR_SCHEME.md
+++ b/docs/COLOR_SCHEME.md
@@ -89,7 +89,7 @@ Functions that support color:
 
 - `top_waits()` / `top_waits_at()` — bar column
 - `query_waits()` / `query_waits_at()` — bar column
-- `waits_by_type()` / `waits_by_type_at()` — bar column
+- `top_by_type()` / `top_by_type_at()` — bar column
 - `timeline_chart()` / `timeline_chart_at()` — chart column
 
 ## Comparison with other tools


### PR DESCRIPTION
## Summary

Release-gate docs/test fixes for pg_ash v1.4:

- update README privilege guidance to prefer `ash.grant_reader()` and remove blanket schema-wide EXECUTE/SELECT advice
- document the complete/current admin/destructive function set, including rollups, rebuild, grant/revoke helpers, and uninstall confirmation
- clarify query-map retention: per-slot cap + lockstep truncation on rotation, no stale GC wording
- fix stale `waits_by_type()` names in `docs/COLOR_SCHEME.md`
- improve v1.4 release note references with issue-vs-PR wording, PR links, commit count since v1.3, and SECURITY.md advisory-lock DoS mention
- add a lightweight docs-lint CI job to catch the stale privilege/name patterns that triggered this review

## Checks

- `git diff --check`
- docs-lint shell guards locally
- local Postgres smoke: fresh install into temporary DB, `ash.grant_reader()` / `ash.revoke_reader()` privilege assertions

No tag, release, or merge in this PR.
