### PR TITLE
Critical bug: prevent rollup/rotation raw sample loss

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2962,6 +2962,198 @@ jobs:
           $$;
           EOF
 
+      - name: "Critical bug #81: rollup and rotation must not lose raw samples"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          set -euo pipefail
+
+          psql_base=(psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1)
+
+          reset_issue_81_state() {
+            "${psql_base[@]}" << 'SQL'
+            select ash.stop();
+            truncate ash.sample;
+            truncate ash.rollup_1m;
+            truncate ash.rollup_1h;
+            truncate ash.wait_event_map restart identity cascade;
+            truncate ash.query_map_0 restart identity;
+            truncate ash.query_map_1 restart identity;
+            truncate ash.query_map_2 restart identity;
+            update ash.config
+            set current_slot = 0,
+              rotated_at = now() - interval '2 days',
+              rotation_period = interval '1 day',
+              last_rollup_1m_ts = null,
+              last_rollup_1h_ts = null,
+              sampling_enabled = true
+            where singleton;
+            select ash._register_wait('active', 'Issue81', 'RotateLoss');
+SQL
+          }
+
+          seed_endangered_sample() {
+            "${psql_base[@]}" << 'SQL'
+            insert into ash.sample (
+              sample_ts, datid, active_count, data, slot
+            )
+            values (
+              ash.ts_from_timestamptz(date_trunc('minute', now()) - interval '2 minutes'),
+              0::oid,
+              1::smallint,
+              array[-1,1,0]::integer[],
+              2::smallint
+            );
+            select count(*) as seeded_rows from ash.sample_2;
+SQL
+          }
+
+          assert_raw_sample_survived() {
+            local context="$1"
+            local raw_rows
+            local rollup_rows
+            local current_slot
+
+            raw_rows="$("${psql_base[@]}" -tAc "select count(*) from ash.sample_2")"
+            rollup_rows="$("${psql_base[@]}" -tAc "select count(*) from ash.rollup_1m")"
+            current_slot="$("${psql_base[@]}" -tAc "select current_slot from ash.config where singleton")"
+
+            if [ "$raw_rows" != "1" ]; then
+              echo "::error::$context: endangered raw sample was truncated (sample_2 rows=$raw_rows, rollup_1m rows=$rollup_rows, current_slot=$current_slot)" >&2
+              exit 1
+            fi
+            if [ "$current_slot" != "0" ]; then
+              echo "::error::$context: rotate advanced current_slot despite failed pre-rollup (current_slot=$current_slot)" >&2
+              exit 1
+            fi
+          }
+
+          wait_until_sql_true() {
+            local description="$1"
+            local sql="$2"
+            local value
+
+            for _ in {1..100}; do
+              value="$("${psql_base[@]}" -tAc "$sql")"
+              if [ "$value" = "t" ]; then
+                return 0
+              fi
+              sleep 0.1
+            done
+
+            echo "::error::timed out waiting for $description" >&2
+            exit 1
+          }
+
+          echo "=== #81A: rollup_minute must not advance while sampler lock is held ==="
+          reset_issue_81_state
+          "${psql_base[@]}" << 'SQL'
+          insert into ash.sample (
+            sample_ts, datid, active_count, data, slot
+          )
+          values (
+            ash.ts_from_timestamptz(date_trunc('minute', now()) - interval '2 minutes'),
+            0::oid,
+            1::smallint,
+            array[-1,1,0]::integer[],
+            0::smallint
+          );
+SQL
+          "${psql_base[@]}" -c "
+            begin;
+            select pg_advisory_xact_lock(
+              hashtext('pg_ash')::int4,
+              hashtext('pg_ash_sampler')::int4
+            );
+            select pg_sleep(5);
+            commit;
+          " &
+          sampler_lock_pid=$!
+          wait_until_sql_true "sampler advisory lock" "
+            select exists (
+              select 1
+              from pg_locks
+              where locktype = 'advisory'
+                and classid = hashtext('pg_ash')::int4::oid
+                and objid = hashtext('pg_ash_sampler')::int4::oid
+                and granted
+                and pid <> pg_backend_pid()
+            )
+          "
+          rollup_result="$("${psql_base[@]}" -tAc "select ash.rollup_minute(5)")"
+          watermark="$("${psql_base[@]}" -tAc "select coalesce(last_rollup_1m_ts::text, '') from ash.config where singleton")"
+          rollup_rows="$("${psql_base[@]}" -tAc "select count(*) from ash.rollup_1m")"
+          wait "$sampler_lock_pid"
+
+          if [ "$rollup_result" != "0" ] || [ -n "$watermark" ] || [ "$rollup_rows" != "0" ]; then
+            echo "::error::rollup_minute advanced while sampler lock was held (result=$rollup_result, watermark=$watermark, rows=$rollup_rows)" >&2
+            exit 1
+          fi
+
+          rollup_result="$("${psql_base[@]}" -tAc "select ash.rollup_minute(5)")"
+          rollup_rows="$("${psql_base[@]}" -tAc "select count(*) from ash.rollup_1m")"
+          if [ "$rollup_result" = "0" ] || [ "$rollup_rows" = "0" ]; then
+            echo "::error::rollup_minute did not process data after sampler lock released (result=$rollup_result, rows=$rollup_rows)" >&2
+            exit 1
+          fi
+
+          echo "=== #81B: rotate must not truncate when rollup advisory lock is busy ==="
+          reset_issue_81_state
+          seed_endangered_sample
+          "${psql_base[@]}" -c "
+            begin;
+            select pg_advisory_xact_lock(
+              hashtext('pg_ash')::int4,
+              hashtext('pg_ash_rollup')::int4
+            );
+            select pg_sleep(5);
+            commit;
+          " &
+          rollup_lock_pid=$!
+          wait_until_sql_true "rollup advisory lock" "
+            select exists (
+              select 1
+              from pg_locks
+              where locktype = 'advisory'
+                and classid = hashtext('pg_ash')::int4::oid
+                and objid = hashtext('pg_ash_rollup')::int4::oid
+                and granted
+                and pid <> pg_backend_pid()
+            )
+          "
+          rotate_result="$("${psql_base[@]}" -tAc "select ash.rotate()")"
+          wait "$rollup_lock_pid"
+          echo "rotate result with busy rollup lock: $rotate_result"
+          assert_raw_sample_survived "busy rollup advisory lock"
+
+          echo "=== #81C: rotate must not truncate when pre-rollup hits lock_timeout ==="
+          reset_issue_81_state
+          seed_endangered_sample
+          "${psql_base[@]}" -c "
+            begin;
+            lock table ash.rollup_1m in access exclusive mode;
+            select pg_sleep(5);
+            commit;
+          " &
+          rollup_table_lock_pid=$!
+          wait_until_sql_true "rollup_1m AccessExclusiveLock" "
+            select exists (
+              select 1
+              from pg_locks
+              where locktype = 'relation'
+                and relation = 'ash.rollup_1m'::regclass
+                and mode = 'AccessExclusiveLock'
+                and granted
+                and pid <> pg_backend_pid()
+            )
+          "
+          rotate_result="$("${psql_base[@]}" -tAc "select ash.rotate()")"
+          wait "$rollup_table_lock_pid"
+          echo "rotate result with rollup_1m lock_timeout: $rotate_result"
+          assert_raw_sample_survived "rollup_1m lock_timeout"
+
+          echo "Critical bug #81 regression tests PASSED"
+
       - name: "Test v1.4: rollup reader functions"
         env:
           PGPASSWORD: postgres
