### PR TITLE
Bug: reject malformed sample data

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2407,6 +2407,43 @@ jobs:
           end $$;
           EOF
 
+      - name: "Test v1.5: malformed sample.data is rejected (#89)"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          begin;
+
+          do $$
+          declare
+            v_inserted boolean := false;
+          begin
+            truncate ash.sample;
+            truncate ash.rollup_1m;
+            truncate ash.wait_event_map restart identity cascade;
+            perform ash._register_wait('active', 'Corrupt', 'Bogus');
+
+            begin
+              insert into ash.sample (sample_ts, datid, active_count, data, slot)
+              values (
+                ash.ts_from_timestamptz(now() - interval '2 minutes'),
+                0::oid,
+                1::smallint,
+                array[-1,1000,0]::int4[],
+                ash.current_slot()
+              );
+              v_inserted := true;
+            exception when check_violation then
+              null;
+            end;
+
+            assert not v_inserted,
+              'ash.sample.data must reject malformed packed arrays whose count exceeds available query ids';
+          end $$;
+
+          rollback;
+          EOF
+
       - name: "Release-gate fixes: negative interval, p_width clamp, decode_sample size cap"
         env:
           PGPASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3963,13 +3963,12 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
-          # Regression for issue #49: the oldest released installer shipped
-          # `array_length(data, 1) >= 2`; later releases require `>= 3`.
-          # No legacy upgrade script rewrote the check, so installs that
-          # started at the oldest release carried the looser form forever.
-          # The current development upgrade chain now detects and rewrites it;
-          # assert that the discovered full chain ends with the tightened
-          # constraint on both the partitioned parent and every partition.
+          # Regression for issue #49 and #89: the oldest released installer
+          # shipped `array_length(data, 1) >= 2`; later releases require full
+          # packed-array shape validation. The current development upgrade
+          # chain detects and rewrites old checks; assert that the discovered
+          # full chain ends with the validator helper on both the partitioned
+          # parent and every partition.
           python3 devel/scripts/ash_sql_chain.py oldest-install-path | sed 's#^#\\i #' > /tmp/ash_oldest_install.sql
           python3 devel/scripts/ash_sql_chain.py upgrade-chain-from-oldest > /tmp/ash_upgrade_from_oldest.sql
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
@@ -3990,8 +3989,9 @@ jobs:
 
           \i /tmp/ash_upgrade_from_oldest.sql
 
-          -- After full dev chain: parent + every partition must carry `>= 3`,
-          -- and none may carry the legacy `>= 2`.
+          -- After full dev chain: parent + every partition must carry the
+          -- packed-array validator, and none may carry legacy array_length
+          -- checks.
           do $$
           declare
             v_bad int;
@@ -4001,8 +4001,8 @@ jobs:
             from pg_constraint c
             where c.conrelid = 'ash.sample'::regclass
               and c.conname  = 'sample_data_check';
-            assert v_parent_def ~ 'array_length\(data, 1\) >= 3',
-              format('parent constraint not tightened; got: %s', v_parent_def);
+            assert v_parent_def ~ '_sample_data_is_valid',
+              format('parent constraint not upgraded to validator; got: %s', v_parent_def);
 
             select count(*) into v_bad
             from pg_constraint c
@@ -4011,9 +4011,9 @@ jobs:
             where n.nspname = 'ash'
               and t.relname ~ '^sample(_[0-9]+)?$'
               and c.contype = 'c'
-              and pg_get_constraintdef(c.oid) ~ 'array_length\(data, 1\) >= 2';
+              and pg_get_constraintdef(c.oid) ~ 'array_length\(data, 1\)';
             assert v_bad = 0,
-              format('%s ash.sample* check(s) still carry the legacy `>= 2` form', v_bad);
+              format('%s ash.sample* check(s) still carry a legacy array_length form', v_bad);
 
             select count(*) into v_bad
             from pg_inherits i
@@ -4022,14 +4022,14 @@ jobs:
             left join pg_constraint c
               on c.conrelid = p.oid
              and c.contype  = 'c'
