### PR TITLE
fix: keep report totals consistent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2071,6 +2071,136 @@ jobs:
           end $$;
           EOF
 
+      - name: "Test 2.0: report totals and formatting edges"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          do $$
+          declare
+            v_ts int4 := ash.ts_from_timestamptz(
+              date_trunc('minute', now()) - interval '10 minutes');
+            v_cpu smallint;
+            v_io smallint;
+            v_ipc smallint;
+            v_lock smallint;
+            v_lwlock smallint;
+            v_client smallint;
+            v_cpu_map int4;
+            v_client_map int4;
+            v_large_map int4;
+            j jsonb;
+            v_text text[];
+          begin
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set current_slot = 0, sample_interval = interval '1 second',
+                last_rollup_1m_ts = null, last_rollup_1h_ts = null
+            where singleton;
+
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+            select ash._register_wait('active', 'IO', 'DataFileRead') into v_io;
+            select ash._register_wait('active', 'IPC', 'ProcArrayGroupUpdate')
+            into v_ipc;
+            select ash._register_wait('active', 'Lock', 'transactionid')
+            into v_lock;
+            select ash._register_wait('active', 'LWLock', 'WALWrite')
+            into v_lwlock;
+            select ash._register_wait('active', 'Client', 'ClientRead')
+            into v_client;
+
+            insert into ash.query_map_0 (query_id)
+            values (900000000000001), (900000000000002), (900000000000003)
+            on conflict (query_id) do nothing;
+            select id into v_cpu_map from ash.query_map_0
+            where query_id = 900000000000001;
+            select id into v_client_map from ash.query_map_0
+            where query_id = 900000000000002;
+            select id into v_large_map from ash.query_map_0
+            where query_id = 900000000000003;
+
+            -- The report total excludes Client, so total query attribution
+            -- must not let a Client-dominant query explain that total.
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values (
+              v_ts, 0::oid, 1, 21,
+              array[v_cpu, 1, v_client, 20]::int4[], '{}'::int8[]
+            );
+            insert into ash.sample (
+              sample_ts, datid, active_count, data, slot
+            ) values (
+              v_ts, 0::oid, 21,
+              array[-v_cpu, 1, v_cpu_map, -v_client, 20]::int4[]
+                || array_fill(v_client_map, array[20]),
+              0
+            );
+            j := ash.report(
+              ash.ts_to_timestamptz(v_ts),
+              ash.ts_to_timestamptz(v_ts + 60)
+            );
+            assert (j->'aas_worst1m'->>'total')::numeric = 0.02,
+              'report total fixture must include CPU only';
+            assert j->'top_queryids_worst1m'->'total'
+                     = '["900000000000001(0.0)"]'::jsonb,
+              'report total query attribution included an excluded wait class: '
+              || (j->'top_queryids_worst1m'->'total')::text;
+
+            -- Total average comes from the summed series, not the sum of five
+            -- independently rounded display fields: 5 / 60 rounds to 0.08.
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m;
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values (
+              v_ts, 0::oid, 1, 5,
+              array[
+                v_cpu, 1, v_io, 1, v_ipc, 1, v_lock, 1, v_lwlock, 1
+              ]::int4[],
+              '{}'::int8[]
+            );
+            j := ash.report(
+              ash.ts_to_timestamptz(v_ts),
+              ash.ts_to_timestamptz(v_ts + 60)
+            );
+            assert (j->'aas_avg'->>'total')::numeric = 0.08,
+              'report aas_avg.total must be 0.08, got '
+              || (j->'aas_avg'->>'total');
+            assert (j->'aas_avg'->>'total')::numeric
+                     <= (j->'aas_worst1m'->>'total')::numeric,
+              'report average total cannot exceed its worst minute';
+
+            -- Four-digit AAS must remain numeric text, not to_char hash
+            -- overflow. 30,000 appearances * 2 seconds / 60 = 1,000.0.
+            truncate ash.rollup_1m;
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values (
+              v_ts, 0::oid, 1, 30000,
+              array[v_io, 30000]::int4[], '{}'::int8[]
+            );
+            insert into ash.sample (
+              sample_ts, datid, active_count, data, slot
+            ) values (
+              v_ts, 0::oid, 30000,
+              array[-v_io, 30000]::int4[]
+                || array_fill(v_large_map, array[30000]),
+              0
+            );
+            v_text := ash._hr_top_events('IO', array[v_ts], 1, 2);
+            assert v_text = array['DataFileRead(1000.0)'],
+              'large event AAS formatting mismatch: ' || v_text::text;
+            v_text := ash._hr_top_queryids('IO', array[v_ts], 1, 2);
+            assert v_text = array['900000000000003(1000.0)'],
+              'large query AAS formatting mismatch: ' || v_text::text;
+
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            raise notice 'ash.report totals and formatting edges PASSED';
+          end $$;
+          EOF
+
       - name: "Test 2.0: pg_stat_statements fan-out and reader edges"
         env:
           PGPASSWORD: postgres

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -4983,8 +4983,8 @@ $$;
 
 /*
  * report helper: top query ids at a set of minutes, optionally within one
- * wait class (type null = across all classes = the 'total' key), read from RAW
- * samples (the wait<->query tie). "queryid(aas)" strings, int64-safe.
+ * wait class (type null = the five classes included in the 'total' key), read
+ * from RAW samples (the wait<->query tie). "queryid(aas)" strings, int64-safe.
  */
 create or replace function ash._hr_top_queryids(
   type text, minutes int4[], n int, si numeric
@@ -5292,9 +5292,9 @@ begin
   end loop;
 
   /*
-   * Total = the summed per-minute series' OWN extreme (matches the platform
-   * ingestion recipe and top_queryids_*.total). Statement 1: values +
-   * unrounded thresholds + worst minute.
+   * Total statistics come from the summed per-minute series (matching the
+   * platform ingestion recipe and top_queryids_*.total). Statement 1: average,
+   * own extremes, unrounded thresholds, and worst minute.
    */
   with grid as (
     select covered.ts, coalesce(total_counts.cnt, 0) * v_si / 60.0 as aas

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -4974,9 +4974,8 @@ as $$
   )
   select coalesce(
     array_agg(ev || '(' ||
-      to_char(round(cnt * si
-                    / (greatest(array_length(minutes, 1), 1) * 60.0), 1),
-              'FM990.0') || ')'
+      round(cnt * si
+            / (greatest(array_length(minutes, 1), 1) * 60.0), 1)::text || ')'
       order by cnt desc),
     array[]::text[])
   from per_minute_event
@@ -5036,17 +5035,19 @@ as $$
      * to the event_map.type column (columns take precedence), not the
      * parameter
      */
-    where (_hr_top_queryids.type is null
-           or event_map.type = _hr_top_queryids.type)
+    where (
+      (_hr_top_queryids.type is null
+       and event_map.type in ('CPU*', 'IO', 'IPC', 'Lock', 'LWLock'))
+      or event_map.type = _hr_top_queryids.type
+    )
     group by query_map.query_id
     order by 2 desc
     limit greatest(n, 0)
   )
   select coalesce(
     array_agg(qid::text || '(' ||
-      to_char(round(cnt * si
-                    / (greatest(array_length(minutes, 1), 1) * 60.0), 1),
-              'FM990.0') || ')'
+      round(cnt * si
+            / (greatest(array_length(minutes, 1), 1) * 60.0), 1)::text || ')'
       order by cnt desc),
     array[]::text[])
   from hits
