### PR TITLE
Keep 1.5 changes in development upgrade path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -235,13 +235,16 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f devel/sql/ash-install.sql
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f "$(python3 devel/scripts/ash_sql_chain.py fresh-install-path)"
 
       - name: Test schema and infrastructure
         env:
           PGPASSWORD: postgres
         run: |
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
+            -v expected_version="$(python3 devel/scripts/ash_sql_chain.py latest-released-version)" << 'EOF'
+          select set_config('pg_ash.expected_version', :'expected_version', false);
+
           do $$
           begin
             -- Schema exists
@@ -251,8 +254,8 @@ jobs:
             -- Config table initialized with version
             assert (select count(*) from ash.config) = 1,
               'config not initialized';
-            assert (select version from ash.config where singleton) = '1.4',
-              'version should be 1.4 for fresh install';
+            assert (select version from ash.config where singleton) = current_setting('pg_ash.expected_version'),
+              'version should match latest released version for fresh install';
 
             -- missed_samples column exists and defaults to 0
             assert exists (
@@ -3468,86 +3471,25 @@ jobs:
           $$;
           EOF
 
-      - name: "Upgrade path: 1.0 → 1.1 → 1.2 → 1.3 → 1.4"
+      - name: "Upgrade path: discovered full chain"
         env:
           PGPASSWORD: postgres
         run: |
+          python3 devel/scripts/ash_sql_chain.py full-upgrade-chain > /tmp/ash_full_upgrade_chain.sql
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
-          -- Start from 1.0
-          \i sql/ash-1.0.sql
+          \i /tmp/ash_full_upgrade_chain.sql
 
           do $$
           begin
-            assert exists (select from pg_namespace where nspname = 'ash'), '1.0 install failed';
-            raise notice '1.0 installed OK';
-          end;
-          $$;
-
-          -- Upgrade to 1.1
-          \i sql/ash-1.1.sql
-
-          do $$
-          begin
-            assert (select version from ash.config where singleton) = '1.1',
-              'version should be 1.1 after upgrade';
-            -- timeline_chart must exist
-            assert exists (
-              select from pg_proc where proname = 'timeline_chart'
-                and pronamespace = 'ash'::regnamespace
-            ), 'timeline_chart missing after 1.1 upgrade';
-            raise notice '1.0 -> 1.1 upgrade PASSED';
-          end;
-          $$;
-
-          -- Upgrade to 1.2
-          \i sql/ash-1.1-to-1.2.sql
-
-          do $$
-          begin
-            assert (select version from ash.config where singleton) = '1.2',
-              'version should be 1.2 after 1.1-to-1.2 upgrade';
-            raise notice '1.1 -> 1.2 upgrade PASSED';
-          end;
-          $$;
-
-          -- Upgrade to 1.3
-          \i sql/ash-1.2-to-1.3.sql
-
-          do $$
-          declare
-            v_count int;
-          begin
-            assert (select version from ash.config where singleton) = '1.3',
-              'version should be 1.3 after upgrade';
-            -- timeline_chart must exist with new column order.
-            -- No seed data here, so don't assert row count — a broken
-            -- function would raise (missing function / bad signature).
-            perform * from ash.timeline_chart('1 hour', '5 minutes', 3, 40);
-            perform * from ash.timeline_chart('1 hour', '5 minutes', 3, 40, true);
-            -- debug_logging must exist
-            assert exists (
-              select from information_schema.columns
-              where table_schema = 'ash' and table_name = 'config' and column_name = 'debug_logging'
-            ), 'debug_logging column missing after 1.3 upgrade';
-            raise notice '1.2 -> 1.3 upgrade PASSED';
-          end;
-          $$;
-
-          -- Upgrade to 1.4
-          \i sql/ash-1.3-to-1.4.sql
-          \i devel/sql/ash-1.4-to-1.5.sql
-
-          do $$
-          begin
-            assert (select version from ash.config where singleton) = '1.4',
-              'version should be 1.4 after upgrade';
             assert exists (
               select from information_schema.columns
               where table_schema = 'ash' and table_name = 'config' and column_name = 'missed_samples'
-            ), 'missed_samples column missing after 1.4 upgrade';
+            ), 'missed_samples column missing after full upgrade';
             assert (select missed_samples from ash.config where singleton) = 0,
               'missed_samples should be 0 after upgrade';
-            raise notice '1.3 -> 1.4 -> 1.5-dev upgrade PASSED';
+            perform * from ash.timeline_chart('1 hour', '5 minutes', 3, 40);
+            perform * from ash.timeline_chart('1 hour', '5 minutes', 3, 40, true);
+            raise notice 'discovered full upgrade chain PASSED';
           end;
           $$;
 
@@ -3576,15 +3518,15 @@ jobs:
             ) into v_id;
 
             assert v_id is null,
-              '1.4-to-1.5 _register_wait should return NULL once wait_event_map has 32000 rows';
+              'latest upgrade _register_wait should return NULL once wait_event_map has 32000 rows';
 
             select count(*) into v_rows from ash.wait_event_map;
             assert v_rows = 32000,
-              '1.4-to-1.5 wait_event_map cap should prevent row 32001, got ' || v_rows;
+              'latest upgrade wait_event_map cap should prevent row 32001, got ' || v_rows;
 
             select register_wait_cap_hits into v_hits from ash.config where singleton;
             assert v_hits = 1,
-              '1.4-to-1.5 register_wait_cap_hits should increment at cap, got ' || v_hits;
+              'latest upgrade register_wait_cap_hits should increment at cap, got ' || v_hits;
           end;
           $$;
 
@@ -3594,20 +3536,23 @@ jobs:
           select ash.uninstall('yes');
           EOF
 
