### PR TITLE
fix: enforce wait_event_map cap exactly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1865,6 +1865,51 @@ jobs:
           $$;
           EOF
 
+      - name: "Regression: wait_event_map cap is exact after truncate"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          begin;
+
+          truncate ash.wait_event_map restart identity cascade;
+          update ash.config set register_wait_cap_hits = 0 where singleton;
+
+          insert into ash.wait_event_map (state, type, event)
+          select
+            'active',
+            'synthetic_type_' || i,
+            'synthetic_event_' || i
+          from generate_series(1, 32000) as gs(i);
+
+          do $$
+          declare
+            v_id smallint;
+            v_rows bigint;
+            v_hits bigint;
+          begin
+            select ash._register_wait(
+              'active',
+              'synthetic_type_over_cap',
+              'synthetic_event_over_cap'
+            ) into v_id;
+
+            assert v_id is null,
+              '_register_wait should return NULL once wait_event_map has 32000 rows';
+
+            select count(*) into v_rows from ash.wait_event_map;
+            assert v_rows = 32000,
+              'wait_event_map cap should prevent row 32001, got ' || v_rows;
+
+            select register_wait_cap_hits into v_hits from ash.config where singleton;
+            assert v_hits = 1,
+              'register_wait_cap_hits should increment at cap, got ' || v_hits;
+          end;
+          $$;
+
+          rollback;
+          EOF
+
       - name: Test edge cases and corner cases
         env:
           PGPASSWORD: postgres
@@ -4119,4 +4164,3 @@ jobs:
           CRON: ${{ matrix.cron }}
         run: |
           echo "All tests passed for PostgreSQL $PG_MAJOR (pg_cron=$CRON)"
