### PR TITLE
fix: defer hourly rollup until minute coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1424,6 +1424,49 @@ jobs:
           PGPASSWORD: postgres
         run: |
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          select case
+                   when exists (
+                     select from pg_extension where extname = 'pg_cron'
+                   ) then 'true'
+                   else 'false'
+                 end as has_pgcron \gset
+          \if :has_pgcron
+            -- Simulate an existing installation whose job still has the old
+            -- unsafe schedule, then prove installer re-apply migrates it.
+            create temp table _legacy_hourly_job (jobid bigint primary key);
+            insert into _legacy_hourly_job
+            select cron.schedule(
+              'ash_rollup_1h', '0 * * * *', 'select ash.rollup_hour()'
+            );
+            select cron.alter_job(
+              job_id := (select jobid from _legacy_hourly_job),
+              active := false
+            );
+            \i sql/ash-install.sql
+            do $migration$
+            declare
+              v_job_id bigint;
+              v_schedule text;
+              v_command text;
+              v_active bool;
+            begin
+              select jobid, schedule, command, active
+              into v_job_id, v_schedule, v_command, v_active
+              from cron.job
+              where jobname = 'ash_rollup_1h';
+              assert v_job_id = (select jobid from _legacy_hourly_job),
+                'installer re-apply replaced the existing hourly job';
+              assert v_schedule = '1 * * * *',
+                'installer re-apply must migrate hourly rollup to minute 1, '
+                'got: ' || v_schedule;
+              assert v_command = 'select ash.rollup_hour()',
+                'installer re-apply changed the hourly command';
+              assert not v_active,
+                'installer re-apply reactivated the disabled hourly job';
+            end
+            $migration$;
+          \endif
+
           do $$
           declare
             v_job_id bigint;
@@ -3506,6 +3549,8 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
+          set -euo pipefail
+
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
           do $$
           declare
@@ -3592,6 +3637,106 @@ jobs:
             raise notice 'rollup_hour completion barrier PASSED';
           end $$;
           EOF
+
+          # Reproduce the pg_cron minute-1 collision. The simulated minute
+          # worker completes the watermark while holding the shared rollup
+          # lock; rollup_hour() must wait, then aggregate instead of returning
+          # 0 and deferring the hour until the next cron run.
+          psql_base=(psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1)
+          hour_ts="$("${psql_base[@]}" -tAc "
+            select (
+              ash.ts_from_timestamptz(
+                date_trunc('hour', now() - interval '1 hour')
+              ) / 3600
+            ) * 3600
+          ")"
+          wait_id="$("${psql_base[@]}" -tAc "
+            select ash._register_wait('active', 'CPU*', 'CPU*')
+          ")"
+
+          "${psql_base[@]}" << SQL
+          truncate ash.rollup_1m, ash.rollup_1h;
+          insert into ash.rollup_1m (
+            ts, datid, samples, peak_backends, wait_counts, query_counts
+          )
+          select
+            ${hour_ts} + minute_idx * 60,
+            0::oid,
+            60,
+            1,
+            array[${wait_id}, 60]::int4[],
+            '{}'::int8[]
+          from generate_series(0, 58) as minute_idx;
+          update ash.config
+          set last_rollup_1m_ts = ${hour_ts} + 3540,
+              last_rollup_1h_ts = ${hour_ts}
+          where singleton;
+          SQL
+
+          "${psql_base[@]}" -c "
+            begin;
+            select pg_advisory_xact_lock(
+              hashtext('pg_ash')::int4,
+              hashtext('pg_ash_rollup')::int4
+            );
+            select pg_sleep(1);
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values (
+              ${hour_ts} + 3540,
+              0::oid,
+              60,
+              1,
+              array[${wait_id}, 60]::int4[],
+              '{}'::int8[]
+            );
+            update ash.config
+            set last_rollup_1m_ts = ${hour_ts} + 3600
+            where singleton;
+            commit;
+          " >/tmp/ash-hourly-lock-holder.log &
+          lock_holder_pid=$!
+
+          lock_seen=false
+          for _ in {1..100}; do
+            if [ "$("${psql_base[@]}" -tAc "
+              select exists (
+                select from pg_locks
+                where locktype = 'advisory'
+                  and classid = hashtext('pg_ash')::int4::oid
+                  and objid = hashtext('pg_ash_rollup')::int4::oid
+                  and granted
+                  and pid <> pg_backend_pid()
+              )
+            ")" = "t" ]; then
+              lock_seen=true
+              break
+            fi
+            sleep 0.05
+          done
+          if [ "$lock_seen" != "true" ]; then
+            echo "::error::timed out waiting for simulated minute worker" >&2
+            wait "$lock_holder_pid"
+            exit 1
+          fi
+
+          hourly_result="$("${psql_base[@]}" -tAc "select ash.rollup_hour()")"
+          wait "$lock_holder_pid"
+          hourly_rows="$("${psql_base[@]}" -tAc "
+            select count(*) from ash.rollup_1h where ts = ${hour_ts}
+          ")"
+          if [ "$hourly_result" != "1" ] || [ "$hourly_rows" != "1" ]; then
+            echo "::error::rollup_hour did not wait for minute coverage (result=$hourly_result, rows=$hourly_rows)" >&2
+            exit 1
+          fi
+          echo "rollup_hour lock serialization PASSED"
+
+          "${psql_base[@]}" -c "
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set last_rollup_1m_ts = null, last_rollup_1h_ts = null
+            where singleton;
+          "
 
       - name: "Critical bug #81: rollup and rotation must not lose raw samples"
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1451,6 +1451,11 @@ jobs:
             assert v_job_id is not null, '1 second should work';
             select schedule into v_schedule from cron.job where jobid = v_job_id;
             assert v_schedule = '1 seconds', '1 second should be 1 seconds, got: ' || v_schedule;