-      - name: "Issue #49: sample_data_check tightened by upgrade chain from 1.0"
+      - name: "Issue #49: sample_data_check tightened by discovered upgrade chain"
         env:
           PGPASSWORD: postgres
         run: |
-          # Regression for issue #49: v1.0 shipped `array_length(data, 1) >= 2`,
-          # v1.1+ requires `>= 3`. No legacy upgrade script rewrote the check,
-          # so installs that started at 1.0 carried the looser form forever.
+          # Regression for issue #49: the oldest released installer shipped
+          # `array_length(data, 1) >= 2`; later releases require `>= 3`.
+          # No legacy upgrade script rewrote the check, so installs that
+          # started at the oldest release carried the looser form forever.
           # The current development upgrade chain now detects and rewrites it;
-          # assert that the full 1.0 -> 1.5-dev chain ends with the tightened
+          # assert that the discovered full chain ends with the tightened
           # constraint on both the partitioned parent and every partition.
+          python3 devel/scripts/ash_sql_chain.py oldest-install-path | sed 's#^#\\i #' > /tmp/ash_oldest_install.sql
+          python3 devel/scripts/ash_sql_chain.py upgrade-chain-from-oldest > /tmp/ash_upgrade_from_oldest.sql
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
-          \i sql/ash-1.0.sql
+          \i /tmp/ash_oldest_install.sql
 
-          -- Sanity-check the precondition: 1.0 ships the looser form.
+          -- Sanity-check the precondition: the oldest released installer ships the looser form.
           do $$
           declare
             v_def text;
@@ -3617,14 +3562,10 @@ jobs:
             where c.conrelid = 'ash.sample'::regclass
               and c.conname  = 'sample_data_check';
             assert v_def ~ 'array_length\(data, 1\) >= 2',
-              format('1.0 should ship `>= 2` form; got: %s', v_def);
+              format('oldest released installer should ship `>= 2` form; got: %s', v_def);
           end $$;
 
-          \i sql/ash-1.1.sql
-          \i sql/ash-1.1-to-1.2.sql
-          \i sql/ash-1.2-to-1.3.sql
-          \i sql/ash-1.3-to-1.4.sql
-          \i devel/sql/ash-1.4-to-1.5.sql
+          \i /tmp/ash_upgrade_from_oldest.sql
 
           -- After full dev chain: parent + every partition must carry `>= 3`,
           -- and none may carry the legacy `>= 2`.
@@ -3675,16 +3616,16 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
-          # The README tells users to run the wrappers (e.g. ash-1.0-to-1.1.sql),
-          # but no existing CI step exercises them — the other upgrade-path
-          # test shortcuts by loading ash-1.1.sql directly. This step exercises
-          # the wrapper chain AND asserts a seeded row is preserved end-to-end
-          # (and that new columns get sensible defaults).
+          # This step exercises the discovered wrapper chain AND asserts a
+          # seeded row is preserved end-to-end (and that new columns get
+          # sensible defaults).
+          python3 devel/scripts/ash_sql_chain.py oldest-install-path | sed 's#^#\\i #' > /tmp/ash_oldest_install.sql
+          python3 devel/scripts/ash_sql_chain.py upgrade-chain-from-oldest > /tmp/ash_upgrade_from_oldest.sql
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
-          -- Install 1.0
-          \i sql/ash-1.0.sql
+          -- Install oldest released schema
+          \i /tmp/ash_oldest_install.sql
 
-          -- Seed fixtures at v1.0 schema:
+          -- Seed fixtures at the oldest released schema:
           --   (a) a non-default config value that all upgrades must preserve
           --   (b) a wait_event_map row + query_map_0 row + a sample referencing them
           --       using a sentinel query_id we can look up later
@@ -3717,30 +3658,22 @@ jobs:
               values (v_ts, 1, 1, array[-v_wait_id, 1, v_qid_id]::integer[], v_slot);
             assert exists (
               select from ash.sample where datid = 1 and active_count = 1
-            ), 'v1.0 fixture sample row missing';
-            raise notice 'v1.0 schema installed and fixtures seeded';
+            ), 'oldest-release fixture sample row missing';
+            raise notice 'oldest released schema installed and fixtures seeded';
           end;
           $$;
 
-          -- Upgrade chain via the DOCUMENTED wrappers (H-CI-1).
-          \i sql/ash-1.0-to-1.1.sql
-          \i sql/ash-1.1-to-1.2.sql
-          \i sql/ash-1.2-to-1.3.sql
-          \i sql/ash-1.3-to-1.4.sql
-          \i devel/sql/ash-1.4-to-1.5.sql
+          -- Upgrade chain via discovered documented wrappers (H-CI-1).
+          \i /tmp/ash_upgrade_from_oldest.sql
 
-          -- Assertions after reaching v1.4 plus the current 1.5-dev delta.
+          -- Assertions after reaching current development state.
           do $$
           declare
             v_cfg record;
             v_sample_rows int;
             v_qid_id int4;
           begin
-            -- Version landed on 1.4
-            assert (select version from ash.config where singleton) = '1.4',
-              'version should be 1.4 after wrapper chain';
-
-            -- (H-CI-2) Pre-existing v1.0 config values must survive
+            -- (H-CI-2) Pre-existing config values must survive
             select * into v_cfg from ash.config where singleton;
             assert v_cfg.include_bg_workers = true,
               'include_bg_workers not preserved across upgrades';
@@ -3787,54 +3720,25 @@ jobs:
           select ash.uninstall('yes');
           EOF
 
-      - name: "Upgrade path: 1.1 → 1.2 → 1.3 → 1.4 (direct)"
+      - name: "Upgrade path: discovered direct chain from second released installer"
         env:
           PGPASSWORD: postgres
         run: |
