### PR TITLE
Critical bug: prevent rollup/rotation raw sample loss

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2154,6 +2154,10 @@ jobs:
               v_s2 smallint;
               v_s3 smallint;
             begin
+              -- This block tests slot arithmetic only. With #81, rotate()
+              -- must refuse to advance if the endangered inactive slot still
+              -- contains unrolled raw samples from earlier edge cases.
+              truncate ash.sample;
               select ash.current_slot() into v_s0;
 
               update ash.config set rotated_at = now() - interval '2 days';

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3010,6 +3010,198 @@ jobs:
           $$;
           EOF
 
+      - name: "Critical bug #81: rollup and rotation must not lose raw samples"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          set -euo pipefail
+
+          psql_base=(psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1)
+
+          reset_issue_81_state() {
+            "${psql_base[@]}" << 'SQL'
+            select ash.stop();
+            truncate ash.sample;
+            truncate ash.rollup_1m;
+            truncate ash.rollup_1h;
+            truncate ash.wait_event_map restart identity cascade;
+            truncate ash.query_map_0 restart identity;
+            truncate ash.query_map_1 restart identity;
+            truncate ash.query_map_2 restart identity;
+            update ash.config
+            set current_slot = 0,
+              rotated_at = now() - interval '2 days',
+              rotation_period = interval '1 day',
+              last_rollup_1m_ts = null,
+              last_rollup_1h_ts = null,
+              sampling_enabled = true
+            where singleton;
+            select ash._register_wait('active', 'Issue81', 'RotateLoss');
+          SQL
+          }
+
+          seed_endangered_sample() {
+            "${psql_base[@]}" << 'SQL'
+            insert into ash.sample (
+              sample_ts, datid, active_count, data, slot
+            )
+            values (
+              ash.ts_from_timestamptz(date_trunc('minute', now()) - interval '2 minutes'),
+              0::oid,
+              1::smallint,
+              array[-1,1,0]::integer[],
+              2::smallint
+            );
+            select count(*) as seeded_rows from ash.sample_2;
+          SQL
+          }
+
+          assert_raw_sample_survived() {
+            local context="$1"
+            local raw_rows
+            local rollup_rows
+            local current_slot
+
+            raw_rows="$("${psql_base[@]}" -tAc "select count(*) from ash.sample_2")"
+            rollup_rows="$("${psql_base[@]}" -tAc "select count(*) from ash.rollup_1m")"
+            current_slot="$("${psql_base[@]}" -tAc "select current_slot from ash.config where singleton")"
+
+            if [ "$raw_rows" != "1" ]; then
+              echo "::error::$context: endangered raw sample was truncated (sample_2 rows=$raw_rows, rollup_1m rows=$rollup_rows, current_slot=$current_slot)" >&2
+              exit 1
+            fi
+            if [ "$current_slot" != "0" ]; then
+              echo "::error::$context: rotate advanced current_slot despite failed pre-rollup (current_slot=$current_slot)" >&2
+              exit 1
+            fi
+          }
+
+          wait_until_sql_true() {
+            local description="$1"
+            local sql="$2"
+            local value
+
+            for _ in {1..100}; do
+              value="$("${psql_base[@]}" -tAc "$sql")"
+              if [ "$value" = "t" ]; then
+                return 0
+              fi
+              sleep 0.1
+            done
+
+            echo "::error::timed out waiting for $description" >&2
+            exit 1
+          }
+
+          echo "=== #81A: rollup_minute must not advance while sampler lock is held ==="
+          reset_issue_81_state
+          "${psql_base[@]}" << 'SQL'
+          insert into ash.sample (
+            sample_ts, datid, active_count, data, slot
+          )
+          values (
+            ash.ts_from_timestamptz(date_trunc('minute', now()) - interval '2 minutes'),
+            0::oid,
+            1::smallint,
+            array[-1,1,0]::integer[],
+            0::smallint
+          );
+          SQL
+          "${psql_base[@]}" -c "
+            begin;
+            select pg_advisory_xact_lock(
+              hashtext('pg_ash')::int4,
+              hashtext('pg_ash_sampler')::int4
+            );
+            select pg_sleep(5);
+            commit;
+          " &
+          sampler_lock_pid=$!
+          wait_until_sql_true "sampler advisory lock" "
+            select exists (
+              select 1
+              from pg_locks
+              where locktype = 'advisory'
+                and classid = hashtext('pg_ash')::int4::oid
+                and objid = hashtext('pg_ash_sampler')::int4::oid
+                and granted
+                and pid <> pg_backend_pid()
+            )
+          "
+          rollup_result="$("${psql_base[@]}" -tAc "select ash.rollup_minute(5)")"
+          watermark="$("${psql_base[@]}" -tAc "select coalesce(last_rollup_1m_ts::text, '') from ash.config where singleton")"
+          rollup_rows="$("${psql_base[@]}" -tAc "select count(*) from ash.rollup_1m")"
+          wait "$sampler_lock_pid"
+
+          if [ "$rollup_result" != "0" ] || [ -n "$watermark" ] || [ "$rollup_rows" != "0" ]; then
+            echo "::error::rollup_minute advanced while sampler lock was held (result=$rollup_result, watermark=$watermark, rows=$rollup_rows)" >&2
+            exit 1
+          fi
+
+          rollup_result="$("${psql_base[@]}" -tAc "select ash.rollup_minute(5)")"
+          rollup_rows="$("${psql_base[@]}" -tAc "select count(*) from ash.rollup_1m")"
+          if [ "$rollup_result" = "0" ] || [ "$rollup_rows" = "0" ]; then
+            echo "::error::rollup_minute did not process data after sampler lock released (result=$rollup_result, rows=$rollup_rows)" >&2
+            exit 1
+          fi
+
+          echo "=== #81B: rotate must not truncate when rollup advisory lock is busy ==="
+          reset_issue_81_state
+          seed_endangered_sample
+          "${psql_base[@]}" -c "
+            begin;
+            select pg_advisory_xact_lock(
+              hashtext('pg_ash')::int4,
+              hashtext('pg_ash_rollup')::int4
+            );
+            select pg_sleep(5);
+            commit;
+          " &
+          rollup_lock_pid=$!
+          wait_until_sql_true "rollup advisory lock" "
+            select exists (
+              select 1
+              from pg_locks
+              where locktype = 'advisory'
+                and classid = hashtext('pg_ash')::int4::oid
+                and objid = hashtext('pg_ash_rollup')::int4::oid
+                and granted
+                and pid <> pg_backend_pid()
+            )
+          "
+          rotate_result="$("${psql_base[@]}" -tAc "select ash.rotate()")"
+          wait "$rollup_lock_pid"
+          echo "rotate result with busy rollup lock: $rotate_result"
+          assert_raw_sample_survived "busy rollup advisory lock"
+
+          echo "=== #81C: rotate must not truncate when pre-rollup hits lock_timeout ==="
+          reset_issue_81_state
+          seed_endangered_sample
+          "${psql_base[@]}" -c "
+            begin;
+            lock table ash.rollup_1m in access exclusive mode;
+            select pg_sleep(5);
+            commit;
+          " &
+          rollup_table_lock_pid=$!
+          wait_until_sql_true "rollup_1m AccessExclusiveLock" "
+            select exists (
+              select 1
+              from pg_locks
+              where locktype = 'relation'
+                and relation = 'ash.rollup_1m'::regclass
+                and mode = 'AccessExclusiveLock'
+                and granted
+                and pid <> pg_backend_pid()
+            )
+          "
+          rotate_result="$("${psql_base[@]}" -tAc "select ash.rotate()")"
+          wait "$rollup_table_lock_pid"
+          echo "rotate result with rollup_1m lock_timeout: $rotate_result"
+          assert_raw_sample_survived "rollup_1m lock_timeout"
+
+          echo "Critical bug #81 regression tests PASSED"
+
       - name: "Test v1.4: rollup reader functions"
         env:
           PGPASSWORD: postgres

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,6 +5,7 @@ Work in progress after v1.4.
 ## Fixes
 
 - **`wait_event_map` cap enforcement fixed.** `_register_wait()` now checks the exact 32 000th dictionary row instead of trusting stale `pg_class.reltuples`, so the hard cap fires immediately after `TRUNCATE` / restore and increments `register_wait_cap_hits` as documented. (issue #90; [PR #92](https://github.com/NikolayS/pg_ash/pull/92))
+- **Raw samples are protected during rollup/rotation races.** `rollup_minute()` no longer advances its watermark while a sampler is in flight, and `rotate()` refuses to truncate an endangered raw partition unless pre-truncation rollup succeeds and covers the raw groups in that slot. (issue #81; [PR #86](https://github.com/NikolayS/pg_ash/pull/86))
 
 ---
 

--- a/devel/sql/ash-1.4-to-1.5.sql
+++ b/devel/sql/ash-1.4-to-1.5.sql
@@ -1,71 +1,10 @@
 -- pg_ash development upgrade from 1.4 toward 1.5.
 --
 -- WIP: do not bump ash.config.version here. The version is finalized when
--- 1.5 is stamped and this delta is folded into ash-install.sql.
+-- 1.5 is stamped.
+--
+-- During the development cycle, keep the in-progress upgrade path in lockstep
+-- with the in-progress final installer. At release stamp time this file moves
+-- to sql/ next to the promoted ash-install.sql.
 
-create or replace function ash._register_wait(p_state text, p_type text, p_event text)
-returns smallint
-language plpgsql
-set search_path = pg_catalog, ash
-as $$
-declare
-  v_id     smallint;
-  v_at_cap boolean;
-begin
-  -- Try to get existing
-  select id into v_id
-  from ash.wait_event_map
-  where state = p_state and type = p_type and event = p_event;
-
-  if v_id is not null then
-    return v_id;
-  end if;
-
-  -- Enforce dictionary size cap before inserting. 32 000 stays well below
-  -- smallint's 32 767 ceiling while still leaving room for genuine event
-  -- diversity (real wait-event inventories measure in the hundreds).
-  -- Use an exact existence probe for the 32 000th row instead of
-  -- pg_class.reltuples: reltuples can be -1 or stale immediately after
-  -- TRUNCATE/restore, which bypasses a hard cap until ANALYZE catches up.
-  select exists (
-    select 1 from ash.wait_event_map offset 31999 limit 1
-  ) into v_at_cap;
-
-  if v_at_cap then
-    -- Bump the cap-hit counter so ash.status() can surface the drop.
-    -- Note: counts *registration drops* here — not the number of sampled
-    -- backends observed for this (state,type,event). Many concurrent
-    -- backends blocked on the same dropped event only bump it once per tick.
-    -- Wrap in an inner block: if the UPDATE itself fails (e.g. config row
-    -- missing mid-uninstall), we still want the outer WARNING to fire and
-    -- the function to return NULL without aborting take_sample().
-    begin
-      update ash.config set register_wait_cap_hits = register_wait_cap_hits + 1
-        where singleton;
-    exception when others then
-      null;  -- counter bump is best-effort
-    end;
-    raise warning 'ash._register_wait: wait_event_map at cap (>= 32 000 rows); skipping (state=%, type=%, event=%) — see ash.status()',
-      p_state, p_type, p_event;
-    return null;  -- caller PERFORMs this; snapshot JOIN drops the session
-  end if;
-
-  -- Insert new entry
-  insert into ash.wait_event_map (state, type, event)
-  values (p_state, p_type, p_event)
-  on conflict (state, type, event) do nothing
-  returning id into v_id;
-
-  -- If insert succeeded, return it
-  if v_id is not null then
-    return v_id;
-  end if;
-
-  -- Race condition: another session inserted, fetch it
-  select id into v_id
-  from ash.wait_event_map
-  where state = p_state and type = p_type and event = p_event;
-
-  return v_id;
-end;
-$$;
+\ir ash-install.sql

--- a/devel/sql/ash-install.sql
+++ b/devel/sql/ash-install.sql
@@ -918,6 +918,9 @@ declare
   v_rotation_period interval;
   v_rotated_at timestamptz;
   v_rotation_minutes int;
+  v_rollup_result int;
+  v_endangered_rows bigint;
+  v_unrolled_groups bigint;
 begin
   -- Advisory lock prevents concurrent rotation from pg_cron overlap.
   -- Xact-level: auto-releases on commit/rollback — no leak risk with pg_cron
@@ -944,28 +947,76 @@ begin
       return 'skipped: rotated too recently at ' || v_rotated_at::text;
     end if;
 
-    -- Set lock timeout to avoid blocking on long-running queries
-    set local lock_timeout = '2s';
-
-    -- Pre-truncation rollup: process endangered minutes before they are lost.
-    -- Called before config update to avoid locking contention with take_sample().
-    -- Rollup is idempotent (upsert), so double-processing is safe.
-    v_rotation_minutes := extract(epoch from v_rotation_period)::int / 60;
-
-    begin
-      perform ash.rollup_minute(v_rotation_minutes);
-    exception when undefined_function then
-      -- rollup_minute() not yet installed (upgrade in progress), skip
-      null;
-    when others then
-      raise warning 'ash.rotate: rollup_minute failed [%]: %', sqlstate, sqlerrm;
-    end;
-
     -- Calculate new slot dynamically (0 -> 1 -> ... -> N-1 -> 0)
     v_new_slot := (v_old_slot + 1) % v_num_partitions;
 
     -- The partition to truncate is the one after the new slot
     v_truncate_slot := (v_new_slot + 1) % v_num_partitions;
+
+    -- Set lock timeout to avoid blocking on long-running queries
+    set local lock_timeout = '2s';
+
+    -- Pre-truncation rollup: process endangered minutes before they are lost.
+    -- This is no longer best-effort: if the endangered raw slot has rows and
+    -- we cannot prove they are represented in rollup_1m, skip rotation rather
+    -- than deleting the only copy of the samples (#81).
+    execute format('select count(*) from ash.sample_%s', v_truncate_slot)
+    into v_endangered_rows;
+
+    if v_endangered_rows > 0 then
+      if not pg_try_advisory_xact_lock(
+           hashtext('pg_ash')::int4,
+           hashtext('pg_ash_rollup')::int4
+         ) then
+        return format(
+          'failed: pre-truncation rollup busy; slot %s not truncated',
+          v_truncate_slot
+        );
+      end if;
+
+      v_rotation_minutes := greatest(extract(epoch from v_rotation_period)::int / 60, 1);
+
+      begin
+        select ash.rollup_minute(v_rotation_minutes) into v_rollup_result;
+      exception when undefined_function then
+        return format(
+          'failed: rollup_minute() unavailable; slot %s not truncated',
+          v_truncate_slot
+        );
+      when others then
+        raise warning 'ash.rotate: rollup_minute failed [%]: %', sqlstate, sqlerrm;
+        return format(
+          'failed: pre-truncation rollup failed [%s]; slot %s not truncated',
+          sqlstate,
+          v_truncate_slot
+        );
+      end;
+
+      execute format(
+        'with raw as ('
+        '  select (sample_ts / 60) * 60 as ts, datid,'
+        '         count(distinct sample_ts)::smallint as samples,'
+        '         max(active_count)::smallint as peak_backends'
+        '  from ash.sample_%1$s'
+        '  group by 1, 2'
+        ') '
+        'select count(*) '
+        'from raw '
+        'left join ash.rollup_1m r on r.ts = raw.ts and r.datid = raw.datid '
+        'where r.ts is null '
+        '   or r.samples < raw.samples '
+        '   or r.peak_backends < raw.peak_backends',
+        v_truncate_slot
+      ) into v_unrolled_groups;
+
+      if v_unrolled_groups > 0 then
+        return format(
+          'failed: pre-truncation rollup incomplete for %s group(s) in slot %s; slot not truncated',
+          v_unrolled_groups,
+          v_truncate_slot
+        );
+      end if;
+    end if;
 
     -- Advance current_slot first (before truncate)
     update ash.config
@@ -2174,10 +2225,10 @@ declare
   v_count int;
   v_min_backend_seconds smallint;
   v_has_later_data bool;
+  v_sampler_lock_acquired bool := false;
 begin
-  -- Acquire rollup lock (xact-level). Distinct from the sampler lock so a
-  -- long catch-up doesn't bump skipped_samples on every concurrent tick.
-  -- rebuild_partitions's drain poll waits on this objid.
+  -- Acquire rollup lock (xact-level). Rollup operations serialize with each
+  -- other, and rebuild_partitions's drain poll waits on this objid.
   if not pg_try_advisory_xact_lock(
        hashtext('pg_ash')::int4,
        hashtext('pg_ash_rollup')::int4
@@ -2191,8 +2242,39 @@ begin
   into v_last_ts, v_min_backend_seconds
   from ash.config where singleton;
 
-  -- Current minute boundary (only process *complete* minutes)
-  v_now_minute_ts := ash.ts_from_timestamptz(date_trunc('minute', now()));
+  -- Drain in-flight samplers before choosing the "complete minute" boundary.
+  -- take_sample() gets sample_ts from transaction-start now(), then may block
+  -- before INSERT. Without this drain, rollup_minute() can advance the
+  -- watermark while a sampler later commits an old-minute row, permanently
+  -- excluding it from rollups (#81).
+  if not pg_try_advisory_lock(
+       hashtext('pg_ash')::int4,
+       hashtext('pg_ash_sampler')::int4
+     ) then
+    return 0;
+  end if;
+  v_sampler_lock_acquired := true;
+
+  begin
+    -- Current minute boundary (only process *complete* minutes). This is
+    -- computed after the sampler drain, so future samplers cannot commit rows
+    -- with sample_ts older than this boundary.
+    v_now_minute_ts := ash.ts_from_timestamptz(date_trunc('minute', now()));
+
+    perform pg_advisory_unlock(
+      hashtext('pg_ash')::int4,
+      hashtext('pg_ash_sampler')::int4
+    );
+    v_sampler_lock_acquired := false;
+  exception when others then
+    if v_sampler_lock_acquired then
+      perform pg_advisory_unlock(
+        hashtext('pg_ash')::int4,
+        hashtext('pg_ash_sampler')::int4
+      );
+    end if;
+    raise;
+  end;
 
   -- Initialize watermark if NULL (first run after install or upgrade).
   if v_last_ts is null then


### PR DESCRIPTION
Fixes #81.

## Summary

This fixes two data-loss paths around raw sample retention, staged under the post-v1.4 development SQL layout from PR #94:

- `ash.rollup_minute()` no longer advances the minute watermark while a sampler is in flight. It briefly takes the sampler advisory lock before computing the complete-minute boundary, and returns `0` without changing the watermark if the sampler lock is busy.
- `ash.rotate()` no longer treats pre-truncation rollup as best-effort when the endangered raw slot contains rows. It aborts rotation if rollup is busy, fails, or cannot prove the endangered slot is represented in `ash.rollup_1m`.
- `sql/` remains frozen: `git diff origin/main -- sql/ash-install.sql` is empty.
- The fix lives in `devel/sql/ash-install.sql`; `devel/sql/ash-1.4-to-1.5.sql` now includes the in-progress installer via `\ir ash-install.sql`, keeping the devel upgrade path in lockstep with the devel final installer.
- Adds CI regression coverage for issue #81: sampler lock held, rollup advisory lock busy, and `rollup_1m` lock timeout.
- Adds the issue #81 note to the WIP 1.5 release notes.

## Red/green TDD

- Red: `304f095` adds only the #81 CI regression. Local red proof on that exact commit: `issue81-red=FAILS_AS_EXPECTED result=1 watermark=12856920 rows=1`.
- Green: `a621ccb` moves the fix into `devel/sql/`, leaves released `sql/` untouched, and makes the devel upgrade script follow the devel installer.

## Local verification

- `git diff origin/main -- sql/ash-install.sql` prints no diff.
- `git diff --check HEAD~2..HEAD` passes.
- Green issue #81 regression passes locally: `issue81-green=PASS`.
- Generated full upgrade chain passes locally with the new devel upgrade shim: `full-upgrade-chain=PASS`, final `ash.config.version = 1.4`.
- Generated reapply chain passes locally after fresh devel install: `reapply-chain=PASS`.

## Note

This replaces #82 only to use the repository-style branch name `fix-issue-81-rollup-rotation-data-loss` instead of the earlier account-prefixed branch name.