-

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -92,12 +92,13 @@ Three new bigint columns on `ash.config`, all surfaced by `ash.status()`:
 - **No more `integer out of range` on absurd reader inputs.** Both the relative-interval readers (`top_waits('1000 years')`, etc.) and the absolute-timestamp `_at` readers (`top_waits_at('1000-01-01', …)`, etc.) now return empty rows cleanly via clamps in the readers and in `ts_from_timestamptz`. (issues #51 and #63; [PR #57](https://github.com/NikolayS/pg_ash/pull/57), [PR #65](https://github.com/NikolayS/pg_ash/pull/65))
 - **`sample_data_check` constraint aligned across upgrade paths.** Installs upgraded from 1.0 had a looser `array_length(data, 1) >= 2` check that 1.1 silently failed to tighten because of `create table if not exists`. An idempotent DO block in install.sql now drops + re-adds the `>= 3` form. (issue #49; [PR #56](https://github.com/NikolayS/pg_ash/pull/56))
 - **`ash.status()` no longer errors for non-superuser monitoring roles when pg_cron is loaded.** A nested `EXCEPTION WHEN insufficient_privilege` substitutes a fallback row pointing at the missing `GRANT USAGE ON SCHEMA cron`. (issue #61; [PR #62](https://github.com/NikolayS/pg_ash/pull/62))
+- **`wait_event_map` cap enforcement fixed.** `_register_wait()` now checks the exact 32 000th dictionary row instead of trusting stale `pg_class.reltuples`, so the hard cap fires immediately after `TRUNCATE` / restore and increments `register_wait_cap_hits` as documented. (#90; [PR #92](https://github.com/NikolayS/pg_ash/pull/92))
 
 ## CI / infra
 
 - End-to-end pg_cron firing test passes on every PG 14–18 cron-enabled job. Provisions a `root` PG role + database to satisfy peer auth in the GHA service container; asserts via `ash.sample` row growth with a real `pg_sleep` workload. (issue #46; [PR #73](https://github.com/NikolayS/pg_ash/pull/73))
 - Schema-equivalence CI now diffs `pg_constraint` between fresh-install and chain-upgrade snapshots — catches the class of divergence behind issue #49. (issue #66; [PR #70](https://github.com/NikolayS/pg_ash/pull/70))
-- **Hot-path perf** improvements in `query_waits` / `query_waits_at` (window-based dedup via `named_hits` CTE), `rotate()` (single-statement `truncate ash.sample_N, ash.query_map_N restart identity`), and the `_register_wait` cap probe (`offset 49999 limit 1` replacing stale `pg_class.reltuples`). ([PR #42](https://github.com/NikolayS/pg_ash/pull/42))
+- **Hot-path perf** improvements in `query_waits` / `query_waits_at` (window-based dedup via `named_hits` CTE), `rotate()` (single-statement `truncate ash.sample_N, ash.query_map_N restart identity`), and the `query_map` cap probe (`offset 49999 limit 1` replacing stale `pg_class.reltuples`). ([PR #42](https://github.com/NikolayS/pg_ash/pull/42))
 - **Supply-chain hardening** for CI: third-party actions pinned to 40-char commit SHAs and least-privilege `permissions:` blocks. ([PR #40](https://github.com/NikolayS/pg_ash/pull/40))
 
 ## Demo
@@ -498,4 +499,3 @@ Benchmark results are published in [issue #1](https://github.com/NikolayS/pg_ash
 - **Rollup tables** — per-minute and per-hour aggregation for long-term trends (designed in `blueprints/ROLLUP_DESIGN.md`, implementation planned for 1.1)
 - **Cross-database query text** — sampling covers all databases (via `pg_stat_activity.datid`), but `top_queries_with_text()` can only resolve query text from pg_stat_statements in the database where pg_ash is installed
 - **Parallel query attribution** — parallel workers are sampled but not linked to their leader
-

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -390,8 +390,8 @@ language plpgsql
 set search_path = pg_catalog, ash
 as $$
 declare
-  v_id    smallint;
-  v_count bigint;
+  v_id     smallint;
+  v_at_cap boolean;
 begin
   -- Try to get existing
   select id into v_id
@@ -405,12 +405,14 @@ begin
   -- Enforce dictionary size cap before inserting. 32 000 stays well below
   -- smallint's 32 767 ceiling while still leaving room for genuine event
   -- diversity (real wait-event inventories measure in the hundreds).
-  -- reltuples is a cheap estimate; an exact count would add a scan on
-  -- every fresh wait-event observation on the sampler's hot path.
-  select reltuples::bigint into v_count
-  from pg_class where oid = 'ash.wait_event_map'::regclass;
+  -- Use an exact existence probe for the 32 000th row instead of
+  -- pg_class.reltuples: reltuples can be -1 or stale immediately after
+  -- TRUNCATE/restore, which bypasses a hard cap until ANALYZE catches up.
+  select exists (
+    select 1 from ash.wait_event_map offset 31999 limit 1
+  ) into v_at_cap;
 
-  if v_count >= 32000 then
+  if v_at_cap then
     -- Bump the cap-hit counter so ash.status() can surface the drop.
     -- Note: counts *registration drops* here — not the number of sampled
     -- backends observed for this (state,type,event). Many concurrent


### PR DESCRIPTION
## Summary

Fixes #90 by replacing `_register_wait()`'s `pg_class.reltuples` cap check with an exact existence probe for the 32,000th `wait_event_map` row.

`reltuples` can be `-1` or stale immediately after `TRUNCATE`/restore, so the advertised hard cap could be bypassed until `ANALYZE` refreshed stats.

## TDD commits

- **Red:** `7f59293` (`test: reproduce wait event map cap bypass`) adds the regression first.
- **Green:** `baf9f80` (`fix: enforce wait event map cap exactly`) makes that regression pass.

## Testing

- Red/green TDD on PostgreSQL 18 with the same regression SQL:
  - **Red (`7f59293`)**: fails with `ASSERT _register_wait should return NULL once wait_event_map has 32000 rows`.
  - **Green (`baf9f80`)**: passes; row 32,001 is rejected, `register_wait_cap_hits = 1`, transaction rolls back.
- Installed patched `sql/ash-install.sql` into a clean PostgreSQL 18 container.
- Re-ran #90 repro: 32,001 registration attempts now leave exactly 32,000 rows, `reltuples = -1`, and `register_wait_cap_hits = 1`.
- Ran the new CI regression block locally.
- `git diff --check`

Note: `actionlint` is not installed on this host, so workflow lint was not run locally.