+          python3 devel/scripts/ash_sql_chain.py second-oldest-install-path | sed 's#^#\\i #' > /tmp/ash_second_oldest_install.sql
+          python3 devel/scripts/ash_sql_chain.py upgrade-chain-from-second-oldest > /tmp/ash_upgrade_from_second_oldest.sql
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
-          \i sql/ash-1.1.sql
+          \i /tmp/ash_second_oldest_install.sql
+          \i /tmp/ash_upgrade_from_second_oldest.sql
 
           do $$
           begin
-            assert (select version from ash.config where singleton) = '1.1',
-              'version should be 1.1';
-            raise notice '1.1 fresh install OK';
-          end;
-          $$;
-
-          \i sql/ash-1.1-to-1.2.sql
-
-          do $$
-          begin
-            assert (select version from ash.config where singleton) = '1.2',
-              'version should be 1.2 after 1.1-to-1.2';
-            raise notice '1.1 -> 1.2 direct upgrade PASSED';
-          end;
-          $$;
-
-          \i sql/ash-1.2-to-1.3.sql
-
-          do $$
-          begin
-            assert (select version from ash.config where singleton) = '1.3',
-              'version should be 1.3 after upgrade';
-            -- No seed data in this path; just verify the function is
-            -- callable after the upgrade (a missing/broken function raises).
-            perform * from ash.timeline_chart('1 hour', '5 minutes', 3, 40);
-            raise notice '1.2 -> 1.3 direct upgrade PASSED';
-          end;
-          $$;
-
-          \i sql/ash-1.3-to-1.4.sql
-          \i devel/sql/ash-1.4-to-1.5.sql
-
-          do $$
-          begin
-            assert (select version from ash.config where singleton) = '1.4',
-              'version should be 1.4 after upgrade';
             assert (select missed_samples from ash.config where singleton) = 0,
               'missed_samples should be 0';
-            raise notice '1.3 -> 1.4 -> 1.5-dev direct upgrade PASSED';
+            -- No seed data in this path; just verify representative functions
+            -- are callable after the discovered direct upgrade chain.
+            perform * from ash.timeline_chart('1 hour', '5 minutes', 3, 40);
+            perform * from ash.timeline_chart('1 hour', '5 minutes', 3, 40, true);
+            raise notice 'discovered direct upgrade chain PASSED';
           end;
           $$;
 
@@ -3858,20 +3762,22 @@ jobs:
           # REPLACE cannot change OUT params). The 1.0 bootstrap and the
           # 1.0-to-1.1 wrapper hit the same path. Those finalized legacy
           # scripts remain immutable and are still exercised end-to-end by
-          # the one-shot upgrade-chain tests above (fresh DB, 1.0 → 1.5-dev).
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
-          \i devel/sql/ash-install.sql
+          # the one-shot upgrade-chain tests above.
+          python3 devel/scripts/ash_sql_chain.py fresh-install-path | sed 's#^#\\i #' > /tmp/ash_fresh_install.sql
+          python3 devel/scripts/ash_sql_chain.py reapply-chain > /tmp/ash_reapply_chain.sql
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
+            -v expected_version="$(python3 devel/scripts/ash_sql_chain.py latest-released-version)" << 'EOF'
+          select set_config('pg_ash.expected_version', :'expected_version', false);
 
-          -- Apply all upgrade scripts on top of fresh install (should be idempotent)
-          \i sql/ash-1.1-to-1.2.sql
-          \i sql/ash-1.2-to-1.3.sql
-          \i sql/ash-1.3-to-1.4.sql
-          \i devel/sql/ash-1.4-to-1.5.sql
+          \i /tmp/ash_fresh_install.sql
+
+          -- Apply all discovered re-apply-safe upgrade scripts on top of fresh install.
+          \i /tmp/ash_reapply_chain.sql
 
           do $$
           begin
-            assert (select version from ash.config where singleton) = '1.4',
-              'version should still be 1.4';
+            assert (select version from ash.config where singleton) = current_setting('pg_ash.expected_version'),
+              'version should still match latest released version';
             raise notice 'Idempotent re-apply PASSED';
           end;
           $$;
@@ -3880,15 +3786,12 @@ jobs:
           update ash.config set missed_samples = 42 where singleton;
 
           -- Apply again — must preserve data
-          \i sql/ash-1.1-to-1.2.sql
-          \i sql/ash-1.2-to-1.3.sql
-          \i sql/ash-1.3-to-1.4.sql
-          \i devel/sql/ash-1.4-to-1.5.sql
+          \i /tmp/ash_reapply_chain.sql
 
           do $$
           begin
-            assert (select version from ash.config where singleton) = '1.4',
-              'version should still be 1.4 after second apply';
+            assert (select version from ash.config where singleton) = current_setting('pg_ash.expected_version'),
+              'version should still match latest released version after second apply';
             assert (select missed_samples from ash.config where singleton) = 42,
               'missed_samples should be preserved (42) after idempotent re-apply';
             -- timeline_chart must still be callable after re-apply. No data
@@ -3954,18 +3857,15 @@ jobs:
           order by c.relname, con.conname;
           SNAPSQL
 
+          python3 devel/scripts/ash_sql_chain.py full-upgrade-chain > /tmp/ash_full_upgrade_chain.sql
+
           # 1) Fresh install → snapshot
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f devel/sql/ash-install.sql > /dev/null 2>&1
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f "$(python3 devel/scripts/ash_sql_chain.py fresh-install-path)" > /dev/null 2>&1
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f /tmp/ash_schema_snapshot.sql > /tmp/fresh_schema.txt
           psql -h localhost -U postgres -d postgres -c "select ash.uninstall('yes')" > /dev/null 2>&1
 
           # 2) Full upgrade path → snapshot
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f sql/ash-1.0.sql > /dev/null 2>&1
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f sql/ash-1.1.sql > /dev/null 2>&1
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f sql/ash-1.1-to-1.2.sql > /dev/null 2>&1
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f sql/ash-1.2-to-1.3.sql > /dev/null 2>&1
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f sql/ash-1.3-to-1.4.sql > /dev/null 2>&1
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f devel/sql/ash-1.4-to-1.5.sql > /dev/null 2>&1
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f /tmp/ash_full_upgrade_chain.sql > /dev/null 2>&1
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f /tmp/ash_schema_snapshot.sql > /tmp/upgraded_schema.txt
           psql -h localhost -U postgres -d postgres -c "select ash.uninstall('yes')" > /dev/null 2>&1
 
