### PR TITLE
Fix v1.5 release upgrade gaps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Guard docs against stale privilege and reader names
         run: |
@@ -67,6 +69,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
 
       - name: Install pg_cron in container
         # The GitHub Actions `services:` block does not let us mount a custom
@@ -2362,6 +2366,16 @@ jobs:
               format('wait_timeline zero bucket must raise explicit bucket validation, got [%s] %s', v_state, v_msg);
 
             begin
+              perform * from ash.wait_timeline_at(now() - interval '1 hour', now(), '0 seconds');
+              raise exception 'wait_timeline_at accepted zero bucket';
+            exception when others then
+              v_state := sqlstate;
+              v_msg := sqlerrm;
+            end;
+            assert v_state <> '22012' and v_msg ilike '%bucket%',
+              format('wait_timeline_at zero bucket must raise explicit bucket validation, got [%s] %s', v_state, v_msg);
+
+            begin
               perform * from ash.timeline_chart('1 hour', '0 seconds', 4, 20);
               raise exception 'timeline_chart accepted zero bucket';
             exception when others then
@@ -2370,6 +2384,16 @@ jobs:
             end;
             assert v_state <> '22012' and v_msg ilike '%bucket%',
               format('timeline_chart zero bucket must raise explicit bucket validation, got [%s] %s', v_state, v_msg);
+
+            begin
+              perform * from ash.timeline_chart_at(now() - interval '1 hour', now(), '0 seconds', 4, 20);
+              raise exception 'timeline_chart_at accepted zero bucket';
+            exception when others then
+              v_state := sqlstate;
+              v_msg := sqlerrm;
+            end;
+            assert v_state <> '22012' and v_msg ilike '%bucket%',
+              format('timeline_chart_at zero bucket must raise explicit bucket validation, got [%s] %s', v_state, v_msg);
 
             -- NULL interval should be handled at function level before
             -- touching ash.config.sample_interval.
@@ -3892,6 +3916,83 @@ jobs:
             raise notice 'Uninstall test PASSED (including v1.4 rollup objects)';
           end;
           $$;
+          EOF
+
+      - name: "Release upgrade path: actual v1.4 tag to v1.5"
+        if: matrix.postgres == 17 && matrix.cron == 'on'
+        env:
+          PGPASSWORD: postgres
+        run: |
+          git show v1.4:sql/ash-install.sql > /tmp/ash-v1.4-install.sql
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          \i /tmp/ash-v1.4-install.sql
+
+          do $$
+          declare
+            v_wait_id smallint;
+            v_slot smallint;
+            v_ts int4 := ash.ts_from_timestamptz(now());
+          begin
+            select ash._register_wait('active', 'DirectUpgrade', 'ValidRaw') into v_wait_id;
+            select ash.current_slot() into v_slot;
+
+            -- v1.4 permits this malformed payload. v1.5 must not fail the
+            -- whole release upgrade when a legacy database already contains it.
+            insert into ash.sample(sample_ts, datid, active_count, data, slot)
+            values (v_ts - 10, 0::oid, 1000, array[-v_wait_id, 1000, 0]::int4[], v_slot);
+
+            -- Valid raw data seeded before the upgrade must still decode after
+            -- the direct v1.4 -> v1.5 wrapper.
+            insert into ash.sample(sample_ts, datid, active_count, data, slot)
+            values (v_ts - 5, 0::oid, 1, array[-v_wait_id, 1, 0]::int4[], v_slot);
+          end $$;
+
+          \i sql/ash-1.4-to-1.5.sql
+
+          do $$
+          declare
+            v_count int;
+            v_wait_id smallint;
+            v_slot smallint;
+            v_retained_slot smallint;
+            v_ts int4 := ash.ts_from_timestamptz(now());
+          begin
+            assert (select version from ash.config where singleton) = '1.5',
+              'direct v1.4 -> v1.5 upgrade did not stamp version 1.5';
+
+            select count(*) into v_count
+            from ash.sample
+            where not ash._sample_data_is_valid(data);
+            assert v_count = 0,
+              format('direct v1.4 -> v1.5 upgrade left % malformed sample rows', v_count);
+
+            assert exists (
+              select 1 from ash.top_waits('1 hour', 100)
+              where wait_event = 'DirectUpgrade:ValidRaw'
+            ), 'direct v1.4 -> v1.5 upgrade lost valid pre-upgrade raw sample';
+
+            perform ash.rebuild_partitions(5, 'yes');
+            select ash.current_slot() into v_slot;
+            v_retained_slot := ((v_slot - 3 + 5) % 5)::smallint;
+            select ash._register_wait('active', 'DirectUpgrade', 'RetainedSlot') into v_wait_id;
+
+            execute format(
+              'insert into ash.sample_%s(sample_ts, datid, active_count, data, slot) values (%s, 0::oid, 1, %L::int4[], %s)',
+              v_retained_slot,
+              v_ts - 60,
+              array[-v_wait_id, 1, 0]::int4[],
+              v_retained_slot
+            );
+
+            assert exists (
+              select 1 from ash.top_waits('2 days', 100)
+              where wait_event = 'DirectUpgrade:RetainedSlot'
+            ), 'direct v1.4 -> v1.5 upgrade did not honor rebuilt retained raw slots';
+
+            raise notice 'direct v1.4 -> v1.5 release upgrade regression PASSED';
+          end $$;
+
+          select ash.uninstall('yes');
           EOF
 
       - name: "Upgrade path: discovered full chain"

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ visible in server / CI logs.
 \i sql/ash-1.3-to-1.4.sql
 
 -- from 1.4 to 1.5
