### PR TITLE
ci: guard released SQL workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,31 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Guard SQL release workflow
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_REF: ${{ github.head_ref }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          changed="$(git diff --name-only "$BASE_SHA"...HEAD)"
+
+          if printf '%s\n' "$changed" | grep -E '^sql/.*\.sql$' >/dev/null; then
+            case "$HEAD_REF:$PR_TITLE" in
+              release/*:*|release-*:*|*:release:*)
+                ;;
+              *)
+                echo "Released SQL under sql/ is frozen between releases." >&2
+                echo "Feature/fix PRs must stage SQL in devel/sql/ and let a release-stamp PR promote it." >&2
+                printf 'Changed released SQL files:\n%s\n' \
+                  "$(printf '%s\n' "$changed" | grep -E '^sql/.*\.sql$')" >&2
+                exit 1
+                ;;
+            esac
+          fi
+
       - name: Guard docs against stale privilege and reader names
         run: |
           set -euo pipefail
@@ -246,7 +271,7 @@ jobs:
           PGPASSWORD: postgres
         run: |
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
-            -v expected_version="$(python3 devel/scripts/ash_sql_chain.py latest-released-version)" << 'EOF'
+            -v expected_version="$(python3 devel/scripts/ash_sql_chain.py fresh-install-version)" << 'EOF'
           select set_config('pg_ash.expected_version', :'expected_version', false);
 
           do $$
@@ -4290,7 +4315,7 @@ jobs:
           python3 devel/scripts/ash_sql_chain.py fresh-install-path | sed 's#^#\\i #' > /tmp/ash_fresh_install.sql
           python3 devel/scripts/ash_sql_chain.py reapply-chain > /tmp/ash_reapply_chain.sql
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
-            -v expected_version="$(python3 devel/scripts/ash_sql_chain.py latest-released-version)" << 'EOF'
+            -v expected_version="$(python3 devel/scripts/ash_sql_chain.py fresh-install-version)" << 'EOF'
           select set_config('pg_ash.expected_version', :'expected_version', false);
 
           \i /tmp/ash_fresh_install.sql

--- a/devel/scripts/ash_sql_chain.py
+++ b/devel/scripts/ash_sql_chain.py
@@ -12,6 +12,7 @@ ROOT = Path(__file__).resolve().parents[2]
 SQL_DIRS = (ROOT / "sql", ROOT / "devel" / "sql")
 INSTALL_RE = re.compile(r"ash-(\d+)\.(\d+)\.sql$")
 UPGRADE_RE = re.compile(r"ash-(\d+\.\d+)-to-(\d+\.\d+)\.sql$")
+VERSION_DEFAULT_RE = re.compile(r"version\s+text\s+not\s+null\s+default\s+'([^']+)'")
 
 
 def version_key(version: str) -> tuple[int, int]:
@@ -83,6 +84,15 @@ def fresh_install_path() -> str:
     return rel(ROOT / "sql" / "ash-install.sql")
 
 
+def fresh_install_version() -> str:
+    path = ROOT / fresh_install_path()
+    text = path.read_text()
+    match = VERSION_DEFAULT_RE.search(text)
+    if not match:
+        raise SystemExit(f"could not find ash.config version default in {rel(path)}")
+    return match.group(1)
+
+
 def emit_psql_include(path: Path) -> None:
     print(rf"\i {rel(path)}")
 
@@ -125,6 +135,7 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     sub = parser.add_subparsers(dest="command", required=True)
     sub.add_parser("fresh-install-path")
+    sub.add_parser("fresh-install-version")
     sub.add_parser("oldest-install-path")
     sub.add_parser("second-oldest-install-path")
     sub.add_parser("latest-released-version")
@@ -136,6 +147,8 @@ def main() -> None:
 
     if args.command == "fresh-install-path":
         print(fresh_install_path())
+    elif args.command == "fresh-install-version":
+        print(fresh_install_version())
     elif args.command == "oldest-install-path":
         print(rel(installers()[oldest_version()]))
     elif args.command == "second-oldest-install-path":

--- a/devel/sql/README.md
+++ b/devel/sql/README.md
@@ -9,3 +9,6 @@ SQL-changing PR for the next development cycle should add:
 - `devel/sql/ash-X.Y-to-X.Z.sql` — future upgrade wrapper/script
 
 Release stamping promotes those files into `sql/`.
+
+Do not edit `sql/*.sql` in feature or bug-fix PRs. CI allows released SQL
+changes only from a release-stamp PR. See `docs/RELEASE_PROCESS.md`.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -22,9 +22,20 @@ present in the checkout.
 CI must test both supported development paths discovered by that helper:
 
 - fresh development install: the helper's `fresh-install-path`
+- fresh development install version: the helper's `fresh-install-version`
 - upgrade path: the helper's `full-upgrade-chain`
 
 Schema-equivalence CI must compare those two paths.
+
+## CI guard
+
+CI rejects ordinary PRs that modify `sql/*.sql`. To make an intentional
+release-stamp PR, use a branch starting with `release/` or `release-`, or a PR
+title starting with `release:`.
+
+That guard is deliberately conservative: if unreleased SQL lands directly under
+`sql/`, a user can copy `sql/ash-install.sql` from `main` and reasonably assume
+it is the published release payload.
 
 ## Release stamp
 


### PR DESCRIPTION
## Summary

- add a CI guard that rejects ordinary PRs changing released `sql/*.sql`
- allow released SQL edits only from release-stamp PRs (`release/*`, `release-*`, or `release:` title)
- teach `ash_sql_chain.py` to report the version of the selected fresh installer so future `devel/sql/ash-install.sql` can carry the next development version without breaking CI assertions
- document the guard in the release-process and development SQL staging docs

## Testing

- `python3 devel/scripts/ash_sql_chain.py fresh-install-version`
- `python3 devel/scripts/ash_sql_chain.py latest-released-version`
- `python3 devel/scripts/ash_sql_chain.py full-upgrade-chain`
- temp-copy smoke: staged `devel/sql/ash-install.sql` with version `1.6`, confirmed `fresh-install-path` selects `devel/sql/ash-install.sql` and `fresh-install-version` returns `1.6`
- `bash -n` on the new CI guard shell block