@@ -4031,7 +3931,7 @@ jobs:
           psql -h localhost -U postgres -d postgres -c "select ash.uninstall('yes')" 2>/dev/null || echo "ash.uninstall skipped (schema absent)"
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
             -c "drop extension if exists pg_stat_statements"
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f devel/sql/ash-install.sql > /dev/null
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f "$(python3 devel/scripts/ash_sql_chain.py fresh-install-path)" > /dev/null
 
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
 
@@ -4159,7 +4059,7 @@ jobs:
           # Use ON_ERROR_STOP so unrelated failures don't get silenced.
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
             -c "drop extension if exists pg_cron cascade"
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f devel/sql/ash-install.sql > /dev/null
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f "$(python3 devel/scripts/ash_sql_chain.py fresh-install-path)" > /dev/null
 
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
           do $$

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,11 +231,11 @@ jobs:
             where jobname like 'ash_%';
           "
 
-      - name: Install pg_ash (fresh install)
+      - name: Install pg_ash (fresh development install)
         env:
           PGPASSWORD: postgres
         run: |
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f sql/ash-install.sql
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f devel/sql/ash-install.sql
 
       - name: Test schema and infrastructure
         env:
@@ -3535,6 +3535,7 @@ jobs:
 
           -- Upgrade to 1.4
           \i sql/ash-1.3-to-1.4.sql
+          \i devel/sql/ash-1.4-to-1.5.sql
 
           do $$
           begin
@@ -3546,9 +3547,48 @@ jobs:
             ), 'missed_samples column missing after 1.4 upgrade';
             assert (select missed_samples from ash.config where singleton) = 0,
               'missed_samples should be 0 after upgrade';
-            raise notice '1.3 -> 1.4 upgrade PASSED';
+            raise notice '1.3 -> 1.4 -> 1.5-dev upgrade PASSED';
           end;
           $$;
+
+          begin;
+
+          truncate ash.wait_event_map restart identity cascade;
+          update ash.config set register_wait_cap_hits = 0 where singleton;
+
+          insert into ash.wait_event_map (state, type, event)
+          select
+            'active',
+            'upgrade_synthetic_type_' || i,
+            'upgrade_synthetic_event_' || i
+          from generate_series(1, 32000) as gs(i);
+
+          do $$
+          declare
+            v_id smallint;
+            v_rows bigint;
+            v_hits bigint;
+          begin
+            select ash._register_wait(
+              'active',
+              'upgrade_synthetic_type_over_cap',
+              'upgrade_synthetic_event_over_cap'
+            ) into v_id;
+
+            assert v_id is null,
+              '1.4-to-1.5 _register_wait should return NULL once wait_event_map has 32000 rows';
+
+            select count(*) into v_rows from ash.wait_event_map;
+            assert v_rows = 32000,
+              '1.4-to-1.5 wait_event_map cap should prevent row 32001, got ' || v_rows;
+
+            select register_wait_cap_hits into v_hits from ash.config where singleton;
+            assert v_hits = 1,
+              '1.4-to-1.5 register_wait_cap_hits should increment at cap, got ' || v_hits;
+          end;
+          $$;
+
+          rollback;
 
           -- Uninstall after upgrade test
           select ash.uninstall('yes');
@@ -3561,9 +3601,9 @@ jobs:
           # Regression for issue #49: v1.0 shipped `array_length(data, 1) >= 2`,
           # v1.1+ requires `>= 3`. No legacy upgrade script rewrote the check,
           # so installs that started at 1.0 carried the looser form forever.
-          # ash-install.sql now detects and rewrites it; assert that the full
-          # 1.0 -> 1.4 chain ends with the tightened constraint on both the
-          # partitioned parent and every partition.
+          # The current development upgrade chain now detects and rewrites it;
+          # assert that the full 1.0 -> 1.5-dev chain ends with the tightened
+          # constraint on both the partitioned parent and every partition.
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
           \i sql/ash-1.0.sql
 
@@ -3584,8 +3624,9 @@ jobs:
           \i sql/ash-1.1-to-1.2.sql
           \i sql/ash-1.2-to-1.3.sql
           \i sql/ash-1.3-to-1.4.sql
+          \i devel/sql/ash-1.4-to-1.5.sql
 
-          -- After full chain: parent + every partition must carry `>= 3`,
+          -- After full dev chain: parent + every partition must carry `>= 3`,
           -- and none may carry the legacy `>= 2`.
           do $$
           declare
@@ -3686,8 +3727,9 @@ jobs:
           \i sql/ash-1.1-to-1.2.sql
           \i sql/ash-1.2-to-1.3.sql
           \i sql/ash-1.3-to-1.4.sql
+          \i devel/sql/ash-1.4-to-1.5.sql
 
-          -- Assertions after reaching v1.4
+          -- Assertions after reaching v1.4 plus the current 1.5-dev delta.
           do $$
           declare
             v_cfg record;
@@ -3784,6 +3826,7 @@ jobs:
           $$;
 
           \i sql/ash-1.3-to-1.4.sql
