### PR TITLE
Bug: fix reader validation edge cases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2298,6 +2298,115 @@ jobs:
           $$;
           EOF
 
+      - name: "Test v1.5: reader and input validation edge cases (#91)"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          begin;
+
+          do $$
+          declare
+            v_data int4[];
+            v_count int;
+            v_state text;
+            v_msg text;
+            v_start record;
+          begin
+            -- top_waits(p_limit => 10) means a hard output row limit: 9
+            -- individual waits plus Other when lower-ranked waits exist.
+            truncate ash.sample;
+
+            with waits as (
+              select
+                i,
+                ash._register_wait('active', 'WaitType', 'WaitEvent' || i)::int as wait_id
+              from generate_series(1, 12) as gs(i)
+            )
+            select array_agg(x order by ord)::int4[]
+            into v_data
+            from waits
+            cross join lateral (
+              values
+                (i * 3 - 2, -wait_id),
+                (i * 3 - 1, 1),
+                (i * 3, 0)
+            ) as encoded(ord, x);
+
+            insert into ash.sample(sample_ts, datid, active_count, data, slot)
+            values (
+              ash.ts_from_timestamptz(now()),
+              0::oid,
+              12::smallint,
+              v_data,
+              ash.current_slot()
+            );
+
+            select count(*) into v_count from ash.top_waits('1 hour', 10, 10);
+            assert v_count = 10,
+              format('top_waits(p_limit=10) must return at most 10 rows, got %s', v_count);
+            assert exists (
+              select 1 from ash.top_waits('1 hour', 10, 10) where wait_event = 'Other'
+            ), 'top_waits(p_limit=10) must include Other when lower-ranked waits exist';
+
+            -- Zero buckets should fail with explicit validation, not raw
+            -- division-by-zero.
+            begin
+              perform * from ash.wait_timeline('1 hour', '0 seconds');
+              raise exception 'wait_timeline accepted zero bucket';
+            exception when others then
+              v_state := sqlstate;
+              v_msg := sqlerrm;
+            end;
+            assert v_state <> '22012' and v_msg ilike '%bucket%',
+              format('wait_timeline zero bucket must raise explicit bucket validation, got [%s] %s', v_state, v_msg);
+
+            begin
+              perform * from ash.timeline_chart('1 hour', '0 seconds', 4, 20);
+              raise exception 'timeline_chart accepted zero bucket';
+            exception when others then
+              v_state := sqlstate;
+              v_msg := sqlerrm;
+            end;
+            assert v_state <> '22012' and v_msg ilike '%bucket%',
+              format('timeline_chart zero bucket must raise explicit bucket validation, got [%s] %s', v_state, v_msg);
+
+            -- NULL interval should be handled at function level before
+            -- touching ash.config.sample_interval.
+            begin
+              select * into v_start from ash.start(null::interval);
+            exception when others then
+              raise exception 'ash.start(NULL) must return a clear error row, got [%] %',
+                sqlstate, sqlerrm;
+            end;
+            assert v_start.job_type = 'error',
+              format('ash.start(NULL) must return job_type=error, got %s', v_start.job_type);
+            assert v_start.status ilike '%null%',
+              format('ash.start(NULL) must mention NULL in status, got %s', v_start.status);
+          end $$;
+
+          rollback;
+
+          do $$
+          begin
+            if not exists (select from pg_roles where rolname = 'ash_reader_probe') then
+              create role ash_reader_probe login password 'probe';
+            end if;
+          end;
+          $$;
+
+          select ash.grant_reader('ash_reader_probe');
+
+          do $$
+          begin
+            assert not has_function_privilege(
+              'ash_reader_probe',
+              'ash._register_wait(text,text,text)',
+              'EXECUTE'
+            ), 'grant_reader must not grant EXECUTE on internal mutating helper ash._register_wait';
+          end $$;
+          EOF
+
       - name: "Release-gate fixes: negative interval, p_width clamp, decode_sample size cap"
         env:
           PGPASSWORD: postgres

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@ Work in progress after v1.4.
 - **Raw readers honor rebuilt partition retention.** `_active_slots_for()` and `_active_slots_for_at()` now enumerate every retained raw slot after `rebuild_partitions(N, 'yes')` instead of only current plus previous slot. (issue #83; [PR #85](https://github.com/NikolayS/pg_ash/pull/85))
 - **pg_stat_statements readers ignore spoofed relations and avoid duplicate top-query rows.** pgss-aware readers now require the real `pg_stat_statements` extension before reading query text/metrics, and `top_queries*` aggregates pgss rows by `queryid` so one ASH query cannot fan out into multiple rows. (issue #87)
 - **`daily_peak_backends.avg_backends` now reports average active backends.** The value is derived from hourly backend-seconds divided by sample count instead of averaging hourly peak values. (issue #88)
+- **Reader and input-validation edge cases fixed.** `top_waits()` now treats `p_limit` as a hard output row limit including `Other`, zero timeline buckets raise explicit validation errors, `ash.start(NULL)` returns a clear error row, and `ash.grant_reader()` no longer grants EXECUTE on internal mutating helper `_register_wait()`. (issue #91)
 
 ---
 

--- a/devel/sql/ash-install.sql
+++ b/devel/sql/ash-install.sql
@@ -1236,6 +1236,14 @@ begin
   end;
 
   -- Validate interval
+  if p_interval is null then
+    job_type := 'error';
+    job_id := null;
+    status := 'interval must not be null';
+    return next;
+    return;
+  end if;
+
   v_seconds := extract(epoch from p_interval)::int;
   if v_seconds < 1 then
     job_type := 'error';
@@ -2975,15 +2983,25 @@ as $$
     select
       t.wait_event,
       t.cnt,
-      row_number() over (order by t.cnt desc) as rn
+      row_number() over (order by t.cnt desc) as rn,
+      count(*) over () as total_rows
     from totals t
   ),
   top_rows as (
-    select wait_event, cnt, rn from ranked where rn <= p_limit
+    select wait_event, cnt, rn
+    from ranked
+    where p_limit > 0
+      and (
+        (total_rows <= p_limit and rn <= p_limit)
+        or (total_rows > p_limit and rn < p_limit)
+      )
   ),
   other as (
     select 'Other'::text as wait_event, sum(cnt) as cnt, (p_limit + 1)::bigint as rn
-    from ranked where rn > p_limit
+    from ranked
+    where p_limit > 0
+      and total_rows > p_limit
+      and rn >= p_limit
     having sum(cnt) > 0
   ),
   max_pct as (
@@ -3012,14 +3030,23 @@ returns table (
   wait_event text,
   samples bigint
 )
-language sql
+language plpgsql
 stable
 set jit = off
 set search_path = pg_catalog, ash
 as $$
+declare
+  v_bucket_secs int4;
+begin
+  v_bucket_secs := extract(epoch from p_bucket)::int4;
+  if v_bucket_secs is null or v_bucket_secs < 1 then
+    raise exception 'bucket must be at least 1 second, got %', p_bucket;
+  end if;
+
+  return query
   with waits as (
     select
-      ash.epoch() + (s.sample_ts - (s.sample_ts % extract(epoch from p_bucket)::int4)) * interval '1 second' as bucket,
+      ash.epoch() + (s.sample_ts - (s.sample_ts % v_bucket_secs)) * interval '1 second' as bucket,
       (-s.data[i])::smallint as wait_id,
       s.data[i + 1] as cnt
     from ash.sample s, generate_subscripts(s.data, 1) i
@@ -3034,7 +3061,8 @@ as $$
   from waits w
   join ash.wait_event_map wm on wm.id = w.wait_id
   group by w.bucket, wm.type, wm.event
-  order by w.bucket, sum(w.cnt) desc
+  order by w.bucket, sum(w.cnt) desc;
+end;
 $$;
 
 -- Top queries by wait samples (inline SQL decode)
@@ -4005,8 +4033,12 @@ begin
   -- via unbounded `repeat()` on the bar characters. 500 is an order of
   -- magnitude beyond any realistic terminal width.
   p_width := least(greatest(p_width, 1), 500);
-  v_start_ts := greatest(least(extract(epoch from now() - p_interval - ash.epoch()), 2147483647), 0)::int4;
   v_bucket_secs := extract(epoch from p_bucket)::int4;
+  if v_bucket_secs is null or v_bucket_secs < 1 then
+    raise exception 'bucket must be at least 1 second, got %', p_bucket;
+  end if;
+
+  v_start_ts := greatest(least(extract(epoch from now() - p_interval - ash.epoch()), 2147483647), 0)::int4;
 
   -- Rank by avg active sessions weighted by bucket presence
   select array_agg(t.wait_event order by t.score desc)
@@ -5003,6 +5035,7 @@ as $$
     'rollup_hour', 'rollup_cleanup', '_drop_all_partitions',
     '_rebuild_query_map_view', '_merge_wait_counts', '_merge_query_counts',
     '_truncate_pairs', '_int4_array_cat_agg', '_int8_array_cat_agg',
+    '_register_wait',
     -- the helpers themselves: granting them to a reader role would let
     -- that role hand out privileges. keep them admin-only.
     'grant_reader', 'revoke_reader',
@@ -5116,9 +5149,10 @@ end $$;
 --     uninstall, rotate, take_sample, set_debug_logging, rebuild_partitions,
 --     rollup_minute, rollup_hour, rollup_cleanup, _drop_all_partitions,
 --     _rebuild_query_map_view, _merge_wait_counts, _merge_query_counts,
---     _truncate_pairs, _int4_array_cat_agg, _int8_array_cat_agg). Defining
---     "reader" by exclusion (rather than enumeration) keeps the helpers
---     correct as new readers and reader-internal helpers are added.
+--     _truncate_pairs, _int4_array_cat_agg, _int8_array_cat_agg,
+--     _register_wait). Defining "reader" by exclusion (rather than
+--     enumeration) keeps the helpers correct as new readers and
+--     reader-internal helpers are added.
 --   - SELECT on ash.sample (+ every sample_N partition), ash.query_map_all
 --     (+ every query_map_N partition), ash.config, ash.wait_event_map,
 --     ash.rollup_1m, ash.rollup_1h.


### PR DESCRIPTION
## Summary

Fixes issue #91.

This keeps the current development/release layout intact:
- `sql/` remains frozen at the latest released baseline.
- implementation changes are in `devel/sql/ash-install.sql`.
- `devel/sql/ash-1.4-to-1.5.sql` continues to apply the in-progress installer for upgrade-path testing.

Behavior changes:
- `top_waits(..., p_limit => N)` now treats `p_limit` as a hard output row limit including `Other`.
- zero `wait_timeline()` / `timeline_chart()` buckets now raise explicit bucket validation instead of division-by-zero.
- `ash.start(NULL::interval)` returns a clear error row before touching `ash.config`.
- `ash.grant_reader()` no longer grants EXECUTE on internal mutating helper `ash._register_wait()`.

## TDD

Red commit:
- `9d567bb` `test: reproduce reader validation edges`
- Local PG18 proof: `issue91-red-rc=3`
- Expected failure: `top_waits(p_limit=10) must return at most 10 rows, got 11`

Green commit:
- `c70d67f` `fix: handle reader validation edges`

## Verification

Local PG18:
- fresh devel install + #91 regression: `issue91-fresh-green-rc=0`
- generated full-upgrade chain + #91 regression: `issue91-full-upgrade-green-rc=0`
- positive smoke calls for `top_waits`, `wait_timeline`, `timeline_chart`, `ash.start(NULL)` passed

Static/local guards:
- `python3 -m py_compile devel/scripts/ash_sql_chain.py`
- workflow YAML parse
- `git diff --check HEAD~1..HEAD`
- `git diff --check`
- `git diff origin/main -- sql/ash-install.sql` is empty
