### PR TITLE
release: format dynamic drop function

### DIFF
--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -204,7 +204,7 @@ begin
         'aas_queries', 'aas_queries_at'
       )
   loop
-    execute 'drop function if exists ' || func_row.sig;
+    execute format('drop function if exists %s', func_row.sig);
   end loop;
 end $$;
 


### PR DESCRIPTION
## Summary

- replace raw string concatenation in the installer dynamic `drop function` DDL with `format()`
- keep the existing `regprocedure` signature rendering, because it already produces the full parser-ready function reference

## Validation

- `git diff --check`
- `python3 -m py_compile devel/scripts/ash_sql_chain.py`
- `python3 devel/scripts/ash_sql_chain.py fresh-install-version` -> `2.0-beta1`
- local PG smoke: fresh install and installer re-apply both reported `2.0-beta1`