+          \i devel/sql/ash-1.4-to-1.5.sql
 
           do $$
           begin
@@ -3791,7 +3834,7 @@ jobs:
               'version should be 1.4 after upgrade';
             assert (select missed_samples from ash.config where singleton) = 0,
               'missed_samples should be 0';
-            raise notice '1.3 -> 1.4 direct upgrade PASSED';
+            raise notice '1.3 -> 1.4 -> 1.5-dev direct upgrade PASSED';
           end;
           $$;
 
@@ -3815,14 +3858,15 @@ jobs:
           # REPLACE cannot change OUT params). The 1.0 bootstrap and the
           # 1.0-to-1.1 wrapper hit the same path. Those finalized legacy
           # scripts remain immutable and are still exercised end-to-end by
-          # the one-shot upgrade-chain tests above (fresh DB, 1.0 → 1.4).
+          # the one-shot upgrade-chain tests above (fresh DB, 1.0 → 1.5-dev).
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
-          \i sql/ash-install.sql
+          \i devel/sql/ash-install.sql
 
           -- Apply all upgrade scripts on top of fresh install (should be idempotent)
           \i sql/ash-1.1-to-1.2.sql
           \i sql/ash-1.2-to-1.3.sql
           \i sql/ash-1.3-to-1.4.sql
+          \i devel/sql/ash-1.4-to-1.5.sql
 
           do $$
           begin
@@ -3839,6 +3883,7 @@ jobs:
           \i sql/ash-1.1-to-1.2.sql
           \i sql/ash-1.2-to-1.3.sql
           \i sql/ash-1.3-to-1.4.sql
+          \i devel/sql/ash-1.4-to-1.5.sql
 
           do $$
           begin
@@ -3857,7 +3902,7 @@ jobs:
           select ash.uninstall('yes');
           EOF
 
-      - name: "Schema equivalence: fresh install vs full upgrade path"
+      - name: "Schema equivalence: fresh dev install vs full upgrade path"
         env:
           PGPASSWORD: postgres
         run: |
@@ -3910,7 +3955,7 @@ jobs:
           SNAPSQL
 
           # 1) Fresh install → snapshot
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f sql/ash-install.sql > /dev/null 2>&1
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f devel/sql/ash-install.sql > /dev/null 2>&1
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f /tmp/ash_schema_snapshot.sql > /tmp/fresh_schema.txt
           psql -h localhost -U postgres -d postgres -c "select ash.uninstall('yes')" > /dev/null 2>&1
 
@@ -3920,14 +3965,15 @@ jobs:
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f sql/ash-1.1-to-1.2.sql > /dev/null 2>&1
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f sql/ash-1.2-to-1.3.sql > /dev/null 2>&1
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f sql/ash-1.3-to-1.4.sql > /dev/null 2>&1
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f devel/sql/ash-1.4-to-1.5.sql > /dev/null 2>&1
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f /tmp/ash_schema_snapshot.sql > /tmp/upgraded_schema.txt
           psql -h localhost -U postgres -d postgres -c "select ash.uninstall('yes')" > /dev/null 2>&1
 
           # 3) Compare
           if diff -u /tmp/fresh_schema.txt /tmp/upgraded_schema.txt; then
-            echo "Schema equivalence test PASSED: fresh install and upgrade path produce identical schemas"
+            echo "Schema equivalence test PASSED: fresh dev install and upgrade path produce identical schemas"
           else
-            echo "::error::Schema equivalence test FAILED: fresh install and upgrade path differ (see diff above)"
+            echo "::error::Schema equivalence test FAILED: fresh dev install and upgrade path differ (see diff above)"
 
             # Issue #66: when constraints diverge, surface a clear, dedicated
             # error naming each affected constraint and both definitions, so
@@ -3985,7 +4031,7 @@ jobs:
           psql -h localhost -U postgres -d postgres -c "select ash.uninstall('yes')" 2>/dev/null || echo "ash.uninstall skipped (schema absent)"
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
             -c "drop extension if exists pg_stat_statements"
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f sql/ash-install.sql > /dev/null
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f devel/sql/ash-install.sql > /dev/null
 
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
 
@@ -4113,7 +4159,7 @@ jobs:
           # Use ON_ERROR_STOP so unrelated failures don't get silenced.
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
             -c "drop extension if exists pg_cron cascade"
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f sql/ash-install.sql > /dev/null
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f devel/sql/ash-install.sql > /dev/null
 
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
           do $$

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,17 +11,17 @@ SQL style guide: https://gitlab.com/postgres-ai/rules/-/blob/main/rules/developm
 CI via GitHub Actions:
 
 - **test.yml**: runs on push and PRs — tests across PostgreSQL 14, 15, 16, 17, 18
-- Tests: fresh install, full upgrade chain up to the in-progress release (currently 1.0→…→1.4), schema equivalence between fresh install and upgrade chain, idempotent re-apply of each legacy upgrade script, degraded mode (no pgss/pg_cron)
+- Tests: fresh development install, discovered full upgrade chain up to the in-progress release, schema equivalence between fresh install and upgrade chain, idempotent re-apply of discovered re-apply-safe upgrade scripts, degraded mode (no pgss/pg_cron)
 - Version schema: `vMAJOR.MINOR` (e.g. `v1.3`). Tag on main after all PRs merged.
 
