### PR TITLE
Bug: compute daily avg backends from backend seconds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3256,6 +3256,10 @@ jobs:
           do $$
           declare
             v_count int;
+            v_peak int;
+            v_avg numeric;
+            v_wait_id smallint;
+            v_day_start timestamptz;
           begin
             -- === Reader functions exist ===
             assert exists (select from pg_proc
@@ -3298,6 +3302,41 @@ jobs:
             select count(*) into v_count
             from ash.daily_peak_backends_at(now() - interval '7 days', now());
             assert v_count >= 0, 'daily_peak_backends_at should not error';
+
+            -- avg_backends should be average active backends from backend-seconds
+            -- over samples, not the average of hourly peak_backends (#88).
+            truncate ash.rollup_1h;
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_wait_id;
+            v_day_start := date_trunc('day', now());
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            )
+            values
+              (
+                ash.ts_from_timestamptz(v_day_start),
+                0::oid,
+                60::smallint,
+                100::smallint,
+                array[v_wait_id, 60]::int4[],
+                '{}'::int8[]
+              ),
+              (
+                ash.ts_from_timestamptz(v_day_start + interval '1 hour'),
+                0::oid,
+                60::smallint,
+                100::smallint,
+                array[v_wait_id, 60]::int4[],
+                '{}'::int8[]
+              );
+
+            select peak_backends, avg_backends
+            into v_peak, v_avg
+            from ash.daily_peak_backends_at(v_day_start, v_day_start + interval '2 hours');
+            assert v_peak = 100,
+              format('daily peak should remain max peak_backends=100, got %s', v_peak);
+            assert v_avg = 1.0,
+              format('daily avg_backends should be backend-seconds/samples=1.0, got %s', v_avg);
 
             -- === Future range: no data ===
             select count(*) into v_count

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,7 @@ Work in progress after v1.4.
 - **Raw samples are protected during rollup/rotation races.** `rollup_minute()` no longer advances its watermark while a sampler is in flight, and `rotate()` refuses to truncate an endangered raw partition unless pre-truncation rollup succeeds and covers the raw groups in that slot. (issue #81; [PR #86](https://github.com/NikolayS/pg_ash/pull/86))
 - **Raw readers honor rebuilt partition retention.** `_active_slots_for()` and `_active_slots_for_at()` now enumerate every retained raw slot after `rebuild_partitions(N, 'yes')` instead of only current plus previous slot. (issue #83; [PR #85](https://github.com/NikolayS/pg_ash/pull/85))
 - **pg_stat_statements readers ignore spoofed relations and avoid duplicate top-query rows.** pgss-aware readers now require the real `pg_stat_statements` extension before reading query text/metrics, and `top_queries*` aggregates pgss rows by `queryid` so one ASH query cannot fan out into multiple rows. (issue #87)
+- **`daily_peak_backends.avg_backends` now reports average active backends.** The value is derived from hourly backend-seconds divided by sample count instead of averaging hourly peak values. (issue #88)
 
 ---
 

--- a/devel/sql/ash-install.sql
+++ b/devel/sql/ash-install.sql
@@ -2788,14 +2788,26 @@ begin
   v_end_ts := ash.ts_from_timestamptz(p_end);
 
   return query
+  with hourly as (
+    select
+      (ash.ts_to_timestamptz(r.ts))::date as d,
+      r.peak_backends,
+      r.samples,
+      coalesce((
+        select sum(u.val)::bigint
+        from unnest(r.wait_counts) with ordinality as u(val, ord)
+        where u.ord % 2 = 0
+      ), 0) as backend_seconds
+    from ash.rollup_1h r
+    where r.ts >= v_start_ts and r.ts < v_end_ts
+  )
   select
-    (ash.ts_to_timestamptz(r.ts))::date as d,
-    max(r.peak_backends)::int,
-    round(avg(r.peak_backends), 1)
-  from ash.rollup_1h r
-  where r.ts >= v_start_ts and r.ts < v_end_ts
-  group by d
-  order by d;
+    h.d,
+    max(h.peak_backends)::int,
+    round(sum(h.backend_seconds)::numeric / nullif(sum(h.samples), 0), 1)
+  from hourly h
+  group by h.d
+  order by h.d;
 end;
 $$;
 


### PR DESCRIPTION
## Summary

Fixes issue #88.

`daily_peak_backends_at()` now computes `avg_backends` from hourly backend-seconds divided by sample count instead of averaging hourly `peak_backends` values. `peak_backends` still reports the max hourly peak.

Development-release layout is respected:
- `sql/` stays frozen.
- The code change is in `devel/sql/ash-install.sql` for the 1.5 development line.

## Red / Green TDD

- Red commit: `dd4134d` (`test: reproduce daily avg backend inflation`)
  - Seeds two hourly rollups with `samples=60`, `peak_backends=100`, and only 60 backend-seconds each.
  - Exact red proof on PG18: `red88=FAILS_AS_EXPECTED rc=3`, failing with `daily avg_backends should be 1.0, got 100.0`.
- Green commit: `7a808f7` (`fix: compute daily average from backend seconds`)
  - Computes daily average as `sum(wait_counts backend-seconds) / sum(samples)`.

## Local verification

- `workflow-yaml=PASS`
- `python3 -m py_compile devel/scripts/ash_sql_chain.py`
- `git diff --check HEAD~2..HEAD`
- `git diff origin/main -- sql/ash-install.sql` is empty.
- Fresh devel install proof: `green88=PASS sha=7a808f7`.
- Full auto-discovered upgrade proof: `full-upgrade88=PASS`.