+            select schedule into v_schedule
+            from cron.job
+            where jobname = 'ash_rollup_1h';
+            assert v_schedule = '1 * * * *',
+              'hourly rollup should run at minute 1, got: ' || v_schedule;
             perform ash.stop();
 
             select job_id into v_job_id

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3491,6 +3491,96 @@ jobs:
           $$;
           EOF
 
+      - name: "Critical: rollup_hour waits for complete minute coverage"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          do $$
+          declare
+            v_hour_ts int4 := (
+              ash.ts_from_timestamptz(
+                date_trunc('hour', now() - interval '2 hours')
+              ) / 3600
+            ) * 3600;
+            v_wait_id smallint;
+            v_result int;
+            v_row record;
+          begin
+            truncate ash.rollup_1m, ash.rollup_1h;
+            select ash._register_wait('active', 'CPU*', 'CPU*')
+              into v_wait_id;
+
+            -- Simulate the top-of-hour race: minute rollup has completed only
+            -- slots 0..58 when the hourly worker starts.
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            )
+            select
+              v_hour_ts + minute_idx * 60,
+              0::oid,
+              60,
+              1,
+              array[v_wait_id, 60]::int4[],
+              '{}'::int8[]
+            from generate_series(0, 58) as minute_idx;
+
+            update ash.config
+            set last_rollup_1m_ts = v_hour_ts + 3540,
+                last_rollup_1h_ts = v_hour_ts
+            where singleton;
+
+            select ash.rollup_hour() into v_result;
+            assert v_result = 0,
+              'rollup_hour must defer an hour not covered by the minute '
+              'watermark, got ' || v_result;
+            assert not exists (
+              select from ash.rollup_1h where ts = v_hour_ts
+            ), 'rollup_hour inserted a partial hour';
+            assert (select last_rollup_1h_ts from ash.config where singleton)
+                     = v_hour_ts,
+              'rollup_hour advanced its watermark past an incomplete hour';
+
+            -- The final minute arrives after the first hourly attempt. The
+            -- retry must now materialize the complete hour exactly once.
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values (
+              v_hour_ts + 3540, 0::oid, 60, 1,
+              array[v_wait_id, 60]::int4[], '{}'::int8[]
+            );
+            update ash.config
+            set last_rollup_1m_ts = v_hour_ts + 3600
+            where singleton;
+
+            select ash.rollup_hour() into v_result;
+            assert v_result = 1,
+              'rollup_hour should process the hour after minute coverage '
+              'completes, got ' || v_result;
+
+            select * into v_row
+            from ash.rollup_1h
+            where ts = v_hour_ts and datid = 0::oid;
+            assert v_row.samples = 3600,
+              'complete hour samples should be 3600, got ' || v_row.samples;
+            assert v_row.wait_counts = array[v_wait_id, 3600]::int4[],
+              'complete hour wait_counts mismatch: ' || v_row.wait_counts::text;
+            assert cardinality(v_row.minute_counts) = 60,
+              'complete hour must preserve all 60 minute slots';
+            assert v_row.minute_counts[60] = 60,
+              'last minute slot missing after retry';
+            assert (select last_rollup_1h_ts from ash.config where singleton)
+                     = v_hour_ts + 3600,
+              'hourly watermark did not advance after complete aggregation';
+
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set last_rollup_1m_ts = null, last_rollup_1h_ts = null
+            where singleton;
+            raise notice 'rollup_hour completion barrier PASSED';
+          end $$;
+          EOF
+
       - name: "Critical bug #81: rollup and rotation must not lose raw samples"
         env:
           PGPASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3291,7 +3291,10 @@ jobs:
                 (v_hour_ts + 60, 0::oid, 60, 3, array[v_wait_id, 100]::int4[], '{12345,40}'::int8[])
               on conflict (ts, datid) do nothing;
 