-`ash-install.sql` is the source of truth. Upgrade scripts for the **in-progress** release (e.g. `ash-1.3-to-1.4.sql` while 1.4 is unreleased) must stay in lockstep with install.sql through the release cycle — any install.sql change that affects schema (new/modified function bodies, new columns, dropped objects) must be mirrored into the in-progress upgrade script. Schema-equivalence CI enforces this on every PR. **Finalized** legacy upgrade scripts (`ash-1.0-to-1.1.sql` through `ash-1.2-to-1.3.sql` today) are immutable: any signature-changing PR must avoid patterns that trip their idempotent re-apply, even if that means restructuring the fix (e.g. keeping an old function signature and using a new helper name instead of changing the return type).
+After a release tag, keep `sql/` frozen at the latest released baseline until the next release-stamp PR. Current development SQL lives under `devel/sql/`: the future final installer and the future upgrade script. CI must discover version chains from files via `devel/scripts/ash_sql_chain.py`, not hardcode concrete version numbers. At release stamp time, promote the development SQL into `sql/`, bump `ash.config.version`, and remove or recreate `devel/sql/` for the next cycle. See `docs/RELEASE_PROCESS.md`.
 
 ## Testing
 
 Red/green TDD: write failing tests first, then fix the code to make them pass.
 
 - **Bug fixes**: always write a test that reproduces the bug (RED), then fix (GREEN). This proves the fix works and prevents regressions.
-- **New features**: write tests for the expected behavior before or alongside the implementation. Run tests locally with `sudo -u postgres psql -v ON_ERROR_STOP=1 -f sql/ash-install.sql` and DO blocks with assertions.
+- **New features**: write tests for the expected behavior before or alongside the implementation. Run current development tests locally with `sudo -u postgres psql -v ON_ERROR_STOP=1 -f devel/sql/ash-install.sql` and DO blocks with assertions.
 - **CI tests** live in `.github/workflows/test.yml`. Each test section uses PL/pgSQL `DO $$ ... assert ... $$` blocks. Assert exact values, not just row existence — a test that only checks "row exists" can't distinguish correct aggregation from garbage.
 - **Test locally on available PG version** before pushing. CI covers PG 14–18.
 

--- a/devel/scripts/ash_sql_chain.py
+++ b/devel/scripts/ash_sql_chain.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Discover pg_ash SQL install and upgrade chains for CI."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SQL_DIRS = (ROOT / "sql", ROOT / "devel" / "sql")
+INSTALL_RE = re.compile(r"ash-(\d+)\.(\d+)\.sql$")
+UPGRADE_RE = re.compile(r"ash-(\d+\.\d+)-to-(\d+\.\d+)\.sql$")
+
+
+def version_key(version: str) -> tuple[int, int]:
+    major, minor = version.split(".", 1)
+    return int(major), int(minor)
+
+
+def rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def installers() -> dict[str, Path]:
+    found: dict[str, Path] = {}
+    for path in (ROOT / "sql").glob("ash-*.sql"):
+        match = INSTALL_RE.fullmatch(path.name)
+        if match:
+            version = f"{match.group(1)}.{match.group(2)}"
+            found[version] = path
+    if not found:
+        raise SystemExit("no released ash-X.Y.sql installer found")
+    return found
+
+
+def upgrades(
+    *, include_devel: bool = True, required: bool = True
+) -> dict[str, tuple[str, Path]]:
+    found: dict[str, tuple[str, Path]] = {}
+    directories = SQL_DIRS if include_devel else (ROOT / "sql",)
+    for directory in directories:
+        if not directory.exists():
+            continue
+        for path in directory.glob("ash-*-to-*.sql"):
+            match = UPGRADE_RE.fullmatch(path.name)
+            if not match:
+                continue
+            src, dst = match.group(1), match.group(2)
+            if src in found:
+                prev = rel(found[src][1])
+                raise SystemExit(f"duplicate upgrade from {src}: {prev}, {rel(path)}")
+            found[src] = (dst, path)
+    if required and not found:
+        raise SystemExit("no ash-X.Y-to-A.B.sql upgrade scripts found")
+    return found
+
+
+def oldest_version() -> str:
+    return min(installers(), key=version_key)
+
+
+def second_oldest_version() -> str:
+    versions = sorted(installers(), key=version_key)
+    if len(versions) < 2:
+        raise SystemExit("need at least two released installers")
+    return versions[1]
+
+
+def latest_released_version() -> str:
+    versions = set(installers())
+    for src, (dst, _path) in upgrades(include_devel=False, required=False).items():
+        versions.add(src)
+        versions.add(dst)
+    return max(versions, key=version_key)
+
+
+def fresh_install_path() -> str:
+    dev_install = ROOT / "devel" / "sql" / "ash-install.sql"
+    if dev_install.exists():
+        return rel(dev_install)
+    return rel(ROOT / "sql" / "ash-install.sql")
+
+
+def emit_psql_include(path: Path) -> None:
+    print(rf"\i {rel(path)}")
+
+
+def emit_upgrade_chain(start: str) -> None:
+    current = start
+    seen: set[str] = set()
+    by_source = upgrades()
+    while current in by_source:
+        if current in seen:
+            raise SystemExit(f"cycle in upgrade chain at {current}")
+        seen.add(current)
+        nxt, path = by_source[current]
+        emit_psql_include(path)
+        current = nxt
+
+
+def emit_full_upgrade_chain(start: str) -> None:
+    install = installers().get(start)
+    if install is None:
+        raise SystemExit(f"no released installer for {start}")
+    emit_psql_include(install)
+    emit_upgrade_chain(start)
+
+
+def emit_reapply_chain() -> None:
+    by_source = upgrades()
+    current = second_oldest_version()
+    seen: set[str] = set()
+    while current in by_source:
+        if current in seen:
+            raise SystemExit(f"cycle in reapply chain at {current}")
+        seen.add(current)
+        nxt, path = by_source[current]
+        emit_psql_include(path)
+        current = nxt
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("fresh-install-path")
+    sub.add_parser("oldest-install-path")
+    sub.add_parser("second-oldest-install-path")
+    sub.add_parser("latest-released-version")
+    sub.add_parser("upgrade-chain-from-oldest")
+    sub.add_parser("upgrade-chain-from-second-oldest")
+    sub.add_parser("full-upgrade-chain")
+    sub.add_parser("reapply-chain")
+    args = parser.parse_args()
+
+    if args.command == "fresh-install-path":
+        print(fresh_install_path())
+    elif args.command == "oldest-install-path":
+        print(rel(installers()[oldest_version()]))
+    elif args.command == "second-oldest-install-path":
+        print(rel(installers()[second_oldest_version()]))
+    elif args.command == "latest-released-version":
+        print(latest_released_version())
+    elif args.command == "upgrade-chain-from-oldest":
+        emit_upgrade_chain(oldest_version())
+    elif args.command == "upgrade-chain-from-second-oldest":
+        emit_upgrade_chain(second_oldest_version())
+    elif args.command == "full-upgrade-chain":
+        emit_full_upgrade_chain(oldest_version())
+    elif args.command == "reapply-chain":
+        emit_reapply_chain()
+
+
+if __name__ == "__main__":
+    main()

