### PR TITLE
test: inspect wait IDs at pair positions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3370,10 +3370,24 @@ jobs:
 
               -- Only the 'active' wait_id should appear, never the 'idle' one
               -- (no sample referenced idle in transaction/ClientRead).
-              assert not (v_idle_cr_id::int4 = any(v_row.wait_counts)),
+              assert not exists (
+                select 1
+                from generate_subscripts(
+                  v_row.wait_counts, 1
+                ) as pair_position(pos)
+                where pair_position.pos % 2 = 1
+                  and v_row.wait_counts[pair_position.pos] = v_idle_cr_id
+              ),
                 'idle-state ClientRead wait_id must not appear in wait_counts: '
                   || v_row.wait_counts::text;
-              assert v_active_cr_id::int4 = any(v_row.wait_counts),
+              assert exists (
+                select 1
+                from generate_subscripts(
+                  v_row.wait_counts, 1
+                ) as pair_position(pos)
+                where pair_position.pos % 2 = 1
+                  and v_row.wait_counts[pair_position.pos] = v_active_cr_id
+              ),
                 'active-state ClientRead wait_id must appear in wait_counts';
 
               raise notice 'ClientRead state-disambiguation regression test PASSED';

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3367,6 +3367,9 @@ jobs:
               assert v_total_count = 3,
                 'wait_counts total should be 3 (not double-counted across states), got '
                   || v_total_count || ' — wait_counts=' || v_row.wait_counts::text;
+              assert v_row.wait_counts = array[v_active_cr_id::int4, 3],
+                'wait_counts should preserve the exact ID/count collision {2,3}, got '
+                  || v_row.wait_counts::text;
 
               -- Only the 'active' wait_id should appear, never the 'idle' one
               -- (no sample referenced idle in transaction/ClientRead).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3289,17 +3289,37 @@ jobs:
             declare
               v_active_cr_id smallint;
               v_idle_cr_id smallint;
+              v_seed_wait_id smallint;
               v_cr_minute_ts int4;
               v_row record;
               v_i int;
               v_total_count int4;
             begin
-              -- Register the same (type, event) under two different states
+              /*
+               * Force [active wait_id, count] = [2, 3] while the excluded
+               * idle wait_id is also 3. Pair-array assertions must inspect
+               * odd ID positions only; scanning every element confuses the
+               * count with an idle wait ID.
+               */
+              truncate ash.sample;
+              truncate ash.rollup_1m;
+              truncate ash.wait_event_map restart identity cascade;
+              select ash._register_wait('active', 'Test', 'PairCollisionSeed')
+                into v_seed_wait_id;
               select ash._register_wait('active', 'Client', 'ClientRead')
                 into v_active_cr_id;
               select ash._register_wait('idle in transaction', 'Client', 'ClientRead')
                 into v_idle_cr_id;
 
+              assert v_seed_wait_id = 1
+                     and v_active_cr_id = 2
+                     and v_idle_cr_id = 3,
+                format(
+                  'pair-collision fixture IDs mismatch: seed=%s active=%s idle=%s',
+                  v_seed_wait_id,
+                  v_active_cr_id,
+                  v_idle_cr_id
+                );
               assert v_active_cr_id <> v_idle_cr_id,
                 'active/ClientRead and idle/ClientRead must have distinct wait_ids';
 


### PR DESCRIPTION
## What changed

- resets the wait map to force active ClientRead ID 2, idle ClientRead ID 3, and a count of 3
- asserts the exact `{2,3}` wait pair produced by the fixture
- checks active/idle membership only at odd wait-ID positions
- preserves the exact total-count and state-disambiguation assertions

## Why

`wait_counts` is `[wait_id, count, ...]`. Scanning every element mistakes counts for IDs, so a correct `{2,3}` rollup can fail when the count equals an excluded wait ID.

## Impact

This is a test-only correction. It removes an identity-allocation-dependent false CI failure without changing product SQL or runtime behavior.

## Validation

PostgreSQL 18.3:

- RED at `df912ca`: `{2,3}` falsely reports idle wait ID 3 as present
- GREEN at `b879d9f`: the complete `Test v1.4: rollup tables and functions` block passes twice
- fresh installer with `ON_ERROR_STOP=1` passes
- `actionlint -shellcheck= .github/workflows/test.yml` passes
- `git diff --check origin/main..HEAD` passes

Closes #153