-              update ash.config set last_rollup_1h_ts = null where singleton;
+              update ash.config
+              set last_rollup_1m_ts = v_hour_ts + 3600,
+                  last_rollup_1h_ts = null
+              where singleton;
               select ash.rollup_hour() into v_result;
               assert v_result > 0,
                 'rollup_hour should process seeded data';
@@ -3471,7 +3474,10 @@ jobs:
               '{12345,40}'::int8[])
             on conflict (ts, datid) do nothing;
 
-            update ash.config set last_rollup_1h_ts = null where singleton;
+            update ash.config
+            set last_rollup_1m_ts = v_hour_ts + 3600,
+                last_rollup_1h_ts = null
+            where singleton;
             select ash.rollup_hour() into v_result;
             assert v_result > 0,
               'rollup_hour should handle different-length arrays';
@@ -3567,8 +3573,9 @@ jobs:
               'complete hour wait_counts mismatch: ' || v_row.wait_counts::text;
             assert cardinality(v_row.minute_counts) = 60,
               'complete hour must preserve all 60 minute slots';
-            assert v_row.minute_counts[60] = 60,
-              'last minute slot missing after retry';
+            assert v_row.minute_counts = array_fill(60, array[60]),
+              'complete hour minute_counts mismatch: '
+              || v_row.minute_counts::text;
             assert (select last_rollup_1h_ts from ash.config where singleton)
                      = v_hour_ts + 3600,
               'hourly watermark did not advance after complete aggregation';
@@ -3949,7 +3956,12 @@ jobs:
                       array[v_cpu, case when i = 30 then 618 else 40 end,
                             v_io,  case when i = 30 then 60  else 20 end]::int4[], '{}'::int8[]);
             end loop;
-            update ash.config set last_rollup_1h_ts = ash.ts_from_timestamptz(v_h) where singleton;
+            update ash.config
+            set last_rollup_1m_ts = ash.ts_from_timestamptz(
+                  v_h + interval '1 hour'
+                ),
+                last_rollup_1h_ts = ash.ts_from_timestamptz(v_h)
+            where singleton;
             perform ash.rollup_hour();
 
             -- rollup_hour() computes minute_counts exactly: 60 slots, storm at 31

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ Also schedule maintenance:
 ```bash
 0 0 * * * psql -qAtX -d mydb -c "select ash.rotate();"
 * * * * * psql -qAtX -d mydb -c "select ash.rollup_minute();"
-0 * * * * psql -qAtX -d mydb -c "select ash.rollup_hour();"
+1 * * * * psql -qAtX -d mydb -c "select ash.rollup_hour();"
 0 3 * * * psql -qAtX -d mydb -c "select ash.rollup_cleanup();"
 ```
 

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -1799,7 +1799,7 @@ begin
     job_id := null;
     status :=
       'schedule ash.rollup_minute() every minute, ash.rollup_hour() '
-      'every hour, ash.rollup_cleanup() daily';
+      'at minute 1 every hour, ash.rollup_cleanup() daily';
     return next;
 
     raise notice
@@ -1817,7 +1817,8 @@ begin
       '(default: daily).';
     raise notice
       'Schedule rollup: ash.rollup_minute() every minute, '
