### PR TITLE
fix: reject NULL elements in decode_sample (#143)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2674,6 +2674,42 @@ jobs:
           rollback;
           EOF
 
+      - name: "Release-gate: decode_sample rejects NULL packed-array elements (#143)"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          set -euo pipefail
+
+          set +e
+          output="$(
+            psql -X -A -t -q -h localhost -U postgres -d postgres \
+              -v ON_ERROR_STOP=1 2>&1 << 'EOF'
+          select 'marker_rows=' || count(*)
+          from ash.decode_sample(array[null, 1, 0]::int4[], null::smallint);
+
+          select 'count_rows=' || count(*)
+          from ash.decode_sample(array[-1, null, 0]::int4[], null::smallint);
+
+          select 'query_map_rows=' || count(*)
+          from ash.decode_sample(array[-1, 1, null]::int4[], null::smallint);
+          EOF
+          )"
+          psql_status=$?
+          set -e
+          printf '%s\n' "$output"
+
+          test "$psql_status" -eq 0
+          test "$(printf '%s\n' "$output" | grep -Fc 'WARNING:  ash.decode_sample:')" -eq 3
+          printf '%s\n' "$output" | grep -Fxq 'marker_rows=0'
+          printf '%s\n' "$output" | grep -Fxq 'count_rows=0'
+          printf '%s\n' "$output" | grep -Fxq 'query_map_rows=0'
+          printf '%s\n' "$output" | grep -Fq \
+            'ash.decode_sample: expected negative wait_id at position 1'
+          printf '%s\n' "$output" | grep -Fq \
+            'ash.decode_sample: non-positive count <NULL> at position 2'
+          printf '%s\n' "$output" | grep -Fq \
+            'ash.decode_sample: expected non-negative query_id at position 3'
+
       - name: "Release-gate fixes: negative interval, width clamp, decode_sample size cap"
         env:
           PGPASSWORD: postgres

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -39,6 +39,14 @@ surface has been replaced by the AAS-oriented 2.0 API:
   official `postgres:19beta1` image until the GA `postgres:19` image exists.
 - **Docs refreshed.** README examples now use the 2.0 named-argument API.
 
+## Fixes since 2.0 beta 1
+
+- **Malformed decoder input is rejected consistently.** `ash.decode_sample()`
+  now returns zero rows with a position-specific warning when a packed sample
+  array contains a NULL wait marker, count, or query-map id, matching the
+  storage validator instead of emitting a fabricated row or raising an
+  internal PL/pgSQL error. (issue #143)
+
 Known security limitation: advisory-lock squat DoS remains possible for roles
 that can intentionally hold pg_ash advisory locks. See
 [SECURITY.md](SECURITY.md#advisory-lock-squat-dos).

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -1137,7 +1137,7 @@ begin
    */
   v_idx := 1;
   while v_idx <= v_len loop
-    if data[v_idx] >= 0 then
+    if data[v_idx] is null or data[v_idx] >= 0 then
       raise warning
         'ash.decode_sample: expected negative wait_id at position %', v_idx;
       return;
@@ -1151,7 +1151,7 @@ begin
       return;
     end if;
     v_count := data[v_idx];
-    if v_count <= 0 then
+    if v_count is null or v_count <= 0 then
       raise warning
         'ash.decode_sample: non-positive count % at position %',
         v_count, v_idx;
@@ -1166,7 +1166,7 @@ begin
       return;
     end if;
     for v_qid_idx in 1..v_count loop
-      if data[v_idx] < 0 then
+      if data[v_idx] is null or data[v_idx] < 0 then
         raise warning
           'ash.decode_sample: expected non-negative query_id at position %',
           v_idx;


### PR DESCRIPTION
Closes #143

## Summary

- reject NULL wait markers, counts, and query-map IDs during the decoder's validation pass
- preserve the existing position-specific warning messages
- return zero rows for every malformed array before the emission pass begins
- keep public decoder behavior aligned with the `_sample_data_is_valid()` storage CHECK

## TDD evidence

Before the fix:

- `array[NULL,1,0]` emitted a fabricated blank row
- `array[-1,NULL,0]` raised `upper bound of FOR loop cannot be null`
- `array[-1,1,NULL]` emitted a fabricated blank row

The new gate checks exact zero-row counts and exactly one warning per input. After the fix the warnings are:

- `expected negative wait_id at position 1`
- `non-positive count <NULL> at position 2`
- `expected non-negative query_id at position 3`

## Validation

Postgres 18:

- fresh install
- installer reapply
- exact three malformed calls
- storage validator rejects all three inputs
- valid packed array still decodes normally
- released-SQL branch guard passes
- `git diff --check` passes

The hosted PG14–PG19 beta/no-cron matrix is left to this draft PR.