### PR TITLE
fix: make SQL entrypoints atomic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -270,6 +270,81 @@ jobs:
         run: |
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f "$(python3 devel/scripts/ash_sql_chain.py fresh-install-path)"
 
+      - name: Test SQL entrypoints fail atomically
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql_base=(
+            psql
+            --no-psqlrc
+            --host=localhost
+            --username=postgres
+          )
+
+          "${psql_base[@]}" --dbname=postgres --set=ON_ERROR_STOP=1 << 'EOF'
+          drop database if exists ash_install_failure_test with (force);
+          create database ash_install_failure_test;
+          drop database if exists ash_migration_failure_test with (force);
+          create database ash_migration_failure_test;
+          EOF
+          "${psql_base[@]}" \
+            --dbname=ash_install_failure_test \
+            --set=ON_ERROR_STOP=1 << 'EOF'
+          create schema ash;
+          create view ash.config as select true as singleton;
+          EOF
+
+          set +e
+          "${psql_base[@]}" \
+            --dbname=ash_install_failure_test \
+            --file=sql/ash-install.sql \
+            >/tmp/ash_install_failure.log 2>&1
+          install_rc=$?
+          set -e
+          if (( install_rc == 0 )); then
+            cat /tmp/ash_install_failure.log >&2
+            echo "fresh installer masked an expected SQL failure" >&2
+            exit 1
+          fi
+
+          "${psql_base[@]}" \
+            --dbname=ash_install_failure_test \
+            --set=ON_ERROR_STOP=1 << 'EOF'
+          do $$
+          begin
+            assert to_regclass('ash.config') is not null,
+              'pre-existing failure fixture must survive rollback';
+            assert not exists (
+              select from pg_proc as proc
+              join pg_namespace as nsp on nsp.oid = proc.pronamespace
+              where nsp.nspname = 'ash'
+            ), 'failed installer left functions behind';
+            assert not exists (
+              select from pg_tables where schemaname = 'ash'
+            ), 'failed installer left tables behind';
+          end $$;
+          EOF
+
+          set +e
+          "${psql_base[@]}" \
+            --dbname=ash_migration_failure_test \
+            --file=sql/migrations/ash-1.1-to-1.2.sql \
+            >/tmp/ash_migration_failure.log 2>&1
+          migration_rc=$?
+          set -e
+          if (( migration_rc == 0 )); then
+            cat /tmp/ash_migration_failure.log >&2
+            echo "canonical migration masked an expected SQL failure" >&2
+            exit 1
+          fi
+
+          "${psql_base[@]}" \
+            --dbname=ash_migration_failure_test \
+            --tuples-only \
+            --no-align \
+            --command="select count(*) from pg_namespace where nspname = 'ash'" \
+            | grep -qx 0
+
       - name: Test schema and infrastructure
         env:
           PGPASSWORD: postgres

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -10,6 +10,8 @@
  * Upgrade from 1.5: \i sql/migrations/ash-1.5-to-2.0.sql
  */
 
+\set ON_ERROR_STOP on
+begin;
 
 /*
  * Preserve function EXECUTE grants across the drop/recreate below (#107).
@@ -6404,3 +6406,5 @@ exception when others then
     'ignore to leave pg_monitor without access',
     sqlstate, sqlerrm;
 end $$;
+
+commit;

--- a/sql/migrations/ash-1.0-to-1.1.sql
+++ b/sql/migrations/ash-1.0-to-1.1.sql
@@ -1,4 +1,7 @@
 -- pg_ash: upgrade from 1.0 to 1.1
 -- ash-1.1.sql is safe to run on top of 1.0 (IF NOT EXISTS / CREATE OR REPLACE)
 -- This file simply loads it.
+\set ON_ERROR_STOP on
+begin;
 \ir ../ash-1.1.sql
+commit;

--- a/sql/migrations/ash-1.1-to-1.2.sql
+++ b/sql/migrations/ash-1.1-to-1.2.sql
@@ -3,6 +3,8 @@
 -- Changes: bar column on query_waits/top_by_type, event_queries(),
 -- chart padding for psql alignment, version tracking.
 
+\set ON_ERROR_STOP on
+begin;
 
 -- Add version column if missing
 do $$
@@ -1464,3 +1466,5 @@ begin
   execute format('grant execute on function ash.rotate() to %I', v_owner);
   execute format('grant execute on function ash.take_sample() to %I', v_owner);
 end $$;
+
+commit;

--- a/sql/migrations/ash-1.2-to-1.3.sql
+++ b/sql/migrations/ash-1.2-to-1.3.sql
@@ -11,6 +11,9 @@
 --   - Version column DEFAULT fix for schema parity (#9)
 --   - Code style: != to <> (#7)
 
+\set ON_ERROR_STOP on
+begin;
+
 -- Add debug_logging column to config if missing
 do $$
 begin
@@ -2653,3 +2656,5 @@ begin
   execute format('grant execute on function ash.take_sample() to %I', v_owner);
   execute format('grant execute on function ash.set_debug_logging(bool) to %I', v_owner);
 end $$;
+
+commit;

--- a/sql/migrations/ash-1.3-to-1.4.sql
+++ b/sql/migrations/ash-1.3-to-1.4.sql
@@ -1,4 +1,5 @@
 -- pg_ash: upgrade from 1.3 to 1.4
+\set ON_ERROR_STOP on
 -- NOTE: this script is a thin shim that runs `\ir ../ash-install.sql`, which
 -- always reflects the LATEST released version. Running it on a 1.3 install
 -- upgrades all the way to the current latest (currently 1.4). This is by

--- a/sql/migrations/ash-1.4-to-1.5.sql
+++ b/sql/migrations/ash-1.4-to-1.5.sql
@@ -4,6 +4,4 @@
 -- upgrade path stays schema-equivalent with fresh 1.5 installs.
 
 \set ON_ERROR_STOP on
-begin;
 \ir ../ash-install.sql
-commit;

--- a/sql/migrations/ash-1.5-to-2.0.sql
+++ b/sql/migrations/ash-1.5-to-2.0.sql
@@ -31,6 +31,4 @@
  */
 
 \set ON_ERROR_STOP on
-begin;
 \ir ../ash-install.sql
-commit;


### PR DESCRIPTION
## What changed

- enables `ON_ERROR_STOP` inside the documented fresh installer and canonical migration entrypoints
- wraps the fresh installer and legacy inline migrations in a transaction
- lets migrations that replay `ash-install.sql` delegate transaction ownership to the installer, avoiding nested `BEGIN` / premature `COMMIT`
- adds negative CI coverage for a deterministic mid-install failure and an invalid canonical migration precondition

## Why

The README-supported paths could emit many SQL errors, continue, and exit 0. A failed fresh install could leave dozens of functions and several tables behind, so automation and interactive operators had no trustworthy success signal.

## Impact

Failed installs and migrations now stop at the first error, return a nonzero psql status, and roll back installer-created objects. Successful fresh installs, re-applies, and the historical upgrade chain retain their existing behavior.

## Validation

Postgres 18:

- RED at `9274ab9`: fresh installer and canonical migration both exited 0; the installer left 53 functions and three tables
- GREEN at `3a46c93`: both failure paths exit 3
- failed fresh install leaves zero functions and zero tables; the pre-existing failure fixture survives
- failed canonical migration leaves no `ash` schema
- fresh install and full installer re-apply pass at `2.0-beta1`
- discovered 1.0 → 2.0 upgrade chain passes and exposes all nine new reader names
- `git diff --check main...HEAD` passes

Closes #124