### PR TITLE
Bug: make raw readers honor configurable retention

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2296,9 +2296,12 @@ jobs:
           do $$
           declare
             v_slots smallint[];
+            v_expected smallint[] := array[0,4,3,2]::smallint[];
             v_n smallint;
             v_min smallint;
             v_max smallint;
+            v_wait_id smallint;
+            v_rows int;
           begin
             -- Default num_partitions = 3.
             select num_partitions into v_n from ash.config where singleton;
@@ -2309,16 +2312,46 @@ jobs:
             select num_partitions into v_n from ash.config where singleton;
             assert v_n = 5, format('after rebuild: expected num_partitions=5, got %s', v_n);
 
-            -- Slot enumeration must stay within [0, 4]; never reference slot 5+.
-            v_slots := ash._active_slots_for('1 minute'::interval);
+            -- Slot enumeration must include every retained raw slot, not just
+            -- current+previous. With N=5 and current_slot=0, retained slots
+            -- are current plus 3 completed partitions: [0,4,3,2].
+            v_slots := ash._active_slots_for('3 days'::interval);
+            assert v_slots = v_expected,
+              format('_active_slots_for(3 days): expected %s, got %s', v_expected, v_slots);
             select min(s), max(s) into v_min, v_max from unnest(v_slots) s;
             assert v_min >= 0 and v_max <= 4,
               format('_active_slots_for slots out of [0,4] after rebuild(5): %s', v_slots);
 
-            v_slots := ash._active_slots_for_at(now() - '1 min'::interval, now());
+            v_slots := ash._active_slots_for_at(now() - '3 days'::interval, now());
+            assert v_slots = v_expected,
+              format('_active_slots_for_at(3 days): expected %s, got %s', v_expected, v_slots);
             select min(s), max(s) into v_min, v_max from unnest(v_slots) s;
             assert v_min >= 0 and v_max <= 4,
               format('_active_slots_for_at slots out of [0,4] after rebuild(5): %s', v_slots);
+
+            v_slots := ash._active_slots_for('4 days'::interval);
+            assert v_slots = array[]::smallint[],
+              format('_active_slots_for(4 days) should exceed raw retention and return {}, got %s', v_slots);
+
+            -- End-to-end reader proof: a row in the third completed retained
+            -- slot must be visible to _at readers.
+            select ash._register_wait('active', 'RetentionProof', 'OlderSlot')
+              into v_wait_id;
+
+            insert into ash.sample (sample_ts, datid, active_count, data, slot)
+            values (
+              ash.ts_from_timestamptz(now() - interval '2 days 10 minutes'),
+              0::oid,
+              1::smallint,
+              array[(-v_wait_id)::int, 1, 0]::int4[],
+              3::smallint
+            );
+
+            select count(*) into v_rows
+            from ash.samples_at(now() - interval '3 days', now(), 100)
+            where wait_event = 'RetentionProof:OlderSlot';
+            assert v_rows = 1,
+              format('samples_at should see retained slot 3 sample, got %s rows', v_rows);
 
             -- Restore N=3.
             perform ash.rebuild_partitions(3, 'yes');
@@ -4119,4 +4152,3 @@ jobs:
           CRON: ${{ matrix.cron }}
         run: |
           echo "All tests passed for PostgreSQL $PG_MAJOR (pg_cron=$CRON)"
-

--- a/sql/ash-1.3-to-1.4.sql
+++ b/sql/ash-1.3-to-1.4.sql
@@ -41,7 +41,8 @@
 --     samples / activity_summary / timeline_chart / event_queries (and
 --     pgss variants) no longer raise `integer out of range` on absurd
 --     intervals (e.g. '1000 years'). _active_slots_for() returns `{}`
---     once the interval exceeds 2 * rotation_period, so reader
+--     once the interval exceeds raw retention
+--     ((num_partitions - 2) * rotation_period), so reader
 --     `slot = any(...)` JOINs naturally yield empty — honoring the
 --     oversized-interval NOTICE's "older samples not available" promise
 --     instead of silently returning all retained data (#51).
@@ -71,8 +72,8 @@
 --     timeline_chart_at / samples_at) routes its slot filter through it,
 --     restoring NOTICE symmetry with _active_slots_for(p_interval): callers
 --     get a loud-warn when the requested range falls outside the retained
