### PR TITLE
fix: keep installer grant restore least-privilege (#107 follow-up)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4610,6 +4610,84 @@ jobs:
           drop role ash_b1_reader;
           EOF
 
+      - name: "Issue #107 follow-up: grant restore stays least-privilege"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          # The #107 grant snapshot/restore must not become a privilege-widening
+          # vector. On every installer re-apply it must:
+          #   (a) NOT re-establish a stray non-owner EXECUTE grant on an admin
+          #       function after the hardening block revoked it (before #107,
+          #       DROP FUNCTION scrubbed such grants);
+          #   (b) NOT widen a role that held a single overload of a function to
+          #       its sibling overloads (restore by exact signature);
+          #   while still preserving legitimate ash.grant_reader() grants.
+          python3 devel/scripts/ash_sql_chain.py fresh-install-path | sed 's#^#\\i #' > /tmp/ash_fresh_install.sql
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          \i /tmp/ash_fresh_install.sql
+
+          do $$ begin
+            if not exists (select from pg_roles where rolname = 'lp_reader')   then create role lp_reader   login password 'x'; end if;
+            if not exists (select from pg_roles where rolname = 'lp_stray')    then create role lp_stray    login password 'x'; end if;
+            if not exists (select from pg_roles where rolname = 'lp_overload') then create role lp_overload login password 'x'; end if;
+          end $$;
+
+          -- legitimate reader: must SURVIVE re-apply (guards the #107 fix)
+          select ash.grant_reader('lp_reader');
+          -- stray manual grant on an admin function in the drop list: must be SCRUBBED
+          grant execute on function ash.rebuild_partitions(int, text) to lp_stray;
+          -- single-overload grant: must NOT widen to the sibling overload
+          grant execute on function ash.decode_sample(integer[], smallint) to lp_overload;
+
+          do $$ begin
+            assert has_function_privilege('lp_stray', 'ash.rebuild_partitions(int,text)', 'EXECUTE'),
+              'precondition: stray admin grant present before re-apply';
+            assert has_function_privilege('lp_overload', 'ash.decode_sample(integer[],smallint)', 'EXECUTE'),
+              'precondition: array overload granted';
+            assert not has_function_privilege('lp_overload', 'ash.decode_sample(integer)', 'EXECUTE'),
+              'precondition: integer overload not granted yet';
+          end $$;
+
+          -- re-apply the installer: drop/recreate + snapshot/restore + hardening
+          \i /tmp/ash_fresh_install.sql
+
+          do $$ begin
+            -- (1) #107 still fixed: legitimate reader keeps every reader grant
+            assert has_function_privilege('lp_reader', 'ash.top_waits(interval,int,int,boolean)', 'EXECUTE'),
+              '#107 regression: reader lost top_waits across re-apply';
+            assert has_function_privilege('lp_reader', 'ash.event_queries(text,interval,int,int,boolean)', 'EXECUTE'),
+              '#107 regression: reader lost event_queries across re-apply';
+            assert has_function_privilege('lp_reader', 'ash.top_queries_with_text(interval,int)', 'EXECUTE'),
+              '#107 regression: reader lost top_queries_with_text across re-apply';
+
+            -- (2) admin-function grant must be scrubbed and NOT restored after hardening
+            assert not has_function_privilege('lp_stray', 'ash.rebuild_partitions(int,text)', 'EXECUTE'),
+              'admin EXECUTE grant re-established after hardening (defense-in-depth regression)';
+            assert not has_function_privilege('lp_reader', 'ash.rebuild_partitions(int,text)', 'EXECUTE'),
+              'reader must not gain admin function EXECUTE';
+            assert not has_function_privilege('lp_reader', 'ash.take_sample()', 'EXECUTE'),
+              'reader must not gain take_sample';
+
+            -- (3) no overload widening
+            assert has_function_privilege('lp_overload', 'ash.decode_sample(integer[],smallint)', 'EXECUTE'),
+              'held overload should survive re-apply';
+            assert not has_function_privilege('lp_overload', 'ash.decode_sample(integer)', 'EXECUTE'),
+              'single-overload grant must NOT widen to the sibling overload';
+
+            -- (4) PUBLIC stays revoked
+            assert not has_function_privilege('public', 'ash.top_waits(interval,int,int,boolean)', 'EXECUTE'),
+              'PUBLIC must stay revoked';
+
+            raise notice 'issue #107 follow-up: grant restore stayed least-privilege';
+          end $$;
+
+          drop owned by lp_reader, lp_stray, lp_overload;
+          select ash.uninstall('yes');
+          drop role lp_reader;
+          drop role lp_stray;
+          drop role lp_overload;
+          EOF
+
       - name: "Schema equivalence: fresh dev install vs full upgrade path"
         env:
           PGPASSWORD: postgres

--- a/devel/sql/ash-install.sql
+++ b/devel/sql/ash-install.sql
@@ -14,7 +14,10 @@
 -- would silently lose access on every upgrade or installer re-apply.
 -- Snapshot every explicit non-owner EXECUTE grant on ash.* functions into
 -- a temp table now; the matching block at the very end of this script
--- re-applies them to the recreated functions and drops the snapshot.
+-- re-applies them to the recreated functions and drops the snapshot. The
+-- argument signature is captured alongside the name so the restore can put
+-- the grant back on the exact same overload and never widen a role that
+-- held only one overload of a function.
 -- PUBLIC (grantee oid 0, which has no pg_roles row) is intentionally
 -- excluded: the hardening block below re-applies the REVOKE-from-PUBLIC
 -- posture on every install.
@@ -23,11 +26,14 @@ begin
   drop table if exists pg_temp._ash_install_func_acl;
   create temp table _ash_install_func_acl (
     proname   name not null,
+    args      text not null,
     grantee   name not null,
     grantable bool not null
   );
-  insert into pg_temp._ash_install_func_acl (proname, grantee, grantable)
-  select distinct p.proname, g.rolname, acl.is_grantable
+  insert into pg_temp._ash_install_func_acl (proname, args, grantee, grantable)
+  select distinct p.proname,
+         pg_catalog.pg_get_function_identity_arguments(p.oid),
+         g.rolname, acl.is_grantable
   from pg_proc p
   join pg_namespace n on p.pronamespace = n.oid
   cross join lateral aclexplode(p.proacl) as acl
@@ -5484,16 +5490,28 @@ begin
 end $$;
 
 -- Re-apply the EXECUTE grants snapshotted before the drop/recreate at the
--- top of this script (#107). Grants are restored by function name to every
--- current overload, because the dropped signatures may no longer exist in
--- this version. This mirrors what CREATE OR REPLACE would have preserved:
--- function names that no longer exist (removed/renamed) are skipped, roles
--- dropped mid-script are skipped, and a role's reach is never widened —
+-- top of this script (#107), keeping the restore strictly least-privilege:
+--   * Admin functions (ash._admin_funcs()) are never restored. They are
+--     locked to the owner by the hardening block above and are never handed
+--     out by ash.grant_reader(); re-applying a stray manual grant on one
+--     would silently undo that hardening on every install. Excluding them
+--     here preserves the pre-#107 behaviour where DROP FUNCTION scrubbed
+--     such grants.
+--   * Each grant is restored to the exact same signature when it still
+--     exists, so a role that held only one overload of a function is not
+--     widened to its siblings. Only when the snapshotted signature is gone
+--     (a genuine cross-version signature change — the case this restore
+--     exists to cover) does it fall back to every current overload of the
+--     name.
+-- This mirrors what CREATE OR REPLACE would have preserved: function names
+-- that no longer exist (removed/renamed) are skipped, roles dropped
+-- mid-script are skipped, and a role's reach is never widened —
 -- functions introduced by this version still require a fresh
 -- ash.grant_reader() call, exactly as before.
 do $$
 declare
   r record;
+  v_admin_funcs constant text[] := ash._admin_funcs();
 begin
   for r in
     select distinct a.grantee, a.grantable, p.proname,
@@ -5504,6 +5522,21 @@ begin
     join pg_catalog.pg_namespace n on n.oid = p.pronamespace
     where n.nspname = 'ash'
       and p.prokind in ('f', 'a')
+      and p.proname::text <> all (v_admin_funcs)
+      and (
+        -- the snapshotted overload still exists: restore exactly it
+        pg_catalog.pg_get_function_identity_arguments(p.oid) = a.args
+        -- the snapshotted overload is gone (signature changed): fall back
+        -- to restoring every current overload of the name
+        or not exists (
+          select 1
+          from pg_catalog.pg_proc p2
+          join pg_catalog.pg_namespace n2 on n2.oid = p2.pronamespace
+          where n2.nspname = 'ash'
+            and p2.proname = a.proname
+            and pg_catalog.pg_get_function_identity_arguments(p2.oid) = a.args
+        )
+      )
   loop
     execute format('grant execute on function ash.%I(%s) to %I%s',
                    r.proname, r.args, r.grantee,


### PR DESCRIPTION
## Summary

Follow-up hardening for the #107 grant-preservation fix shipped in PR #110. During pre-1.6 release-gate validation (manual red/green on real Postgres + a REV-style multi-agent review of #108/#110), the #110 grant snapshot/restore was found to **widen privileges** on every installer re-apply:

1. **Admin-function grants re-established after hardening.** The restore had no `ash._admin_funcs()` filter and runs as the *last* block in the installer — after the admin-hardening block. A stray non-owner `EXECUTE` grant on an admin function in the drop list (e.g. `ash.rebuild_partitions`, `ash.uninstall`) was snapshotted, scrubbed by `DROP FUNCTION`, then **re-granted** afterward, silently undoing the "admin functions stay admin-only on every install" posture.
2. **Overload widening.** The restore re-granted by *name* to every overload. A role holding a single overload of `ash.decode_sample` was widened to all overloads — contradicting the restore's own documented "a role's reach is never widened" contract.

Neither is exploitable for a properly `ash.grant_reader()`-configured role (it never hands out admin functions and already grants every reader overload), but both weaken the documented least-privilege posture and are **latent escalation paths** for any future reader→admin migration. This is a regression vs. pre-#110 behaviour, where `DROP FUNCTION` scrubbed such grants.

## Reproduction (real Postgres, PG17)

| Scenario | pre-#110 (released `sql/`) | post-#110 (`main` `devel/`) | this PR |
|---|---|---|---|
| Stray grant on `rebuild_partitions` survives re-apply | `f` (scrubbed) | **`t` (regression)** | `f` (scrubbed) |
| Single `decode_sample` overload widens to sibling | n/a | **`t` (widened)** | `f` (not widened) |
| `grant_reader` reader grants survive re-apply | `t` | `t` | `t` |

## Fix

Mirrors `grant_reader`'s own filter:
- exclude `ash._admin_funcs()` from the restore (placed in the end-of-script block where that function is defined; the top-of-script snapshot cannot call it);
- capture the argument signature in the snapshot and restore the **exact** overload when it still exists, falling back to by-name for every current overload **only** when the snapshotted signature is gone — the genuine cross-version signature change the by-name restore exists to cover. So #107 reader-grant preservation across real upgrade chains is unaffected (verified: 1.0→1.5→1.6 + re-apply keeps all reader grants).

Staged in `devel/sql/` per the release freeze; `sql/` untouched.

## Tests

Adds a CI regression (`Issue #107 follow-up: grant restore stays least-privilege`) asserting, across an installer re-apply: legitimate reader grants survive, a stray admin grant is scrubbed, a single-overload grant does not widen, reader cannot reach admin functions, and PUBLIC stays revoked. Red on `main` (`admin EXECUTE grant re-established after hardening`), green with this fix. Validated locally on PG 16, 17, 18.

> Do not merge without project-owner approval and a full release-gate re-run.

