### PR TITLE
fix: correct admin documentation contracts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,15 @@ jobs:
             fi
           done
 
+          if ! grep -Fq "Only \`ash.rebuild_partitions\` and \`ash.uninstall\` require the exact \`'yes'\` confirmation token." README.md; then
+            echo "README.md must limit the exact 'yes' confirmation contract to rebuild_partitions and uninstall." >&2
+            exit 1
+          fi
+          if grep -Fq "All destructive calls require" README.md; then
+            echo "README.md must not claim every destructive operation takes a confirmation token." >&2
+            exit 1
+          fi
+
           grep -q "ash.grant_reader" README.md
           grep -q "SECURITY.md#advisory-lock-squat-dos" README.md
           grep -q "SECURITY.md#advisory-lock-squat-dos" RELEASE_NOTES.md
@@ -4776,7 +4785,7 @@ jobs:
           end $$;
           EOF
 
-      - name: "Test v1.4: status output"
+      - name: "Test v1.4: status output and admin catalog contracts"
         env:
           PGPASSWORD: postgres
         run: |
@@ -4784,6 +4793,8 @@ jobs:
           do $$
           declare
             v_metrics text[];
+            v_rotate_description text;
+            v_rebuild_description text;
           begin
             -- Collect all metric names from status()
             select array_agg(metric) into v_metrics from ash.status();
@@ -4812,7 +4823,29 @@ jobs:
             assert 'current_slot' = any(v_metrics),
               'status should include current_slot';
 
-            raise notice 'Status output tests PASSED';
+            -- Issue #147: catalog documentation is a public contract for
+            -- humans and agents. It must use the same conservative readable
+            -- raw-retention formula surfaced by status() and README.
+            select obj_description('ash.rotate()'::regprocedure)
+              into v_rotate_description;
+            select obj_description(
+              'ash.rebuild_partitions(integer,text)'::regprocedure
+            ) into v_rebuild_description;
+
+            assert v_rotate_description like
+                     '%Readable raw retention is approximately (num_partitions - 2) * rotation_period.%',
+              'rotate description has the wrong raw-retention formula';
+            assert v_rebuild_description like
+                     '%Readable raw retention is approximately (num_partitions - 2) * rotation_period.%',
+              'rebuild_partitions description has the wrong raw-retention formula';
+            assert position(
+              'num_partitions x rotation_period' in v_rotate_description
+            ) = 0, 'rotate description retains the overstated formula';
+            assert position(
+              'raw retention = slots x rotation_period' in v_rebuild_description
+            ) = 0, 'rebuild_partitions description retains the overstated formula';
+
+            raise notice 'Status output and admin catalog contract tests PASSED';
           end;
           $$;
           EOF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4832,11 +4832,17 @@ jobs:
               'ash.rebuild_partitions(integer,text)'::regprocedure
             ) into v_rebuild_description;
 
-            assert v_rotate_description like
-                     '%Readable raw retention is approximately (num_partitions - 2) * rotation_period.%',
+            assert position(
+              'Readable raw retention is approximately '
+              '(num_partitions - 2) * rotation_period.'
+              in v_rotate_description
+            ) > 0,
               'rotate description has the wrong raw-retention formula';
-            assert v_rebuild_description like
-                     '%Readable raw retention is approximately (num_partitions - 2) * rotation_period.%',
+            assert position(
+              'Readable raw retention is approximately '
+              '(num_partitions - 2) * rotation_period.'
+              in v_rebuild_description
+            ) > 0,
               'rebuild_partitions description has the wrong raw-retention formula';
             assert position(
               'num_partitions x rotation_period' in v_rotate_description

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ renamed or removed.
 | `ash.revoke_reader(role)` | Revoke the monitoring-reader bundle |
 | `ash.uninstall('yes')` | Drop pg_ash and unschedule jobs |
 
-All destructive calls require the exact `'yes'` confirmation token.
+Only `ash.rebuild_partitions` and `ash.uninstall` require the exact `'yes'` confirmation token.
 
 ## Scheduling
 

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -5814,7 +5814,7 @@ comment on function ash.take_sample() is
 $$Admin/internal: take one wait-event sample of pg_stat_activity into the current slot (the every-second worker that ash.start() schedules). Returns the number of active backends captured. Call manually only for testing; continuous sampling belongs to ash.start().$$;
 
 comment on function ash.rotate() is
-$$Admin: rotate to the next partition slot, rolling up and truncating the oldest (the daily job scheduled by ash.start()). Controls raw retention: num_partitions x rotation_period of raw samples are kept. Safe to call manually to force a rotation.$$;
+$$Admin: rotate to the next partition slot, rolling up and truncating the oldest (the daily job scheduled by ash.start()). Readable raw retention is approximately (num_partitions - 2) * rotation_period. Safe to call manually to force a rotation.$$;
 
 comment on function ash.rollup_minute(int) is
 $$Admin: fold completed minutes of raw samples into ash.rollup_1m (the every-minute job scheduled by ash.start()); batch_limit caps catch-up minutes per call. Returns minutes processed. Readers pick rollups automatically — this only needs manual calls when pg_cron is absent.$$;
@@ -5826,7 +5826,7 @@ comment on function ash.rollup_cleanup() is
 $$Admin: delete rollup rows past retention (rollup_1m_retention_days / rollup_1h_retention_days in ash.config; the daily job scheduled by ash.start()). Returns a summary of rows deleted.$$;
 
 comment on function ash.rebuild_partitions(int, text) is
-$$Admin, DESTRUCTIVE: drop and recreate the sample/query-map partitions with num_partitions slots (3-32; raw retention = slots x rotation_period). Requires confirm => 'yes'. DELETES ALL RAW SAMPLES (rollups are kept). Re-run ash.grant_reader() for every monitoring role afterwards — the new partitions carry no grants.$$;
+$$Admin, DESTRUCTIVE: drop and recreate the sample/query-map partitions with num_partitions slots (3-32). Readable raw retention is approximately (num_partitions - 2) * rotation_period. Requires confirm => 'yes'. DELETES ALL RAW SAMPLES (rollups are kept). Re-run ash.grant_reader() for every monitoring role afterwards — the new partitions carry no grants.$$;
 
 comment on function ash.set_debug_logging(bool) is
 $$Admin: toggle debug logging for the sampler and rollup jobs (null argument reports the current setting). Returns the resulting state.$$;


### PR DESCRIPTION
## What changed

- limits the README's exact `'yes'` confirmation contract to `rebuild_partitions` and `uninstall`
- corrects `rotate()` and `rebuild_partitions()` catalog descriptions to `(num_partitions - 2) * rotation_period`
- adds two-sided README and installed-catalog contract guards
- uses literal `position()` assertions so underscores cannot act as `LIKE` wildcards

## Rebase integration

Rebased by hand onto `origin/main` at `fb5935d`. The known #129 workflow conflict was resolved by retaining the complete `Test 2.0: raw retention ignores the excluded ring slot` step first, immediately followed by the renamed `Test v1.4: status output and admin catalog contracts` step. Both pass.

## Validation

Postgres 17.9:

- RED catalog: the branch's named contract step against base SQL exits 3 at `rotate description has the wrong raw-retention formula`
- GREEN catalog at `3769482`: exact corrected wording is present and both old formulas are absent
- RED docs: the branch guard against base docs exits 1 because the broad confirmation claim remains
- GREEN docs: the complete guard passes
- preserved #129 N=6 and retention-boundary step passes
- actionlint, YAML ordering assertion, and `git diff --check` pass
- `codex review --base origin/main` reports no actionable regression

Closes #147