---     window (now() - 2 * rotation_period .. now()) instead of a silent
---     empty result. The three SQL-language range readers (top_waits_at,
+--     window (now() - raw_retention .. now()) instead of a silent empty
+--     result. The three SQL-language range readers (top_waits_at,
 --     wait_timeline_at, top_by_type_at) flip to plpgsql so the helper can be
 --     invoked into a local — otherwise the planner would constant-fold the
 --     time predicate and skip the helper call (and its NOTICE).

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -1666,11 +1666,11 @@ as $$
 $$;
 
 -- Helper used by reader functions that accept a user-supplied interval.
--- Returns the same array as ash._active_slots() for in-range intervals.
--- For intervals beyond 2 * rotation_period, returns an empty array so
--- reader `slot = any(...)` JOINs naturally yield zero rows — honoring
--- the NOTICE's "older samples not available" promise (and avoiding the
--- int4-epoch underflow that would otherwise raise `integer out of range`).
+-- Returns every raw slot still retained by the configured N-partition ring.
+-- For intervals beyond (num_partitions - 2) * rotation_period, returns an
+-- empty array so reader `slot = any(...)` JOINs naturally yield zero rows —
+-- honoring the NOTICE's "older samples not available" promise (and avoiding
+-- the int4-epoch underflow that would otherwise raise `integer out of range`).
 -- A single NOTICE is emitted per transaction in that case so callers get
 -- a clear signal instead of a silent empty set.
 -- Deduplication uses a transaction-scoped GUC (ash.notice_oversized) so
@@ -1690,12 +1690,15 @@ declare
   v_current_slot smallint;
   v_num_partitions smallint;
   v_rotation_period interval;
+  v_raw_retention interval;
   v_already text;
 begin
   select current_slot, num_partitions, rotation_period
     into v_current_slot, v_num_partitions, v_rotation_period
   from ash.config
   where singleton;
+
+  v_raw_retention := (v_num_partitions - 2) * v_rotation_period;
 
   -- Negative interval is meaningless and would underflow `now() - p_interval`
   -- past the int4 horizon downstream. Treat as out-of-window.
@@ -1710,46 +1713,48 @@ begin
     return array[]::smallint[];
   end if;
 
-  if p_interval is not null and p_interval > 2 * v_rotation_period then
+  if p_interval is not null and p_interval > v_raw_retention then
     -- Suppress duplicate NOTICEs within the same transaction. The GUC is
     -- set local to the current transaction and auto-resets on commit/rollback.
     v_already := current_setting('ash.notice_oversized', true);
     if v_already is null or v_already = '' then
       raise notice
-        'requested interval % exceeds 2 * rotation_period (%); only the last two partitions are retained, so older samples are not available. Shorten the interval or increase rotation_period via ash.config.',
-        p_interval, v_rotation_period;
+        'requested interval % exceeds raw retention (%); only % completed partition(s) plus the current partial partition are retained. Shorten the interval, increase rotation_period, or rebuild with more partitions.',
+        p_interval, v_raw_retention, v_num_partitions - 2;
       perform set_config('ash.notice_oversized', '1', true);
     end if;
     -- Honor the NOTICE: return no slots so reader JOINs (`slot = any(...)`)
     -- yield empty. Without this, an absurd interval like '1000 years' clamps
     -- v_min_ts to 0 and matches every retained sample, contradicting the
     -- "older samples not available" promise. Callers wanting all retained
-    -- data should pass an interval <= 2 * rotation_period.
+    -- data should pass an interval <= raw_retention.
     return array[]::smallint[];
   end if;
 
-  -- Slot enumeration must use the configured num_partitions (default 3,
-  -- configurable in [3, 32] via rebuild_partitions). Hardcoded `% 3` would
-  -- mis-enumerate on N != 3.
-  return array[
-    v_current_slot,
-    ((v_current_slot - 1 + v_num_partitions) % v_num_partitions)::smallint
-  ];
+  -- Slot enumeration must use the configured num_partitions and include every
+  -- retained raw slot, not just current+previous. Readers still filter by
+  -- sample_ts; the slot list only keeps the partition-pruning contract honest.
+  return array(
+    select ((v_current_slot - gs.i + v_num_partitions) % v_num_partitions)::smallint
+    from generate_series(0, v_num_partitions - 2) as gs(i)
+    order by gs.i
+  );
 end;
 $$;
 
 -- Absolute-range counterpart to ash._active_slots_for(interval), used by every
 -- _at reader (top_waits_at, samples_at, query_waits_at, etc.). Returns the
 -- active slot set when the requested [p_start, p_end) range overlaps what raw
