### PR TITLE
fix: avoid stale rollup reads

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3712,6 +3712,69 @@ jobs:
           end $$;
           EOF
 
+      - name: "Test 2.0: stale rollup falls back to raw"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          -- A wide aggregate read may prefer rollup_1m only when that rollup
+          -- covers the requested end. If raw covers the whole window while the
+          -- rollup worker lags, choosing rollup silently drops the recent load.
+          do $$
+          declare
+            v_wait smallint;
+            v_start timestamptz := date_trunc('minute', now()) - interval '2 hours';
+            v_end timestamptz := date_trunc('minute', now());
+            v_start_ts int4;
+            v_recent_ts int4;
+            a record;
+          begin
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set current_slot = 0,
+                sample_interval = interval '1 second',
+                last_rollup_1m_ts = ash.ts_from_timestamptz(
+                  v_start + interval '1 minute'),
+                last_rollup_1h_ts = null
+            where singleton;
+
+            select ash._register_wait('active', 'IO', 'StaleRollupProof')
+            into v_wait;
+            v_start_ts := ash.ts_from_timestamptz(v_start);
+            v_recent_ts := ash.ts_from_timestamptz(v_end - interval '1 minute');
+
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values (
+              v_start_ts, 0::oid, 1, 1,
+              array[v_wait, 1]::int4[], '{}'::int8[]
+            );
+            insert into ash.sample (
+              sample_ts, datid, active_count, data, slot
+            ) values
+              (v_start_ts, 0::oid, 1, array[-v_wait, 1, 0]::int4[], 0),
+              (v_recent_ts, 0::oid, 1, array[-v_wait, 1, 0]::int4[], 0);
+
+            select * into a from ash.aas(v_start, v_end);
+            assert a.source = 'raw',
+              'stale rollup must fall back to raw, got ' || a.source;
+            assert a.buckets_with_data = 2,
+              'raw fallback should retain both covered minutes, got '
+              || a.buckets_with_data;
+            assert a.backend_seconds = 2.00,
+              'raw fallback should retain both backend-seconds, got '
+              || a.backend_seconds;
+
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set last_rollup_1m_ts = null, last_rollup_1h_ts = null
+            where singleton;
+            raise notice 'stale-rollup source fallback PASSED';
+          end $$;
+          EOF
+
       - name: "Test 2.0: minute-grain peak/p99 survive the rollup_1h seam"
         env:
           PGPASSWORD: postgres

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -3486,7 +3486,9 @@ $$;
  * the non-tie drills of top / chart). Raw and rollup_1m share per-minute
  * grain, so for anything wider than ~1 hour that rollup_1m fully covers we
  * prefer rollup_1m (a raw decode of a wide window spills hundreds of MB — the
- * last-24h read cost ~4.5s and ~500MB before this). Narrow windows still fall
+ * last-24h read cost ~4.5s and ~500MB before this). The rollup watermark must
+ * also reach the requested end whenever raw covers the window start; otherwise
+ * a stalled rollup worker would hide newer raw load. Narrow windows still fall
  * through to _pick_source (raw preferred) so the freshest partial minute is
  * captured, and windows rollup can't cover (or where rollup is
  * disabled/lagging) still fall to raw / rollup_1h. Leaf tie-drills
@@ -3505,7 +3507,19 @@ as $$
   select case
     when extract(epoch from (until - since)) > 3600
          and ash._rollup_1m_retention_start() is not null
-         and since >= ash._rollup_1m_retention_start() then 'rollup_1m'
+         and since >= ash._rollup_1m_retention_start()
+         and (
+           ash._raw_retention_start() is null
+           or since < ash._raw_retention_start()
+           or coalesce(
+                (
+                  select ash.ts_to_timestamptz(last_rollup_1m_ts) >= until
+                  from ash.config
+                  where singleton
+                ),
+                false
+              )
+         ) then 'rollup_1m'
     else ash._pick_source(since)
   end
 $$;


### PR DESCRIPTION
## What changed

- adds a behavioral regression for a greater-than-one-hour window where raw samples cover the requested window but `rollup_1m` stops after its first minute
- makes `ash._pick_source_agg()` require the rollup watermark to reach `until` when raw covers `since`
- preserves the existing partial-rollup fallback when raw cannot answer the window start

## Why

The 2.0 aggregate readers selected `rollup_1m` from its retention start alone. If the rollup worker lagged or stopped, the readers returned plausible but incomplete values and omitted newer raw load.

This is a release-candidate SQL correction on a `release/*` branch because the beta installer is already stamped under `sql/`.

## Impact

The correction applies to the new aggregate surface that delegates to `_pick_source_agg()`: `aas`, `timeline`, `periods`, non-tie `top`, and `chart`.

## Validation

- RED on Postgres 18 at `54362ff`: `stale rollup must fall back to raw, got rollup_1m`
- GREEN on Postgres 18 at `6123780`: exact source, covered-minute, and backend-second assertions pass
- fresh install and full installer re-apply with `ON_ERROR_STOP=1` pass
- `git diff --check main...HEAD` passes

Closes #122