@@ -5250,13 +5251,6 @@ begin
       v_p99 := v_p99 || jsonb_build_object(v_class.k, v_cp99);
       v_p999 := v_p999 || jsonb_build_object(v_class.k, v_cp999);
       /*
-       * avg of a sum == sum of the class avgs, so total avg is accumulated
-       * here; worst1m/p99/p999 total come from the summed series' OWN extreme
-       * (below), not the sum of each class's independent worst minute.
-       */
-      v_tot_avg := v_tot_avg + coalesce(v_cavg, 0);
-
-      /*
        * top_events (rollup) and top_queryids (raw) for the four non-cpu
        * classes; top_queryids 'total' is handled once, outside this loop.
        */
@@ -5320,6 +5314,7 @@ begin
     ) as total_counts on total_counts.ts = covered.ts
   )
   select
+    round(coalesce(avg(aas), 0), 2),
     round(coalesce(max(aas), 0), 2),
     round(coalesce(
       percentile_cont(0.99) within group (order by aas), 0)::numeric, 2),
@@ -5328,7 +5323,8 @@ begin
     percentile_cont(0.99) within group (order by aas),
     percentile_cont(0.999) within group (order by aas),
     (select ts from grid order by aas desc, ts limit 1)
-  into v_tot_worst, v_tot_p99, v_tot_p999, v_t99_thr, v_t999_thr, v_tworst_min
+  into v_tot_avg, v_tot_worst, v_tot_p99, v_tot_p999,
+       v_t99_thr, v_t999_thr, v_tworst_min
   from grid;
 
   -- Statement 2: the p99/p999 minute sets (>= the unrounded thresholds).


### PR DESCRIPTION
## What changed

- restricts `top_queryids_*.total` attribution to the same five wait classes included in report total
- formats pre-rendered event/query AAS via rounded numeric text instead of the width-limited `FM990.0` mask
- computes `aas_avg.total` from the summed per-minute series rather than summing independently rounded class fields
- adds exact behavioral regressions for all three cases
- clarifies the two affected total-series comments

## Why

The 2.0 machine-report payload could attribute excluded Client load to its total, render AAS 1,000 as `###.#`, and report an average total greater than its worst-minute total through compounded rounding.

## Impact

The frozen JSON key structure is unchanged. Values now remain internally consistent and valid at high load.

## Validation

Postgres 17.9 after rebasing onto `origin/main` at `88b69cf`:

- RED: the named regression step exits 3 because the excluded Client query leads `top_queryids_worst1m.total`
- GREEN at `6f39138`:
  - total query attribution contains only the CPU query in the mixed CPU/Client fixture
  - five one-count classes report `aas_avg.total = 0.08` and `aas_worst1m.total = 0.08`
  - both event and query helpers render exactly `1000.0`
- `codex review --base origin/main` reports no findings
- `git diff --check origin/main...HEAD` passes

Closes #126