-      'ash.rollup_hour() every hour, ash.rollup_cleanup() daily.';
+      'ash.rollup_hour() at minute 1 every hour, '
+      'ash.rollup_cleanup() daily.';
 
     return;
   end if;
@@ -6427,15 +6428,23 @@ declare
 begin
   if ash._pg_cron_available() then
     for v_hourly_job in
-      select jobid
+      select jobname, command
       from cron.job
       where jobname = 'ash_rollup_1h'
         and database = current_database()
+        and username = current_user
         and schedule = '0 * * * *'
     loop
-      perform cron.alter_job(
-        job_id := v_hourly_job.jobid,
-        schedule := '1 * * * *'
+      /*
+       * Named cron.schedule() updates the caller's existing job in place and
+       * is available to ordinary pg_cron job owners. cron.alter_job() is not:
+       * pg_cron revokes it from PUBLIC by default. Reusing the stored command
+       * also preserves custom command text; pg_cron keeps jobid/active state.
+       */
+      perform cron.schedule(
+        v_hourly_job.jobname,
+        '1 * * * *',
+        v_hourly_job.command
       );
     end loop;
   end if;

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -3118,6 +3118,7 @@ set search_path = pg_catalog, ash
 as $$
 declare
   v_last_ts int4;
+  v_last_1m_ts int4;
   v_now_hour_ts int4;
   v_hour_start int4;
   v_hour_end int4;
@@ -3137,7 +3138,8 @@ begin
     return 0;
   end if;
 
-  select last_rollup_1h_ts into v_last_ts
+  select last_rollup_1h_ts, last_rollup_1m_ts
+  into v_last_ts, v_last_1m_ts
   from ash.config where singleton;
 
   v_now_hour_ts := ash.ts_from_timestamptz(date_trunc('hour', now()));
@@ -3154,6 +3156,18 @@ begin
 
   while v_hour_start < v_now_hour_ts and v_batch_limit > 0 loop
     v_hour_end := v_hour_start + 3600;
+
+    /*
+     * The minute and hourly jobs both fire at the top of the hour. If this
+     * worker wins the shared rollup lock before rollup_minute() has processed
+     * the just-completed final minute, aggregating now would seal a partial
+     * hour and advance last_rollup_1h_ts past data that arrives moments later.
+     * The minute watermark is the authoritative completion boundary: defer
+     * this hour without inserting or advancing until it reaches v_hour_end.
+     */
+    if v_last_1m_ts is null or v_last_1m_ts < v_hour_end then
+      exit;
+    end if;
 
     insert into ash.rollup_1h (
       ts, datid, samples, peak_backends, wait_counts, query_counts,

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -1982,7 +1982,8 @@ begin
   status := 'created';
   return next;
 
-  -- rollup_hour: every hour at minute 1, after the minute-0 rollup finishes
+  -- rollup_hour: every hour at minute 1; its blocking shared lock sequences it
+  -- after any in-flight minute rollup before it checks the minute watermark.
   begin
     perform cron.unschedule('ash_rollup_1h');
   exception when others then
@@ -3127,16 +3128,14 @@ declare
   v_count int;
 begin
   /*
-   * Acquire rollup lock (xact-level). Same kind as rollup_minute /
-   * rollup_cleanup so they serialize among themselves; distinct from
-   * the sampler lock.
+   * Wait for the shared rollup lock instead of skipping. The hourly pg_cron
+   * job runs at minute 1, when the every-minute worker also fires; a try-lock
+   * here could lose that race every hour and starve hourly aggregation.
    */
-  if not pg_try_advisory_xact_lock(
-       hashtext('pg_ash')::int4,
-       hashtext('pg_ash_rollup')::int4
-     ) then
-    return 0;
-  end if;
+  perform pg_advisory_xact_lock(
+    hashtext('pg_ash')::int4,
+    hashtext('pg_ash_rollup')::int4
+  );
 
   select last_rollup_1h_ts, last_rollup_1m_ts
   into v_last_ts, v_last_1m_ts
@@ -3158,12 +3157,10 @@ begin
     v_hour_end := v_hour_start + 3600;
 
     /*
-     * The minute and hourly jobs both fire at the top of the hour. If this
-     * worker wins the shared rollup lock before rollup_minute() has processed
-     * the just-completed final minute, aggregating now would seal a partial
-     * hour and advance last_rollup_1h_ts past data that arrives moments later.
-     * The minute watermark is the authoritative completion boundary: defer
-     * this hour without inserting or advancing until it reaches v_hour_end.
+     * The minute watermark is the authoritative completion boundary. The
+     * blocking lock above observes a completed in-flight minute rollup, while
+     * this guard also protects manual/external calls and missing coverage:
+     * defer without inserting or advancing rather than seal a partial hour.
      */
     if v_last_1m_ts is null or v_last_1m_ts < v_hour_end then
       exit;
@@ -6417,4 +6414,29 @@ exception when others then
     '(%: %); run "select ash.grant_reader(''pg_monitor'')" manually, or '
     'ignore to leave pg_monitor without access',
     sqlstate, sqlerrm;
+end $$;
+
+/*
+ * Installer re-apply migration for running installations. Defining the new
+ * ash.start() body is not enough: an existing pg_cron job keeps its old
+ * minute-0 schedule until start() is called again.
+ */
+do $$
+declare
+  v_hourly_job record;
+begin
+  if ash._pg_cron_available() then
+    for v_hourly_job in
+      select jobid
+      from cron.job
+      where jobname = 'ash_rollup_1h'
+        and database = current_database()
+        and schedule = '0 * * * *'
+    loop
+      perform cron.alter_job(
+        job_id := v_hourly_job.jobid,
+        schedule := '1 * * * *'
+      );
+    end loop;
+  end if;
 end $$;

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -1982,7 +1982,7 @@ begin
   status := 'created';
   return next;
 
-  -- rollup_hour: every hour at minute 0
+  -- rollup_hour: every hour at minute 1, after the minute-0 rollup finishes
   begin
     perform cron.unschedule('ash_rollup_1h');
   exception when others then
@@ -1991,7 +1991,7 @@ begin
 
   select cron.schedule(
     'ash_rollup_1h',
-    '0 * * * *',
+    '1 * * * *',
     'select ash.rollup_hour()'
   ) into v_rotation_job;
 


### PR DESCRIPTION
## What changed

- reads `last_rollup_1m_ts` alongside the hourly watermark and refuses to seal an incomplete hour
- makes `rollup_hour()` wait behind an in-flight minute rollup instead of losing the shared-lock race
- schedules hourly rollup at minute 1 for pg_cron and documented external schedulers
- migrates an existing minute-0 pg_cron job in place during installer reapply, using the ordinary job-owner-capable named `cron.schedule()` path
- adds deterministic barrier, lock-contention, schedule, and installer-reapply regressions

## Why

If the hourly worker ran before minute 59 was rolled up, it could permanently seal a 59-minute row. A try-lock at minute 1 could also starve hourly aggregation, and merely redefining `ash.start()` did not migrate existing jobs.

## Impact

Incomplete hours are deferred without inserting or advancing. The hourly worker waits for an in-flight minute worker, and existing/default schedulers use minute 1. Installer reapply preserves the legacy job ID, command, and active state while changing only its exact old default schedule.

## Validation

- RED on rebased `origin/main`: incomplete-hour regression exits 3 after `rollup_hour()` returns 1 and seals the partial hour
- GREEN: incomplete hour returns 0; no row or watermark advance; retry after minute 59 creates exactly 3,600 samples/counts and 60 minute slots
- lock contention RED before serialization: `rollup_hour_result=0`, `hourly_rows=0`; GREEN after fix: result 1 and one hourly row after the minute worker commits
- schedule RED/GREEN: legacy/default `0 * * * *` becomes `1 * * * *`
- ordinary non-superuser pg_cron job owner, without `cron.alter_job` EXECUTE: installer reapply succeeds and migrates the job
- fresh PG17 focused tests and disposable pg_cron PG17 tests pass; workflow YAML and `git diff --check` pass

Closes #132

## Audit side effects

- The former minute-0 collision could leave `rollup_1h` about one hour behind. The branch now uses minute 1 in pg_cron, installer migration, no-pg_cron guidance, and README examples; `rollup_hour()` also blocks behind any in-flight minute rollup.
- `ash.rollup_hour()` remains a silent no-op when `last_rollup_1m_ts` is NULL even if `ash.rollup_1m` already contains rows. This is an explicit operational side effect of using the minute watermark as the completion boundary.