--- a/devel/sql/ash-1.4-to-1.5.sql
+++ b/devel/sql/ash-1.4-to-1.5.sql
@@ -1,0 +1,71 @@
+-- pg_ash development upgrade from 1.4 toward 1.5.
+--
+-- WIP: do not bump ash.config.version here. The version is finalized when
+-- 1.5 is stamped and this delta is folded into ash-install.sql.
+
+create or replace function ash._register_wait(p_state text, p_type text, p_event text)
+returns smallint
+language plpgsql
+set search_path = pg_catalog, ash
+as $$
+declare
+  v_id     smallint;
+  v_at_cap boolean;
+begin
+  -- Try to get existing
+  select id into v_id
+  from ash.wait_event_map
+  where state = p_state and type = p_type and event = p_event;
+
+  if v_id is not null then
+    return v_id;
+  end if;
+
+  -- Enforce dictionary size cap before inserting. 32 000 stays well below
+  -- smallint's 32 767 ceiling while still leaving room for genuine event
+  -- diversity (real wait-event inventories measure in the hundreds).
+  -- Use an exact existence probe for the 32 000th row instead of
+  -- pg_class.reltuples: reltuples can be -1 or stale immediately after
+  -- TRUNCATE/restore, which bypasses a hard cap until ANALYZE catches up.
+  select exists (
+    select 1 from ash.wait_event_map offset 31999 limit 1
+  ) into v_at_cap;
+
+  if v_at_cap then
+    -- Bump the cap-hit counter so ash.status() can surface the drop.
+    -- Note: counts *registration drops* here — not the number of sampled
+    -- backends observed for this (state,type,event). Many concurrent
+    -- backends blocked on the same dropped event only bump it once per tick.
+    -- Wrap in an inner block: if the UPDATE itself fails (e.g. config row
+    -- missing mid-uninstall), we still want the outer WARNING to fire and
+    -- the function to return NULL without aborting take_sample().
+    begin
+      update ash.config set register_wait_cap_hits = register_wait_cap_hits + 1
+        where singleton;
+    exception when others then
+      null;  -- counter bump is best-effort
+    end;
+    raise warning 'ash._register_wait: wait_event_map at cap (>= 32 000 rows); skipping (state=%, type=%, event=%) — see ash.status()',
+      p_state, p_type, p_event;
+    return null;  -- caller PERFORMs this; snapshot JOIN drops the session
+  end if;
+
+  -- Insert new entry
+  insert into ash.wait_event_map (state, type, event)
+  values (p_state, p_type, p_event)
+  on conflict (state, type, event) do nothing
+  returning id into v_id;
+
+  -- If insert succeeded, return it
+  if v_id is not null then
+    return v_id;
+  end if;
+
+  -- Race condition: another session inserted, fetch it
+  select id into v_id
+  from ash.wait_event_map
+  where state = p_state and type = p_type and event = p_event;
+
+  return v_id;
+end;
+$$;

--- a/devel/sql/ash-install.sql
+++ b/devel/sql/ash-install.sql
@@ -1,10 +1,8 @@
 -- pg_ash: Active Session History for Postgres
--- Version: 1.4 (latest)
--- Fresh install: \i sql/ash-install.sql
--- Upgrade from 1.0: \i sql/ash-1.0-to-1.1.sql, then \i sql/ash-1.1-to-1.2.sql, then \i sql/ash-1.2-to-1.3.sql, then \i sql/ash-1.3-to-1.4.sql
--- Upgrade from 1.1: \i sql/ash-1.1-to-1.2.sql, then \i sql/ash-1.2-to-1.3.sql, then \i sql/ash-1.3-to-1.4.sql
--- Upgrade from 1.2: \i sql/ash-1.2-to-1.3.sql, then \i sql/ash-1.3-to-1.4.sql
--- Upgrade from 1.3: \i sql/ash-1.3-to-1.4.sql
+-- Development installer for the next release after v1.4.
+-- This file is promoted to sql/ash-install.sql during the release-stamp PR.
+-- Fresh development install: \i devel/sql/ash-install.sql
+-- Upgrade from v1.4 in development: \i devel/sql/ash-1.4-to-1.5.sql
 
 
 -- Drop functions removed or changed in 1.1 (handled by DO block below)
@@ -390,8 +388,8 @@ language plpgsql
 set search_path = pg_catalog, ash
 as $$
 declare
-  v_id    smallint;
-  v_count bigint;
+  v_id     smallint;
+  v_at_cap boolean;
 begin
   -- Try to get existing
   select id into v_id
@@ -405,12 +403,14 @@ begin
   -- Enforce dictionary size cap before inserting. 32 000 stays well below
   -- smallint's 32 767 ceiling while still leaving room for genuine event
   -- diversity (real wait-event inventories measure in the hundreds).
