### PR TITLE
ci: add Postgres 19 beta support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,7 +70,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres: [14, 15, 16, 17, 18]
+        # PG19 is still beta, so the official image tag is 19beta1 until GA.
+        postgres: [14, 15, 16, 17, 18, 19beta1]
         # Quoted so YAML doesn't coerce on/off into booleans — GitHub Actions
         # compares these as strings in the step-level `if`/conditionals.
         cron: ["on"]
@@ -129,7 +130,7 @@ jobs:
           fi
           # Install pg_cron inside the PostgreSQL container (not on host).
           # Allow apt failures to be non-fatal here — PGDG sometimes lags on
-          # new PG majors (e.g. PG18 right after release), and we want to
+          # new PG majors (e.g. PG19 while still in beta), and we want to
           # still exercise the no-cron branch rather than fail the whole job.
           # The follow-up "Verify pg_cron install matches expectation" step
           # enforces the expected state.
@@ -171,7 +172,7 @@ jobs:
             echo "matrix.cron=off — not creating pg_cron extension"
           else
             # pg_cron may legitimately be unavailable on new PG majors before
-            # PGDG catches up (e.g. PG18). Don't fail the job; downstream
+            # PGDG catches up (e.g. PG19 while still in beta). Don't fail the job; downstream
             # cron-gated tests check `pg_extension` and skip themselves.
             psql -h localhost -U postgres -d postgres -c "create extension if not exists pg_cron;" || echo "pg_cron not available (PGDG package missing for this PG major)"
 
@@ -1397,7 +1398,7 @@ jobs:
             v_schedule text;
             v_has_pgcron boolean;
           begin
-            -- Skip cron schedule tests if pg_cron not available (e.g., PG18)
+            -- Skip cron schedule tests if pg_cron not available (e.g., PG19 beta)
             select exists (select from pg_extension where extname = 'pg_cron') into v_has_pgcron;
             if not v_has_pgcron then
               -- Just verify start() works without pg_cron (no error)
@@ -5622,7 +5623,7 @@ jobs:
         run: |
           # Install pg_ash fresh without pg_cron.
           # `drop extension if exists` is a no-op when pg_cron isn't installed
-          # (e.g. PG18 where PGDG package may be missing, or matrix.cron=off).
+          # (e.g. PG19 beta where PGDG package may be missing, or matrix.cron=off).
           # Use ON_ERROR_STOP so unrelated failures don't get silenced.
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
             -c "drop extension if exists pg_cron cascade"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ SQL style guide: https://gitlab.com/postgres-ai/rules/-/blob/main/rules/developm
 
 CI via GitHub Actions:
 
-- **test.yml**: runs on push and PRs — tests across PostgreSQL 14, 15, 16, 17, 18
+- **test.yml**: runs on push and PRs — tests across PostgreSQL 14, 15, 16, 17, 18, 19 beta
 - Tests: fresh development install, discovered full upgrade chain up to the in-progress release, schema equivalence between fresh install and upgrade chain, idempotent re-apply of discovered re-apply-safe upgrade scripts, degraded mode (no pgss/pg_cron)
 - Version schema: `vMAJOR.MINOR` (e.g. `v1.3`). Tag on main after all PRs merged.
 
@@ -23,7 +23,7 @@ Red/green TDD: write failing tests first, then fix the code to make them pass.
 - **Bug fixes**: always write a test that reproduces the bug (RED), then fix (GREEN). This proves the fix works and prevents regressions.
 - **New features**: write tests for the expected behavior before or alongside the implementation. Run current development tests locally with `sudo -u postgres psql -v ON_ERROR_STOP=1 -f "$(python3 devel/scripts/ash_sql_chain.py fresh-install-path)"` and DO blocks with assertions.
 - **CI tests** live in `.github/workflows/test.yml`. Each test section uses PL/pgSQL `DO $$ ... assert ... $$` blocks. Assert exact values, not just row existence — a test that only checks "row exists" can't distinguish correct aggregation from garbage.
-- **Test locally on available PG version** before pushing. CI covers PG 14–18.
+- **Test locally on available PG version** before pushing. CI covers PG 14–19.
 
 ## Code Review
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # pg_ash
 
 [![CI](https://github.com/NikolayS/pg_ash/actions/workflows/test.yml/badge.svg)](https://github.com/NikolayS/pg_ash/actions/workflows/test.yml)
-[![Postgres 14-18](https://img.shields.io/badge/Postgres-14--18-336791?logo=postgresql&logoColor=white)](https://github.com/NikolayS/pg_ash)
+[![Postgres 14-19](https://img.shields.io/badge/Postgres-14--19-336791?logo=postgresql&logoColor=white)](https://github.com/NikolayS/pg_ash)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Pure SQL](https://img.shields.io/badge/Pure_SQL-no_C_extension-green)](https://github.com/NikolayS/pg_ash)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,6 +35,8 @@ surface has been replaced by the AAS-oriented 2.0 API:
 - **Default monitoring access.** Fresh installs and upgrades best-effort grant
   the reader bundle to `pg_monitor`; opt out with
   `select ash.revoke_reader('pg_monitor');`.
+- **Postgres 19 beta support.** CI now covers Postgres 14 through 19, using the
+  official `postgres:19beta1` image until the GA `postgres:19` image exists.
 - **Docs and demos refreshed.** README examples and the generated GIF now use
   the 2.0 named-argument API.
 


### PR DESCRIPTION
## What changed

- Adds `postgres:19beta1` to the GitHub Actions test matrix.
- Updates CI comments for the new-major pg_cron fallback path.
- Updates the README support badge to Postgres 14-19.
- Adds a pg_ash 2.0 beta 1 release-note line for Postgres 19 beta support.
- Updates `CLAUDE.md` CI coverage notes.

## Why

pg_ash 2.0 beta 1 is already usable, and Postgres 19 beta is available as the official `postgres:19beta1` Docker image. Testing it now makes the beta support claim real instead of decorative.

## Validation

- `docker manifest inspect postgres:19beta1`
- local Postgres 19beta1 Docker smoke: install `sql/ash-install.sql`, verify `2.0-beta1`, call `ash.take_sample()` during an active `pg_sleep()` backend
- docs-lint guard commands from `.github/workflows/test.yml`
- `git diff --check`
- `python3 -m py_compile devel/scripts/ash_sql_chain.py`