### PR TITLE
Bug: harden pg_stat_statements reader resolution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4181,6 +4181,7 @@ jobs:
           do $$
           declare
             v_count int;
+            v_text_count int;
             v_cpu_id smallint;
             v_q1 int4;
             v_now_ts int4;
@@ -4217,6 +4218,30 @@ jobs:
             perform ash.status();
             perform ash.set_debug_logging();
 
+            -- A user-created public.pg_stat_statements relation must not be
+            -- trusted when the real extension is absent (#87). It must not
+            -- duplicate ASH rows or supply spoofed query_text.
+            create table public.pg_stat_statements (
+              queryid bigint,
+              query text,
+              calls bigint,
+              total_exec_time double precision,
+              mean_exec_time double precision,
+              dbid oid
+            );
+
+            insert into public.pg_stat_statements values
+              (999999, 'select same from user_a', 10, 100.0, 10.0, 1::oid),
+              (999999, 'select same from user_b', 20, 400.0, 20.0, 2::oid);
+
+            select count(*), count(query_text)
+            into v_count, v_text_count
+            from ash.top_queries('1 hour', 10)
+            where query_id = 999999;
+            assert v_count = 1 and v_text_count = 0,
+              format('top_queries must ignore spoofed pg_stat_statements, got rows=%s text_rows=%s',
+                     v_count, v_text_count);
+
             -- Functions that should ERROR without pgss:
             begin
               perform ash.top_queries_with_text('1 hour');
@@ -4241,6 +4266,8 @@ jobs:
               assert SQLERRM like '%pg_stat_statements%',
                 'event_queries_at error should mention pg_stat_statements, got: ' || SQLERRM;
             end;
+
+            drop table public.pg_stat_statements;
 
             raise notice 'All degraded-mode (no pgss) tests PASSED';
           end;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@ Work in progress after v1.4.
 - **`wait_event_map` cap enforcement fixed.** `_register_wait()` now checks the exact 32 000th dictionary row instead of trusting stale `pg_class.reltuples`, so the hard cap fires immediately after `TRUNCATE` / restore and increments `register_wait_cap_hits` as documented. (issue #90; [PR #92](https://github.com/NikolayS/pg_ash/pull/92))
 - **Raw samples are protected during rollup/rotation races.** `rollup_minute()` no longer advances its watermark while a sampler is in flight, and `rotate()` refuses to truncate an endangered raw partition unless pre-truncation rollup succeeds and covers the raw groups in that slot. (issue #81; [PR #86](https://github.com/NikolayS/pg_ash/pull/86))
 - **Raw readers honor rebuilt partition retention.** `_active_slots_for()` and `_active_slots_for_at()` now enumerate every retained raw slot after `rebuild_partitions(N, 'yes')` instead of only current plus previous slot. (issue #83; [PR #85](https://github.com/NikolayS/pg_ash/pull/85))
+- **pg_stat_statements readers ignore spoofed relations and avoid duplicate top-query rows.** pgss-aware readers now require the real `pg_stat_statements` extension before reading query text/metrics, and `top_queries*` aggregates pgss rows by `queryid` so one ASH query cannot fan out into multiple rows. (issue #87)
 
 ---
 

--- a/devel/sql/ash-install.sql
+++ b/devel/sql/ash-install.sql
@@ -3056,13 +3056,17 @@ as $$
 declare
   v_has_pgss boolean := false;
 begin
-  -- Probe the view directly — extension installed <> shared library loaded
-  begin
-    perform 1 from pg_stat_statements limit 1;
-    v_has_pgss := true;
-  exception when others then
-    v_has_pgss := false;
-  end;
+  -- Trust pg_stat_statements only when the real extension is installed.
+  -- Otherwise a user-created public.pg_stat_statements relation could spoof
+  -- query text and execution metrics (#87).
+  if ash._pgss_schema() is not null then
+    begin
+      perform 1 from pg_stat_statements limit 1;
+      v_has_pgss := true;
+    exception when others then
+      v_has_pgss := false;
+    end;
+  end if;
 
   if v_has_pgss then
     return query
@@ -3084,6 +3088,13 @@ begin
     ),
     grand_total as (
       select sum(cnt) as total from resolved
+    ),
+    pgss as (
+      select
+        p.queryid,
+        min(p.query) as query
+      from pg_stat_statements p
+      group by p.queryid
     )
     select
       r.query_id,
@@ -3092,7 +3103,7 @@ begin
       left(pss.query, 100) as query_text
     from resolved r
     cross join grand_total gt
-    left join pg_stat_statements pss on pss.queryid = r.query_id
+    left join pgss pss on pss.queryid = r.query_id
     order by r.cnt desc
     limit p_limit;
   else
@@ -3205,13 +3216,17 @@ as $$
 declare
   v_has_pgss boolean := false;
 begin
-  -- Probe the view directly — extension installed <> shared library loaded
-  begin
-    perform 1 from pg_stat_statements limit 1;
-    v_has_pgss := true;
-  exception when others then
-    v_has_pgss := false;
-  end;
+  -- Trust pg_stat_statements only when the real extension is installed.
+  -- Otherwise a user-created public.pg_stat_statements relation could spoof
+  -- query text and execution metrics (#87).
+  if ash._pgss_schema() is not null then
+    begin
+      perform 1 from pg_stat_statements limit 1;
+      v_has_pgss := true;
+    exception when others then
+      v_has_pgss := false;
+    end;
+  end if;
 
   if v_has_pgss then
     return query
@@ -3233,6 +3248,19 @@ begin
     ),
     grand_total as (
       select sum(cnt) as total from resolved
+    ),
+    pgss as (
+      select
+        p.queryid,
+        sum(p.calls)::bigint as calls,
+        sum(p.total_exec_time) as total_exec_time,
+        case
+          when sum(p.calls) > 0 then sum(p.total_exec_time) / sum(p.calls)
+          else max(p.mean_exec_time)
+        end as mean_exec_time,
+        min(p.query) as query
+      from pg_stat_statements p
+      group by p.queryid
     )
     select
       r.query_id,
@@ -3244,7 +3272,7 @@ begin
       left(pss.query, 200) as query_text
     from resolved r
     cross join grand_total gt
-    left join pg_stat_statements pss on pss.queryid = r.query_id
+    left join pgss pss on pss.queryid = r.query_id
     order by r.cnt desc
     limit p_limit;
   else
@@ -3535,13 +3563,17 @@ declare
   v_start int4 := ash.ts_from_timestamptz(p_start);
   v_end int4 := ash.ts_from_timestamptz(p_end);
 begin
-  -- Probe the view directly — extension installed <> shared library loaded
-  begin
-    perform 1 from pg_stat_statements limit 1;
-    v_has_pgss := true;
-  exception when others then
-    v_has_pgss := false;
-  end;
+  -- Trust pg_stat_statements only when the real extension is installed.
+  -- Otherwise a user-created public.pg_stat_statements relation could spoof
+  -- query text and execution metrics (#87).
+  if ash._pgss_schema() is not null then
+    begin
+      perform 1 from pg_stat_statements limit 1;
+      v_has_pgss := true;
+    exception when others then
+      v_has_pgss := false;
+    end;
+  end if;
 
   if v_has_pgss then
     return query
@@ -3561,12 +3593,19 @@ begin
     ),
     grand_total as (
       select sum(cnt) as total from resolved
+    ),
+    pgss as (
+      select
+        p.queryid,
+        min(p.query) as query
+      from pg_stat_statements p
+      group by p.queryid
     )
     select r.query_id, r.cnt, round(r.cnt::numeric / gt.total * 100, 2),
        left(pss.query, 100)
     from resolved r
     cross join grand_total gt
-    left join pg_stat_statements pss on pss.queryid = r.query_id
+    left join pgss pss on pss.queryid = r.query_id
     order by r.cnt desc limit p_limit;
   else
     raise warning 'pg_stat_statements is not installed — query_text will be NULL. Run: CREATE EXTENSION pg_stat_statements;';
@@ -4364,12 +4403,14 @@ declare
 begin
   v_min_ts := greatest(least(extract(epoch from now() - p_interval - ash.epoch()), 2147483647), 0)::int4;
 
-  begin
-    perform 1 from pg_stat_statements limit 1;
-    v_has_pgss := true;
-  exception when others then
-    v_has_pgss := false;
-  end;
+  if ash._pgss_schema() is not null then
+    begin
+      perform 1 from pg_stat_statements limit 1;
+      v_has_pgss := true;
+    exception when others then
+      v_has_pgss := false;
+    end;
+  end if;
 
   if v_has_pgss then
     return query
@@ -4475,12 +4516,14 @@ begin
   -- the time predicate folds to false on absurd ranges (#69).
   v_slots := ash._active_slots_for_at(p_start, p_end);
 
-  begin
-    perform 1 from pg_stat_statements limit 1;
-    v_has_pgss := true;
-  exception when others then
-    v_has_pgss := false;
-  end;
+  if ash._pgss_schema() is not null then
+    begin
+      perform 1 from pg_stat_statements limit 1;
+      v_has_pgss := true;
+    exception when others then
+      v_has_pgss := false;
+    end;
+  end if;
 
   if v_has_pgss then
     return query
@@ -4626,12 +4669,14 @@ declare
 begin
   v_min_ts := greatest(least(extract(epoch from now() - p_interval - ash.epoch()), 2147483647), 0)::int4;
 
-  begin
-    perform 1 from pg_stat_statements limit 1;
-    v_has_pgss := true;
-  exception when others then
-    v_has_pgss := false;
-  end;
+  if ash._pgss_schema() is not null then
+    begin
+      perform 1 from pg_stat_statements limit 1;
+      v_has_pgss := true;
+    exception when others then
+      v_has_pgss := false;
+    end;
+  end if;
 
   if v_has_pgss then
     return query
@@ -4735,12 +4780,14 @@ declare
   -- the time predicate folds to false on absurd ranges (#69).
   v_slots smallint[] := ash._active_slots_for_at(p_start, p_end);
 begin
-  begin
-    perform 1 from pg_stat_statements limit 1;
-    v_has_pgss := true;
-  exception when others then
-    v_has_pgss := false;
-  end;
+  if ash._pgss_schema() is not null then
+    begin
+      perform 1 from pg_stat_statements limit 1;
+      v_has_pgss := true;
+    exception when others then
+      v_has_pgss := false;
+    end;
+  end if;
 
   if v_has_pgss then
     return query


### PR DESCRIPTION
## Summary

Fixes issue #87.

- pgss-aware readers now trust `pg_stat_statements` only when the real extension is installed; a user-created `public.pg_stat_statements` relation is ignored.
- `top_queries()`, `top_queries_at()`, and `top_queries_with_text()` aggregate pgss rows by `queryid` before joining, so one ASH query row cannot fan out into multiple rows when pgss has multiple entries for the same `queryid`.
- `sql/` stays frozen; the code change is in `devel/sql/ash-install.sql` for the 1.5 development line.

## Red / Green TDD

- Red commit: `7de6a2c` (`test: reproduce pgss reader spoofing`)
  - Fresh no-pgss install creates a spoofed `public.pg_stat_statements` table with two rows for the same queryid.
  - Exact red proof on PG18: `red87=FAILS_AS_EXPECTED rc=3`, failing with `top_queries must ignore spoofed pg_stat_statements, got rows=2 text_rows=2`.
- Green commit: `2a27c41` (`fix: harden pgss reader resolution`)
  - Requires real extension metadata before reading pgss query text/metrics.
  - Aggregates pgss rows by `queryid` for top-query readers.

## Local verification

- `workflow-yaml=PASS`
- `python3 -m py_compile devel/scripts/ash_sql_chain.py`
- `git diff --check HEAD~2..HEAD`
- `git diff origin/main -- sql/ash-install.sql` is empty.
- Fresh devel install proof: `green87=PASS sha=2a27c41`.
- Full auto-discovered upgrade proof: `full-upgrade87=PASS`.