@@ -4119,4 +4311,3 @@ jobs:
           CRON: ${{ matrix.cron }}
         run: |
           echo "All tests passed for PostgreSQL $PG_MAJOR (pg_cron=$CRON)"
-

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -918,6 +918,9 @@ declare
   v_rotation_period interval;
   v_rotated_at timestamptz;
   v_rotation_minutes int;
+  v_rollup_result int;
+  v_endangered_rows bigint;
+  v_unrolled_groups bigint;
 begin
   -- Advisory lock prevents concurrent rotation from pg_cron overlap.
   -- Xact-level: auto-releases on commit/rollback — no leak risk with pg_cron
@@ -944,28 +947,76 @@ begin
       return 'skipped: rotated too recently at ' || v_rotated_at::text;
     end if;
 
-    -- Set lock timeout to avoid blocking on long-running queries
-    set local lock_timeout = '2s';
-
-    -- Pre-truncation rollup: process endangered minutes before they are lost.
-    -- Called before config update to avoid locking contention with take_sample().
-    -- Rollup is idempotent (upsert), so double-processing is safe.
-    v_rotation_minutes := extract(epoch from v_rotation_period)::int / 60;
-
-    begin
-      perform ash.rollup_minute(v_rotation_minutes);
-    exception when undefined_function then
-      -- rollup_minute() not yet installed (upgrade in progress), skip
-      null;
-    when others then
-      raise warning 'ash.rotate: rollup_minute failed [%]: %', sqlstate, sqlerrm;
-    end;
-
     -- Calculate new slot dynamically (0 -> 1 -> ... -> N-1 -> 0)
     v_new_slot := (v_old_slot + 1) % v_num_partitions;
 
     -- The partition to truncate is the one after the new slot
     v_truncate_slot := (v_new_slot + 1) % v_num_partitions;