--- samples retain (~2 * rotation_period back from now()), and an empty array
--- with a NOTICE when it doesn't — restoring loud-warn symmetry with the
--- relative readers (#69). Without this, _at readers silently returned 0 rows
--- on absurd inputs (year 1000, year 3000) thanks to ts_from_timestamptz()'s
--- int4 clamp (#63), which was a UX regression vs the interval path.
+-- samples retain ((num_partitions - 2) * rotation_period back from now()), and
+-- an empty array with a NOTICE when it doesn't — restoring loud-warn symmetry
+-- with the relative readers (#69). Without this, _at readers silently returned
+-- 0 rows on absurd inputs (year 1000, year 3000) thanks to
+-- ts_from_timestamptz()'s int4 clamp (#63), which was a UX regression vs the
+-- interval path.
 --
 -- Out-of-retention conditions (each emits the NOTICE and returns {}):
---   * p_end   <= now() - 2 * rotation_period   (range entirely too old)
---   * p_start >  now()                          (range entirely in the future)
+--   * p_end   <= now() - raw_retention (range entirely too old)
+--   * p_start >  now()                  (range entirely in the future)
 --
 -- Importantly, an empty range (p_start >= p_end) inside the retained window
 -- is NOT flagged — callers may legitimately ask for a zero-length window and
@@ -1779,6 +1784,7 @@ declare
   v_num_partitions  smallint;
   v_rotation_period interval;
   v_now             timestamptz := now();
+  v_raw_retention   interval;
   v_retention_start timestamptz;
   v_already         text;
 begin
@@ -1787,7 +1793,8 @@ begin
   from ash.config
   where singleton;
 
-  v_retention_start := v_now - 2 * v_rotation_period;
+  v_raw_retention := (v_num_partitions - 2) * v_rotation_period;
+  v_retention_start := v_now - v_raw_retention;
 
   -- Out-of-retention check. Skip when either bound is null (the reader's
   -- own WHERE will yield empty without us needing to NOTICE) or when the
@@ -1797,17 +1804,18 @@ begin
     v_already := current_setting('ash.notice_oversized', true);
     if v_already is null or v_already = '' then
       raise notice
-        'requested range [%, %) lies outside the retained window (now - 2 * rotation_period .. now, i.e. [%, %)); only the last two partitions are retained, so older or future samples are not available. Adjust the range or increase rotation_period via ash.config.',
-        p_start, p_end, v_retention_start, v_now;
+        'requested range [%, %) lies outside the retained window (now - raw_retention .. now, i.e. [%, %)); only % completed partition(s) plus the current partial partition are retained. Adjust the range, increase rotation_period, or rebuild with more partitions.',
+        p_start, p_end, v_retention_start, v_now, v_num_partitions - 2;
       perform set_config('ash.notice_oversized', '1', true);
     end if;
     return array[]::smallint[];
   end if;
 
-  return array[
-    v_current_slot,
-    ((v_current_slot - 1 + v_num_partitions) % v_num_partitions)::smallint
-  ];
+  return array(
+    select ((v_current_slot - gs.i + v_num_partitions) % v_num_partitions)::smallint
+    from generate_series(0, v_num_partitions - 2) as gs(i)
+    order by gs.i
+  );
 end;
 $$;
 


### PR DESCRIPTION
Fixes #83.

## Summary

Raw readers now honor the configured raw retention window after `ash.rebuild_partitions(N, 'yes')`:

- `_active_slots_for(interval)` uses `(num_partitions - 2) * rotation_period` instead of a hardcoded `2 * rotation_period` window.
- `_active_slots_for_at(start, end)` uses the same configurable retention window.
- Both helpers enumerate every retained raw slot, not just `current_slot` and previous slot.
- The v1.4 upgrade shim comments are updated to describe the corrected retention rule.

## Proof

RED on current main:

```text
current_slot    = 0
num_partitions  = 5
raw_retention   = 3 days + current partial
rotation_period = 1 day

direct_sample_3_rows = 1

NOTICE: requested interval 3 days exceeds 2 * rotation_period (1 day); only the last two partitions are retained...
slots_for_3_days    = {}
slots_for_2_days    = {0,4}
slots_for_at_3_days = {0,4}

samples_at_rows = 0
```

The raw row exists in `ash.sample_3` and is inside the documented 3-day retention window, but `samples_at()` cannot see it.

GREEN after the fix, run in the `postgres-massive-dml-lab` PostgreSQL 16 container:

- `_active_slots_for('3 days')` returns `{0,4,3,2}` after `rebuild_partitions(5, 'yes')`.
- `_active_slots_for_at(now() - interval '3 days', now())` returns `{0,4,3,2}`.
- `samples_at(now() - interval '3 days', now(), 100)` sees the row seeded in slot 3.
- `_active_slots_for('4 days')` still returns `{}` with a NOTICE because it exceeds the documented 3-day raw retention.

## Local checks

- Fresh install into scratch DB via `docker exec -i postgres-massive-dml-lab psql -U postgres -d ash_retention_test -v ON_ERROR_STOP=1 < sql/ash-install.sql`.
- Focused RED/ GREEN reproduction for issue #83.
- CI DO-block matching the updated workflow step: passed.
- `git diff --check -- .github/workflows/test.yml sql/ash-install.sql sql/ash-1.3-to-1.4.sql`: passed.