-             and pg_get_constraintdef(c.oid) ~ 'array_length\(data, 1\) >= 3'
+             and pg_get_constraintdef(c.oid) ~ '_sample_data_is_valid'
             where i.inhparent = 'ash.sample'::regclass
               and n.nspname = 'ash'
               and c.oid is null;
             assert v_bad = 0,
-              format('%s partition(s) of ash.sample missing `>= 3` check', v_bad);
+              format('%s partition(s) of ash.sample missing validator check', v_bad);
 
-            raise notice 'issue #49 regression PASSED: sample_data_check is `>= 3` everywhere';
+            raise notice 'issue #49/#89 regression PASSED: sample_data_check uses validator everywhere';
           end $$;
 
           select ash.uninstall('yes');

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@ Work in progress after v1.4.
 - **pg_stat_statements readers ignore spoofed relations and avoid duplicate top-query rows.** pgss-aware readers now require the real `pg_stat_statements` extension before reading query text/metrics, and `top_queries*` aggregates pgss rows by `queryid` so one ASH query cannot fan out into multiple rows. (issue #87)
 - **`daily_peak_backends.avg_backends` now reports average active backends.** The value is derived from hourly backend-seconds divided by sample count instead of averaging hourly peak values. (issue #88)
 - **Reader and input-validation edge cases fixed.** `top_waits()` now treats `p_limit` as a hard output row limit including `Other`, zero timeline buckets raise explicit validation errors, `ash.start(NULL)` returns a clear error row, and `ash.grant_reader()` no longer grants EXECUTE on internal mutating helper `_register_wait()`. (issue #91)
+- **Malformed raw sample payloads are rejected.** `ash.sample.data` now uses a packed-array validator CHECK constraint, preventing rows whose declared wait count exceeds the available query-id payload from making raw readers report impossible totals. (issue #89)
 
 ---
 

--- a/devel/sql/ash-install.sql
+++ b/devel/sql/ash-install.sql
@@ -263,13 +263,73 @@ as $$
   select current_slot from ash.config where singleton
 $$;
 
+-- Validate the packed ash.sample.data representation.
+--
+-- Layout: one or more groups of:
+--   - negative wait-id marker
+--   - positive backend count N
+--   - exactly N non-negative query_map ids, where 0 means NULL query_id
+--
+-- Kept as a standalone immutable helper so both fresh installs and upgrades
+-- can use one table CHECK expression. The function intentionally performs
+-- shape validation only; wait/query dictionary lookups stay in readers.
+create or replace function ash._sample_data_is_valid(p_data integer[])
+returns boolean
+language plpgsql
+immutable
+strict
+parallel safe
+set search_path = pg_catalog
+as $$
+declare
+  v_len int;
+  v_idx int := 1;
+  v_count int;
+  v_qid_idx int;
+begin
+  v_len := array_length(p_data, 1);
+  if v_len is null or v_len < 3 or v_len > 100000 then
+    return false;
+  end if;
+
+  while v_idx <= v_len loop
+    if p_data[v_idx] is null or p_data[v_idx] >= 0 then
+      return false;
+    end if;
+    v_idx := v_idx + 1;
+
+    if v_idx > v_len then
+      return false;
+    end if;
+    v_count := p_data[v_idx];
+    if v_count is null or v_count <= 0 then
+      return false;
+    end if;
+    v_idx := v_idx + 1;
+
+    if v_idx + v_count - 1 > v_len then
+      return false;
+    end if;
+
+    for v_qid_idx in 1..v_count loop
+      if p_data[v_idx] is null or p_data[v_idx] < 0 then
+        return false;
+      end if;
+      v_idx := v_idx + 1;
+    end loop;
+  end loop;
+
+  return true;
+end;
+$$;
+
 -- Sample table (partitioned by slot)
 create table if not exists ash.sample (
   sample_ts    int4 not null,
   datid        oid not null,
   active_count smallint not null,
   data         integer[] not null
-         check (data[1] < 0 and array_length(data, 1) >= 3),
+         check (ash._sample_data_is_valid(data)),
   slot         smallint not null default ash.current_slot()
 ) partition by list (slot);
 
@@ -300,29 +360,33 @@ begin
   end loop;
 end $$;
 
--- Migration (issue #49): align sample.data check across upgrade paths.
--- v1.0 shipped `array_length(data, 1) >= 2`; v1.1 tightened it to `>= 3`,
--- but no legacy upgrade script rewrote the constraint, so installs that
--- started at 1.0 still carry the looser form. Detect and fix in place.
--- Idempotent: only rewrites when the current definition is missing or
--- the old `>= 2` form. Drops on the partitioned parent cascade to all
--- partitions; ADD CONSTRAINT on the parent propagates back to children.
+-- Migration (issues #49, #89): align sample.data check across upgrade paths.
+-- v1.0 shipped `array_length(data, 1) >= 2`; v1.1 tightened it to `>= 3`;
+-- v1.5 validates the full packed shape so impossible wait counts are rejected
+-- at INSERT time. Detect and fix in place. Idempotent: only rewrites when the
+-- current definition is missing or not using the validator helper. Drops on the
+-- partitioned parent cascade to all partitions; ADD CONSTRAINT on the parent
+-- propagates back to children.
 do $$
 declare
   v_def text;
+  v_valid boolean;
 begin
-  select pg_get_constraintdef(c.oid) into v_def
+  select pg_get_constraintdef(c.oid), c.convalidated
+    into v_def, v_valid
   from pg_constraint c
   where c.conrelid = 'ash.sample'::regclass
     and c.conname  = 'sample_data_check';
 
-  if v_def is null or v_def !~ 'array_length\(data, 1\) >= 3' then
+  if v_def is null or v_def !~ '_sample_data_is_valid' then
     if v_def is not null then
       alter table ash.sample drop constraint sample_data_check;
     end if;
     alter table ash.sample
       add constraint sample_data_check
-      check (data[1] < 0 and array_length(data, 1) >= 3);
+      check (ash._sample_data_is_valid(data));
+  elsif not v_valid then
+    alter table ash.sample validate constraint sample_data_check;
   end if;
 end $$;
 


### PR DESCRIPTION
## Summary

Fixes issue #89.

Chosen fix: reject malformed packed `ash.sample.data` at insert time. That is cleaner than making every raw reader duplicate decoder validation, and it prevents future impossible raw-reader totals from entering the table.

Changes:
- add immutable `ash._sample_data_is_valid(int4[])` shape validator
- make `ash.sample.data` CHECK use that validator
- upgrade legacy `sample_data_check` definitions to the validator helper through the devel upgrade path
- keep `sql/ash-install.sql` frozen; implementation lives in `devel/sql/ash-install.sql`
- update the existing issue #49 upgrade-chain test so it expects the validator, not only `array_length(data, 1) >= 3`

## TDD

Red commit:
- `8f867ab` `test: reproduce malformed sample data insert`
- Local PG18 proof: `issue89-red-rc=3`
- Expected failure: `ash.sample.data must reject malformed packed arrays whose count exceeds available query ids`

Green commit:
- `ed75585` `fix: reject malformed sample data`

## Verification

Local PG18:
- fresh devel install + #89 regression: `issue89-fresh-green-rc=0`
- generated full-upgrade chain + #89 regression: `issue89-full-upgrade-green-rc=0`
- upgraded parent and partition constraints use validated `_sample_data_is_valid`
- after CI feedback, re-applied devel installer on upgraded DB and confirmed `pg_get_constraintdef(...) = CHECK (ash._sample_data_is_valid(data))` without `NOT VALID`

Static/local guards:
- `python3 -m py_compile devel/scripts/ash_sql_chain.py`
- workflow YAML parse
- `git diff --check HEAD~1..HEAD`
- `git diff --check`
- `git diff origin/main -- sql/ash-install.sql` is empty
