### PR TITLE
fix: ignore excluded raw ring slot

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4693,6 +4693,30 @@ jobs:
           PGPASSWORD: postgres
         run: |
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          begin;
+
+          update ash.config
+          set num_partitions = 6,
+              current_slot = 2
+          where singleton;
+
+          do $$
+          declare
+            v_slots smallint[];
+          begin
+            select ash._active_slots() into v_slots;
+
+            assert v_slots = array[2, 1, 0, 5, 4]::smallint[],
+              format(
+                '_active_slots() for N=6/current=2: '
+                'expected {2,1,0,5,4}, got %s',
+                v_slots
+              );
+          end
+          $$;
+
+          rollback;
+
           do $$
           declare
             v_wait smallint;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4688,6 +4688,70 @@ jobs:
           end $$;
           EOF
 
+      - name: "Test 2.0: raw retention ignores the excluded ring slot"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          do $$
+          declare
+            v_wait smallint;
+            v_old_ts int4 := ash.ts_from_timestamptz(
+              date_trunc('minute', now()) - interval '2 days');
+            v_recent_ts int4 := ash.ts_from_timestamptz(
+              date_trunc('minute', now()) - interval '10 minutes');
+            v_start timestamptz;
+            v_status_start timestamptz;
+            v_slots smallint[];
+            v_raised boolean := false;
+          begin
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            update ash.config
+            set current_slot = 0, num_partitions = 3,
+                rotation_period = interval '1 day'
+            where singleton;
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_wait;
+
+            -- For N=3/current=0, readers retain slots {0,2}; slot 1 is the
+            -- excluded oldest ring slot awaiting its next truncate.
+            insert into ash.sample (
+              sample_ts, datid, active_count, data, slot
+            ) values
+              (v_old_ts, 0::oid, 1, array[-v_wait, 1, 0]::int4[], 1),
+              (v_recent_ts, 0::oid, 1, array[-v_wait, 1, 0]::int4[], 0);
+
+            v_slots := ash._active_slots();
+            assert v_slots = array[0, 2]::smallint[],
+              'retained slot set should be {0,2}, got ' || v_slots::text;
+            v_start := ash._raw_retention_start();
+            assert v_start = ash.ts_to_timestamptz(v_recent_ts),
+              'raw retention start used excluded slot 1: ' || v_start::text;
+            select value::timestamptz into v_status_start
+            from ash.status() where metric = 'raw_retention_start';
+            assert v_status_start = v_start,
+              'status raw_retention_start disagrees with retained slots';
+
+            begin
+              perform * from ash.aas(
+                ash.ts_to_timestamptz(v_old_ts),
+                ash.ts_to_timestamptz(v_old_ts + 60),
+                wait_event => 'CPU*', query_id => 128128
+              );
+            exception when others then
+              if sqlerrm like '%entirely outside raw retention%' then
+                v_raised := true;
+              else
+                raise;
+              end if;
+            end;
+            assert v_raised,
+              'tie drill over the excluded slot must raise past retention';
+
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            raise notice 'raw retention excludes the oldest ring slot PASSED';
+          end $$;
+          EOF
+
       - name: "Test v1.4: status output"
         env:
           PGPASSWORD: postgres

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -2217,18 +2217,23 @@ $$;
 -- STEP 5: Reader and diagnostic functions
 --------------------------------------------------------------------------------
 
--- Helper to get active slots (current and previous).
+-- Helper to get every raw slot retained by the configured partition ring.
 create or replace function ash._active_slots()
 returns smallint[]
 language sql
 stable
 set search_path = pg_catalog, ash
 as $$
-  select array[
-    current_slot,
-    ((current_slot - 1 + num_partitions) % num_partitions)::smallint
-  ]
-  from ash.config
+  select array(
+    select
+      ((config_row.current_slot - slot_offset.i
+        + config_row.num_partitions) % config_row.num_partitions)::smallint
+    from generate_series(
+      0, config_row.num_partitions - 2
+    ) as slot_offset(i)
+    order by slot_offset.i
+  )
+  from ash.config as config_row
   where singleton
 $$;
 
@@ -3445,7 +3450,9 @@ language sql
 stable
 set search_path = pg_catalog, ash
 as $$
-  select ash.ts_to_timestamptz(min(sample_ts)) from ash.sample
+  select ash.ts_to_timestamptz(min(sample_ts))
+  from ash.sample
+  where slot = any(ash._active_slots())
 $$;
 
 create or replace function ash._rollup_1m_retention_start()


### PR DESCRIPTION
## What changed

- makes `ash._active_slots()` enumerate the configured retained ring offsets `0 .. num_partitions - 2`
- filters `ash._raw_retention_start()` to that exact readable slot set
- adds a behavioral regression with a populated excluded oldest slot
- adds a discriminating six-partition assertion for the generalized slot enumeration

## Why

The physical oldest ring slot remains populated until its next truncate but is deliberately excluded from raw readers. Including it in the retention minimum made `status()` and report coverage advertise unreadable history and allowed old event/query tie drills to pass the guard before returning a silent zero.

## Impact

Raw-retention metadata now describes data the reader helpers can actually access. An event/query tie drill over excluded history raises the documented outside-retention error.

This PR intentionally does not fix the time-bound path from #128. It also moves the boundary newer, making the partial-first-minute defect in #163 strictly worse; #163 must be fixed with or immediately after this change. Frozen 1.x installers still contain the old two-slot `_active_slots()` body and must not be reapplied as a terminal installer over 2.0.

## Validation

Postgres 17.9 after rebasing onto `origin/main` at `ce541ac`:

- RED: the new N=6/current=2 assertion exits 3 on the base with `got {2,1}`
- GREEN at `2006159`: `_active_slots()` returns exact `{2,1,0,5,4}` and the complete named retention regression exits 0
- existing N=3 fixture still verifies `{0,2}`, helper/status agreement, and the outside-retention error
- actionlint and `git diff --check` pass
- `codex review --base origin/main` reports no introduced correctness issue

Refs #128