-\i sql/ash-1.4-to-1.5.sql
+\i sql/ash-1.4-to-1.5.sql  -- atomic wrapper; run with ON_ERROR_STOP enabled
 
 -- check version
 select * from ash.status();

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,8 +5,9 @@ safety, and release-process hardening. Upgrade from 1.4:
 `\i sql/ash-1.4-to-1.5.sql`. Fresh install or upgrade from any version:
 `\i sql/ash-install.sql`.
 
-Thanks to @r314tive for reporting issue #90 and for bringing the original PRs
-behind the rollup/rotation and raw-retention fixes ([PR #86](https://github.com/NikolayS/pg_ash/pull/86),
+Thanks to @r314tive for the sustained bug-reporting work behind this release:
+issues #81, #83, and #87-#91, plus the original PRs behind the rollup/rotation
+and raw-retention fixes ([PR #86](https://github.com/NikolayS/pg_ash/pull/86),
 [PR #85](https://github.com/NikolayS/pg_ash/pull/85)).
 
 ## Fixes
@@ -23,10 +24,10 @@ behind the rollup/rotation and raw-retention fixes ([PR #86](https://github.com/
 
 - **Development SQL is staged outside released SQL.** Between releases, new SQL
   lives under `devel/sql/`; release stamping promotes it into `sql/` only when
-  cutting the next tag. (PR #94)
+  cutting the next tag. ([PR #94](https://github.com/NikolayS/pg_ash/pull/94))
 - **CI discovers SQL chains from files.** The test workflow uses
   `devel/scripts/ash_sql_chain.py` instead of hardcoded version paths, so future
-  version bumps require adding/moving files, not rewriting CI. (PR #94)
+  version bumps require adding/moving files, not rewriting CI. ([PR #94](https://github.com/NikolayS/pg_ash/pull/94))
 
 ---
 

--- a/devel/sql/README.md
+++ b/devel/sql/README.md
@@ -1,0 +1,11 @@
+# Development SQL staging
+
+Keep in-progress SQL for the next release here.
+
+After a release tag, `sql/` is frozen at the tagged baseline. The first
+SQL-changing PR for the next development cycle should add:
+
+- `devel/sql/ash-install.sql` — future final installer
+- `devel/sql/ash-X.Y-to-X.Z.sql` — future upgrade wrapper/script
+
+Release stamping promotes those files into `sql/`.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -40,7 +40,10 @@ development SQL into released core SQL:
    references if the helper no longer emits them after promotion.
 6. Run the full release gate before tagging.
 
-After the tag, create a new `devel/sql/` area for the next development cycle.
+After the tag, keep an empty `devel/sql/` area as the next development-cycle
+landing zone. The first SQL-changing PR after a release adds the next
+`devel/sql/ash-install.sql` and `devel/sql/ash-X.Y-to-X.Z.sql` files there
+before touching released `sql/` files.
 
 ## Legacy upgrade scripts
 

--- a/sql/ash-1.4-to-1.5.sql
+++ b/sql/ash-1.4-to-1.5.sql
@@ -3,4 +3,7 @@
 -- Bug-fix release. Replays the finalized 1.5 installer so the 1.4-to-1.5
 -- upgrade path stays schema-equivalent with fresh 1.5 installs.
 
+\set ON_ERROR_STOP on
+begin;
 \ir ash-install.sql
+commit;

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -374,6 +374,7 @@ do $$
 declare
   v_def text;
   v_valid boolean;
+  v_invalid bigint;
 begin
   select pg_get_constraintdef(c.oid), c.convalidated
     into v_def, v_valid
@@ -382,6 +383,31 @@ begin
     and c.conname  = 'sample_data_check';
 
   if v_def is null or v_def !~ '_sample_data_is_valid' then
+    select count(*) into v_invalid
+    from ash.sample
+    where not ash._sample_data_is_valid(data);
+
+    if v_invalid > 0 then
+      create table if not exists ash.sample_malformed_1_5 (
+        sample_ts int4 not null,
+        datid oid not null,
+        active_count smallint not null,
+        data integer[] not null,
+        slot smallint not null,
+        quarantined_at timestamptz not null default clock_timestamp()
+      );
+
+      insert into ash.sample_malformed_1_5(sample_ts, datid, active_count, data, slot)
+      select sample_ts, datid, active_count, data, slot
+      from ash.sample
+      where not ash._sample_data_is_valid(data);
+
+      raise warning 'pg_ash upgrade: quarantined and deleted % malformed ash.sample row(s) rejected by the v1.5 data-shape validator',
+        v_invalid;
+      delete from ash.sample
+      where not ash._sample_data_is_valid(data);
+    end if;
+
     if v_def is not null then
       alter table ash.sample drop constraint sample_data_check;
     end if;
@@ -3767,11 +3793,17 @@ declare
   v_slots smallint[] := ash._active_slots_for_at(p_start, p_end);
   v_start int4       := ash.ts_from_timestamptz(p_start);
   v_end   int4       := ash.ts_from_timestamptz(p_end);
+  v_bucket_secs int4;
 begin
+  v_bucket_secs := extract(epoch from p_bucket)::int4;
+  if v_bucket_secs is null or v_bucket_secs < 1 then
+    raise exception 'bucket must be at least 1 second, got %', p_bucket;
+  end if;
+
   return query
   with waits as (
     select
-      ash.epoch() + (s.sample_ts - (s.sample_ts % extract(epoch from p_bucket)::int4)) * interval '1 second' as bucket,
+      ash.epoch() + (s.sample_ts - (s.sample_ts % v_bucket_secs)) * interval '1 second' as bucket,
       (-s.data[i])::smallint as wait_id,
       s.data[i + 1] as cnt
     from ash.sample s, generate_subscripts(s.data, 1) i
@@ -4323,6 +4355,9 @@ begin
   -- inner queries' time predicates fold to false (#69).
   v_slots := ash._active_slots_for_at(p_start, p_end);
   v_bucket_secs := extract(epoch from p_bucket)::int4;
+  if v_bucket_secs is null or v_bucket_secs < 1 then
+    raise exception 'bucket must be at least 1 second, got %', p_bucket;
+  end if;
 
   -- Rank by avg active sessions weighted by bucket presence
   select array_agg(t.wait_event order by t.score desc)


### PR DESCRIPTION
## Summary

Post-release REV on `v1.5` found real gaps. This PR fixes them instead of pretending the release gate was enough.

Fixes:
- Make `sql/ash-1.4-to-1.5.sql` atomic under psql by setting `ON_ERROR_STOP` and wrapping the installer replay in `BEGIN`/`COMMIT`.
- Let direct v1.4 -> v1.5 upgrades survive legacy malformed `ash.sample.data` rows: quarantine them into `ash.sample_malformed_1_5`, delete the invalid raw rows, then add the v1.5 validator CHECK.
- Add explicit zero-bucket validation to `ash.wait_timeline_at()` and `ash.timeline_chart_at()`.
- Add CI coverage for an actual `v1.4` tag install upgraded directly through `sql/ash-1.4-to-1.5.sql`, including malformed legacy data, valid raw-data preservation, and rebuilt retained-slot visibility.
- Broaden @r314tive thanks in release notes, link PR #94 references, and add `devel/sql/` next-cycle staging docs.

## REV findings addressed

- High: direct v1.4 -> v1.5 upgrade failed if a v1.4 database already contained malformed sample payloads that v1.4 allowed.
- Medium: `_at` timeline readers still raised raw division-by-zero for zero buckets.
- Medium: the upgrade wrapper exposed installer replay under psql autocommit.
- High process gap: CI did not directly test actual tagged v1.4 state through the release upgrade wrapper.
- Low docs gaps: too-narrow contributor thanks, unlinked PR #94 refs, ambiguous `devel/sql/` post-tag state.

## Verification

Local:
- `git diff --check`
- workflow YAML parses
- `python3 -m py_compile devel/scripts/ash_sql_chain.py`
- docs-lint guard passes
- Docker PG17 actual `v1.4` tag -> current `sql/ash-1.4-to-1.5.sql` direct upgrade regression passes
- Docker PG17 fresh install `_at` zero-bucket validation passes
- Post-release Docker matrix run before this PR: PG14-PG18 fresh + full upgrade smoke passed for version, #89/#90/#91 probes; PG18 was rerun after fixing the local harness TCP/sockets mistake.

Follow-up after this PR is green: decide whether to move/replace `v1.5` or publish a corrective tag. I will not move the published tag without explicit owner approval.