-  -- reltuples is a cheap estimate; an exact count would add a scan on
-  -- every fresh wait-event observation on the sampler's hot path.
-  select reltuples::bigint into v_count
-  from pg_class where oid = 'ash.wait_event_map'::regclass;
+  -- Use an exact existence probe for the 32 000th row instead of
+  -- pg_class.reltuples: reltuples can be -1 or stale immediately after
+  -- TRUNCATE/restore, which bypasses a hard cap until ANALYZE catches up.
+  select exists (
+    select 1 from ash.wait_event_map offset 31999 limit 1
+  ) into v_at_cap;
 
-  if v_count >= 32000 then
+  if v_at_cap then
     -- Bump the cap-hit counter so ash.status() can surface the drop.
     -- Note: counts *registration drops* here — not the number of sampled
     -- backends observed for this (state,type,event). Many concurrent

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,0 +1,48 @@
+# pg_ash development and release SQL process
+
+## Between releases
+
+After a release tag, `sql/` is frozen at the latest released baseline.
+
+For the 1.5 cycle, the files currently resolve to:
+
+- `sql/ash-install.sql` remains the exact v1.4 installer.
+- `sql/ash-1.3-to-1.4.sql` and older upgrade scripts are finalized legacy scripts.
+- `devel/sql/ash-install.sql` is the in-progress future final installer.
+- `devel/sql/ash-1.4-to-1.5.sql` is the in-progress future upgrade script.
+
+All post-v1.4 SQL changes must be made in `devel/sql/`, not in released
+files under `sql/`.
+
+CI must not hardcode concrete version chains. It uses
+`devel/scripts/ash_sql_chain.py` to discover released installers, released
+upgrade scripts, and in-progress `devel/sql/` upgrade scripts from the files
+present in the checkout.
+
+CI must test both supported development paths discovered by that helper:
+
+- fresh development install: the helper's `fresh-install-path`
+- upgrade path: the helper's `full-upgrade-chain`
+
+Schema-equivalence CI must compare those two paths.
+
+## Release stamp
+
+Right before tagging 1.5, use a release-stamp PR to promote the development
+SQL into released core SQL:
+
+1. Replace `sql/ash-install.sql` with `devel/sql/ash-install.sql`.
+2. Move `devel/sql/ash-1.4-to-1.5.sql` to `sql/ash-1.4-to-1.5.sql`.
+3. Bump `ash.config.version` and top-of-file version comments to `1.5`.
+4. Update release notes and README install/upgrade instructions.
+5. Leave CI on discovery-based helpers; remove only obsolete `devel/sql/`
+   references if the helper no longer emits them after promotion.
+6. Run the full release gate before tagging.
+
+After the tag, create a new `devel/sql/` area for the next development cycle.
+
+## Legacy upgrade scripts
+
+Finalized upgrade scripts are immutable. Do not rewrite `sql/ash-1.0-to-1.1.sql`
+through the latest tagged upgrade script except for an explicit emergency
+backport/re-release decision.


### PR DESCRIPTION
## Summary
- keep released core SQL under `sql/` frozen at v1.4 until the 1.5 release-stamp PR
- stage the future 1.5 final installer as `devel/sql/ash-install.sql`
- stage the future 1.4 -> 1.5 upgrade script as `devel/sql/ash-1.4-to-1.5.sql`
- keep the #90 `_register_wait()` fix in `devel/sql/`, not released `sql/`
- make CI discover install/upgrade chains from files via `devel/scripts/ash_sql_chain.py` instead of hardcoding version numbers
- document the process in `docs/RELEASE_PROCESS.md` and link it from `CLAUDE.md`

## Development/release process now documented
- Between releases: all post-tag SQL changes go to `devel/sql/`.
- `sql/` remains the latest tagged release baseline.
- CI discovers released installers, released upgrade scripts, and in-progress devel upgrade scripts from the checkout.
- Right before tagging 1.5: promote `devel/sql/ash-install.sql` to `sql/ash-install.sql`, move `devel/sql/ash-1.4-to-1.5.sql` to `sql/ash-1.4-to-1.5.sql`, bump version, update docs/release notes, and run the full release gate.

## Red/green TDD
- Red: `a38d926` makes CI require `devel/sql/ash-install.sql` and `devel/sql/ash-1.4-to-1.5.sql`; those files are absent in that commit.
- Green: `69552ab` adds the devel SQL files, discovery helper, and release-process docs, while keeping `sql/ash-install.sql` frozen at v1.4.

## Local verification
- `git diff v1.4 -- sql/ash-install.sql` is empty: released installer is back to the tag baseline.
- Red commit lacks both devel SQL files: `git cat-file -e HEAD~1:devel/sql/ash-install.sql` fails, same for `devel/sql/ash-1.4-to-1.5.sql`.
- `python3 -m py_compile devel/scripts/ash_sql_chain.py` passes.
- `python3 devel/scripts/ash_sql_chain.py latest-released-version` returns `1.4` by discovering released upgrade targets from `sql/`.
- Generated full chain from file discovery: `sql/ash-1.0.sql`, released upgrade scripts, then `devel/sql/ash-1.4-to-1.5.sql`.
- Generated full chain executes locally and ends with `auto-full-upgrade-chain=PASS`.
- Fresh development install passes #90: `psql -f devel/sql/ash-install.sql` + wait_event_map cap regression => PASS.
- Explicit upgrade passes #90: `psql -f sql/ash-install.sql`; `psql -f devel/sql/ash-1.4-to-1.5.sql`; wait_event_map cap regression => PASS.
- CI has no hardcoded psql include chains and no hardcoded `version = '1.4'` assertions; version assertions use the helper-discovered latest released version.
- `git diff --check HEAD~2..HEAD` clean.