+
+    -- Set lock timeout to avoid blocking on long-running queries
+    set local lock_timeout = '2s';
+
+    -- Pre-truncation rollup: process endangered minutes before they are lost.
+    -- This is no longer best-effort: if the endangered raw slot has rows and
+    -- we cannot prove they are represented in rollup_1m, skip rotation rather
+    -- than deleting the only copy of the samples (#81).
+    execute format('select count(*) from ash.sample_%s', v_truncate_slot)
+    into v_endangered_rows;
+
+    if v_endangered_rows > 0 then
+      if not pg_try_advisory_xact_lock(
+           hashtext('pg_ash')::int4,
+           hashtext('pg_ash_rollup')::int4
+         ) then
+        return format(
+          'failed: pre-truncation rollup busy; slot %s not truncated',
+          v_truncate_slot
+        );
+      end if;
+
+      v_rotation_minutes := greatest(extract(epoch from v_rotation_period)::int / 60, 1);
+
+      begin
+        select ash.rollup_minute(v_rotation_minutes) into v_rollup_result;
+      exception when undefined_function then
+        return format(
+          'failed: rollup_minute() unavailable; slot %s not truncated',
+          v_truncate_slot
+        );
+      when others then
+        raise warning 'ash.rotate: rollup_minute failed [%]: %', sqlstate, sqlerrm;
+        return format(
+          'failed: pre-truncation rollup failed [%s]; slot %s not truncated',
+          sqlstate,
+          v_truncate_slot
+        );
+      end;
+
+      execute format(
+        'with raw as ('
+        '  select (sample_ts / 60) * 60 as ts, datid,'
+        '         count(distinct sample_ts)::smallint as samples,'
+        '         max(active_count)::smallint as peak_backends'
+        '  from ash.sample_%1$s'
+        '  group by 1, 2'
+        ') '
+        'select count(*) '
+        'from raw '
+        'left join ash.rollup_1m r on r.ts = raw.ts and r.datid = raw.datid '
+        'where r.ts is null '
+        '   or r.samples < raw.samples '
+        '   or r.peak_backends < raw.peak_backends',
+        v_truncate_slot
+      ) into v_unrolled_groups;
+
+      if v_unrolled_groups > 0 then
+        return format(
+          'failed: pre-truncation rollup incomplete for %s group(s) in slot %s; slot not truncated',
+          v_unrolled_groups,
+          v_truncate_slot
+        );
+      end if;
+    end if;
 
     -- Advance current_slot first (before truncate)
     update ash.config
@@ -2174,10 +2225,10 @@ declare
   v_count int;
   v_min_backend_seconds smallint;
   v_has_later_data bool;
+  v_sampler_lock_acquired bool := false;
 begin
-  -- Acquire rollup lock (xact-level). Distinct from the sampler lock so a
-  -- long catch-up doesn't bump skipped_samples on every concurrent tick.
-  -- rebuild_partitions's drain poll waits on this objid.
+  -- Acquire rollup lock (xact-level). Rollup operations serialize with each
+  -- other, and rebuild_partitions's drain poll waits on this objid.
   if not pg_try_advisory_xact_lock(
        hashtext('pg_ash')::int4,
        hashtext('pg_ash_rollup')::int4
@@ -2191,8 +2242,39 @@ begin
   into v_last_ts, v_min_backend_seconds
   from ash.config where singleton;
 
-  -- Current minute boundary (only process *complete* minutes)
-  v_now_minute_ts := ash.ts_from_timestamptz(date_trunc('minute', now()));
+  -- Drain in-flight samplers before choosing the "complete minute" boundary.
+  -- take_sample() gets sample_ts from transaction-start now(), then may block
+  -- before INSERT. Without this drain, rollup_minute() can advance the
+  -- watermark while a sampler later commits an old-minute row, permanently
+  -- excluding it from rollups (#81).
+  if not pg_try_advisory_lock(
+       hashtext('pg_ash')::int4,
+       hashtext('pg_ash_sampler')::int4
+     ) then
+    return 0;
+  end if;
+  v_sampler_lock_acquired := true;
+
+  begin
+    -- Current minute boundary (only process *complete* minutes). This is
+    -- computed after the sampler drain, so future samplers cannot commit rows
+    -- with sample_ts older than this boundary.
+    v_now_minute_ts := ash.ts_from_timestamptz(date_trunc('minute', now()));
+
+    perform pg_advisory_unlock(
+      hashtext('pg_ash')::int4,
+      hashtext('pg_ash_sampler')::int4
+    );
+    v_sampler_lock_acquired := false;
+  exception when others then
+    if v_sampler_lock_acquired then
+      perform pg_advisory_unlock(
+        hashtext('pg_ash')::int4,
+        hashtext('pg_ash_sampler')::int4
+      );
+    end if;
+    raise;
+  end;
 
   -- Initialize watermark if NULL (first run after install or upgrade).
   if v_last_ts is null then


### PR DESCRIPTION
Fixes #81.

## Summary

This fixes two data-loss paths around raw sample retention:

- `ash.rollup_minute()` no longer advances the minute watermark while a sampler is in flight. It briefly takes the sampler advisory lock before computing the complete-minute boundary, and returns `0` without changing the watermark if the sampler lock is busy.
- `ash.rotate()` no longer treats pre-truncation rollup as best-effort when the endangered raw slot contains rows. It aborts rotation if rollup is busy, fails, or cannot prove the endangered slot is represented in `ash.rollup_1m`.
- Adds CI regression coverage for issue #81: sampler lock held, rollup advisory lock busy, and `rollup_1m` lock timeout.

## Proof

RED on current behavior before the fix:

- With the sampler advisory lock held, `ash.rollup_minute(5)` advanced the watermark and wrote rollup rows: `result=1`, `rollup_1m rows=1`.
- With the rollup advisory lock held, `ash.rotate()` still truncated the endangered raw slot.
- With `ash.rollup_1m` locked until `lock_timeout`, `ash.rotate()` warned and still truncated the endangered raw slot.

GREEN after the fix, run locally against PostgreSQL 16 in the lab container:

- `#81A`: while sampler lock was held, `ash.rollup_minute(5)` returned `0`, `last_rollup_1m_ts` stayed NULL, and `ash.rollup_1m` stayed empty. After the lock was released, the next rollup processed the row.
- `#81B`: with rollup advisory lock busy, `ash.rotate()` returned `failed: pre-truncation rollup busy; slot 2 not truncated`; `ash.sample_2` still had the raw row and `current_slot` stayed `0`.
- `#81C`: with `ash.rollup_1m` locked, `ash.rotate()` returned `failed: pre-truncation rollup failed [55P03]; slot 2 not truncated`; `ash.sample_2` still had the raw row and `current_slot` stayed `0`.

## Local checks

- `PGPASSWORD=postgres psql -h 127.0.0.1 -p 55432 -U postgres -d ash_fix_test -v ON_ERROR_STOP=1 -f sql/ash-install.sql`
- Local issue #81 regression script matching the new CI step: passed (`GREEN`).
- `git diff --check -- .github/workflows/test.yml sql/ash-install.sql`: passed.
