### PR TITLE
Bug: make raw readers honor configurable retention

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2464,6 +2464,10 @@ jobs:
             v_num smallint;
             v_result text;
             v_slot smallint;
+            v_retention_slots smallint[];
+            v_expected_retention_slots smallint[] := array[0,4,3,2]::smallint[];
+            v_retention_wait_id smallint;
+            v_retention_rows int;
           begin
             -- === Confirmation token required (issue #53) ===
             -- Without 'yes': raises and leaves state untouched.
@@ -2533,6 +2537,44 @@ jobs:
             -- Verify sampling_enabled is false after rebuild (must call start())
             assert (select sampling_enabled from ash.config where singleton) = false,
               'sampling_enabled should be false after rebuild';
+
+            -- Raw readers must honor all retained partitions after rebuild.
+            -- With N=5 and current_slot=0, retained raw slots are current plus
+            -- three completed partitions: [0,4,3,2].
+            v_retention_slots := ash._active_slots_for('3 days'::interval);
+            assert v_retention_slots = v_expected_retention_slots,
+              format('_active_slots_for(3 days): expected %s, got %s',
+                     v_expected_retention_slots, v_retention_slots);
+
+            v_retention_slots := ash._active_slots_for_at(now() - interval '3 days', now());
+            assert v_retention_slots = v_expected_retention_slots,
+              format('_active_slots_for_at(3 days): expected %s, got %s',
+                     v_expected_retention_slots, v_retention_slots);
+
+            v_retention_slots := ash._active_slots_for('4 days'::interval);
+            assert v_retention_slots = array[]::smallint[],
+              format('_active_slots_for(4 days) should exceed raw retention and return {}, got %s',
+                     v_retention_slots);
+
+            select ash._register_wait('active', 'RetentionProof', 'OlderSlot')
+            into v_retention_wait_id;
+
+            insert into ash.sample (sample_ts, datid, active_count, data, slot)
+            values (
+              ash.ts_from_timestamptz(now() - interval '2 days 10 minutes'),
+              0::oid,
+              1::smallint,
+              array[(-v_retention_wait_id)::int, 1, 0]::int4[],
+              3::smallint
+            );
+
+            select count(*) into v_retention_rows
+            from ash.samples_at(now() - interval '3 days', now(), 100)
+            where wait_event = 'RetentionProof:OlderSlot';
+            assert v_retention_rows = 1,
+              format('samples_at should see retained slot 3 sample, got %s rows', v_retention_rows);
+
+            truncate ash.sample;
 
             -- === Rotate with 5 partitions ===
             update ash.config

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@ Work in progress after v1.4.
 
 - **`wait_event_map` cap enforcement fixed.** `_register_wait()` now checks the exact 32 000th dictionary row instead of trusting stale `pg_class.reltuples`, so the hard cap fires immediately after `TRUNCATE` / restore and increments `register_wait_cap_hits` as documented. (issue #90; [PR #92](https://github.com/NikolayS/pg_ash/pull/92))
 - **Raw samples are protected during rollup/rotation races.** `rollup_minute()` no longer advances its watermark while a sampler is in flight, and `rotate()` refuses to truncate an endangered raw partition unless pre-truncation rollup succeeds and covers the raw groups in that slot. (issue #81; [PR #86](https://github.com/NikolayS/pg_ash/pull/86))
+- **Raw readers honor rebuilt partition retention.** `_active_slots_for()` and `_active_slots_for_at()` now enumerate every retained raw slot after `rebuild_partitions(N, 'yes')` instead of only current plus previous slot. (issue #83; [PR #85](https://github.com/NikolayS/pg_ash/pull/85))
 
 ---
 

--- a/devel/sql/ash-install.sql
+++ b/devel/sql/ash-install.sql
@@ -1717,11 +1717,11 @@ as $$
 $$;
 
 -- Helper used by reader functions that accept a user-supplied interval.
--- Returns the same array as ash._active_slots() for in-range intervals.
--- For intervals beyond 2 * rotation_period, returns an empty array so
--- reader `slot = any(...)` JOINs naturally yield zero rows — honoring
--- the NOTICE's "older samples not available" promise (and avoiding the
--- int4-epoch underflow that would otherwise raise `integer out of range`).
+-- Returns every raw slot still retained by the configured N-partition ring.
+-- For intervals beyond (num_partitions - 2) * rotation_period, returns an
+-- empty array so reader `slot = any(...)` JOINs naturally yield zero rows —
+-- honoring the NOTICE's "older samples not available" promise (and avoiding
+-- the int4-epoch underflow that would otherwise raise `integer out of range`).
 -- A single NOTICE is emitted per transaction in that case so callers get
 -- a clear signal instead of a silent empty set.
 -- Deduplication uses a transaction-scoped GUC (ash.notice_oversized) so
@@ -1741,12 +1741,15 @@ declare
   v_current_slot smallint;
   v_num_partitions smallint;
   v_rotation_period interval;
+  v_raw_retention interval;
   v_already text;
 begin
   select current_slot, num_partitions, rotation_period
     into v_current_slot, v_num_partitions, v_rotation_period
   from ash.config
   where singleton;
+
+  v_raw_retention := (v_num_partitions - 2) * v_rotation_period;
 
   -- Negative interval is meaningless and would underflow `now() - p_interval`
   -- past the int4 horizon downstream. Treat as out-of-window.
@@ -1761,46 +1764,48 @@ begin
     return array[]::smallint[];
   end if;
 
-  if p_interval is not null and p_interval > 2 * v_rotation_period then
+  if p_interval is not null and p_interval > v_raw_retention then
     -- Suppress duplicate NOTICEs within the same transaction. The GUC is
     -- set local to the current transaction and auto-resets on commit/rollback.
     v_already := current_setting('ash.notice_oversized', true);
     if v_already is null or v_already = '' then
       raise notice
-        'requested interval % exceeds 2 * rotation_period (%); only the last two partitions are retained, so older samples are not available. Shorten the interval or increase rotation_period via ash.config.',
-        p_interval, v_rotation_period;
+        'requested interval % exceeds raw retention (%); only % completed partition(s) plus the current partial partition are retained. Shorten the interval, increase rotation_period, or rebuild with more partitions.',
+        p_interval, v_raw_retention, v_num_partitions - 2;
       perform set_config('ash.notice_oversized', '1', true);
     end if;
     -- Honor the NOTICE: return no slots so reader JOINs (`slot = any(...)`)
     -- yield empty. Without this, an absurd interval like '1000 years' clamps
     -- v_min_ts to 0 and matches every retained sample, contradicting the
     -- "older samples not available" promise. Callers wanting all retained
-    -- data should pass an interval <= 2 * rotation_period.
+    -- data should pass an interval <= raw_retention.
     return array[]::smallint[];
   end if;
 
-  -- Slot enumeration must use the configured num_partitions (default 3,
-  -- configurable in [3, 32] via rebuild_partitions). Hardcoded `% 3` would
-  -- mis-enumerate on N != 3.
-  return array[
-    v_current_slot,
-    ((v_current_slot - 1 + v_num_partitions) % v_num_partitions)::smallint
-  ];
+  -- Slot enumeration must use the configured num_partitions and include every
+  -- retained raw slot, not just current+previous. Readers still filter by
+  -- sample_ts; the slot list only keeps the partition-pruning contract honest.
+  return array(
+    select ((v_current_slot - gs.i + v_num_partitions) % v_num_partitions)::smallint
+    from generate_series(0, v_num_partitions - 2) as gs(i)
+    order by gs.i
+  );
 end;
 $$;
 
 -- Absolute-range counterpart to ash._active_slots_for(interval), used by every
 -- _at reader (top_waits_at, samples_at, query_waits_at, etc.). Returns the
 -- active slot set when the requested [p_start, p_end) range overlaps what raw
--- samples retain (~2 * rotation_period back from now()), and an empty array
--- with a NOTICE when it doesn't — restoring loud-warn symmetry with the
--- relative readers (#69). Without this, _at readers silently returned 0 rows
--- on absurd inputs (year 1000, year 3000) thanks to ts_from_timestamptz()'s
--- int4 clamp (#63), which was a UX regression vs the interval path.
+-- samples retain ((num_partitions - 2) * rotation_period back from now()), and
+-- an empty array with a NOTICE when it doesn't — restoring loud-warn symmetry
+-- with the relative readers (#69). Without this, _at readers silently returned
+-- 0 rows on absurd inputs (year 1000, year 3000) thanks to
+-- ts_from_timestamptz()'s int4 clamp (#63), which was a UX regression vs the
+-- interval path.
 --
 -- Out-of-retention conditions (each emits the NOTICE and returns {}):
---   * p_end   <= now() - 2 * rotation_period   (range entirely too old)
---   * p_start >  now()                          (range entirely in the future)
+--   * p_end   <= now() - raw_retention (range entirely too old)
+--   * p_start >  now()                  (range entirely in the future)
 --
 -- Importantly, an empty range (p_start >= p_end) inside the retained window
 -- is NOT flagged — callers may legitimately ask for a zero-length window and
@@ -1830,6 +1835,7 @@ declare
   v_num_partitions  smallint;
   v_rotation_period interval;
   v_now             timestamptz := now();
+  v_raw_retention   interval;
   v_retention_start timestamptz;
   v_already         text;
 begin
@@ -1838,7 +1844,8 @@ begin
   from ash.config
   where singleton;
 
-  v_retention_start := v_now - 2 * v_rotation_period;
+  v_raw_retention := (v_num_partitions - 2) * v_rotation_period;
+  v_retention_start := v_now - v_raw_retention;
 
   -- Out-of-retention check. Skip when either bound is null (the reader's
   -- own WHERE will yield empty without us needing to NOTICE) or when the
@@ -1848,17 +1855,18 @@ begin
     v_already := current_setting('ash.notice_oversized', true);
     if v_already is null or v_already = '' then
       raise notice
-        'requested range [%, %) lies outside the retained window (now - 2 * rotation_period .. now, i.e. [%, %)); only the last two partitions are retained, so older or future samples are not available. Adjust the range or increase rotation_period via ash.config.',
-        p_start, p_end, v_retention_start, v_now;
+        'requested range [%, %) lies outside the retained window (now - raw_retention .. now, i.e. [%, %)); only % completed partition(s) plus the current partial partition are retained. Adjust the range, increase rotation_period, or rebuild with more partitions.',
+        p_start, p_end, v_retention_start, v_now, v_num_partitions - 2;
       perform set_config('ash.notice_oversized', '1', true);
     end if;
     return array[]::smallint[];
   end if;
 
-  return array[
-    v_current_slot,
-    ((v_current_slot - 1 + v_num_partitions) % v_num_partitions)::smallint
-  ];
+  return array(
+    select ((v_current_slot - gs.i + v_num_partitions) % v_num_partitions)::smallint
+    from generate_series(0, v_num_partitions - 2) as gs(i)
+    order by gs.i
+  );
 end;
 $$;
 


### PR DESCRIPTION
## Summary

Fixes issue #83 by making raw readers honor the configured raw retention window after `ash.rebuild_partitions(N, 'yes')`.

Development-release layout is respected:
- `sql/` stays frozen at the released v1.4 baseline.
- The 1.5 development installer changes live in `devel/sql/ash-install.sql`.
- The 1.4 -> 1.5 upgrade path follows the devel installer through `devel/sql/ash-1.4-to-1.5.sql`.

## Red / Green TDD

- Red commit: `9897073` (`test: reproduce raw retention reader blind spot`)
  - Adds a regression for `rebuild_partitions(5, 'yes')` where current slot is `0` and retained raw slots should be `{0,4,3,2}`.
  - Exact red proof on PG18: fails with `_active_slots_for(3 days): expected {0,4,3,2}, got {}`.
- Green commit: `7944ce6` (`fix: enumerate rebuilt raw retention slots`)
  - `_active_slots_for()` and `_active_slots_for_at()` enumerate all retained raw slots based on `num_partitions`, not the old fixed two-slot assumption.

## Local verification

- `workflow-yaml=PASS`
- `python3 -m py_compile devel/scripts/ash_sql_chain.py`
- `git diff --check HEAD~2..HEAD`
- `git diff origin/main -- sql/ash-install.sql` is empty.
- Red proof: `red83=FAILS_AS_EXPECTED rc=3 sha=9897073`.
- Green fresh devel install proof: `green83=PASS sha=7944ce6`.
- Full auto-discovered upgrade proof: `full-upgrade83=PASS`.

## Note

PR #96 mirrors this rebuilt branch inside `NikolayS/pg_ash` so GitHub Actions can run normally.