### PR TITLE
docs: polish user-facing text for clarity and consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# pg_ash
+# pg_ash: Active Session History for Postgres
 
 [![CI](https://github.com/NikolayS/pg_ash/actions/workflows/test.yml/badge.svg)](https://github.com/NikolayS/pg_ash/actions/workflows/test.yml)
 [![Postgres 14-19](https://img.shields.io/badge/Postgres-14--19-336791?logo=postgresql&logoColor=white)](https://github.com/NikolayS/pg_ash)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Pure SQL](https://img.shields.io/badge/Pure_SQL-no_C_extension-green)](https://github.com/NikolayS/pg_ash)
 
-Active Session History for Postgres, implemented in plain SQL and PL/pgSQL.
+pg_ash is Active Session History (ASH) for Postgres, implemented in plain SQL and PL/pgSQL.
 
 pg_ash samples `pg_stat_activity`, stores compact wait-event history in the
 database, and lets you answer "what was happening then?" after the problem is
 gone. It works on managed Postgres because it is not a C extension: no
 `shared_preload_libraries`, no provider approval, no restart.
 
-## Why
+## Why pg_ash
 
 Postgres has excellent current-state views, but almost no built-in memory. If a
 lock storm ended ten minutes ago, `pg_stat_activity` cannot tell you who waited,
@@ -28,7 +28,7 @@ Use pg_ash when you need:
 - a tool that can run on RDS, Cloud SQL, AlloyDB, Supabase, Neon, and similar
   managed platforms
 
-## Quick Start
+## Quick start
 
 The current `main` branch contains the 2.0 beta 1 SQL in `sql/`.
 
@@ -45,7 +45,7 @@ select * from ash.top('query_id');
 select * from ash.chart(since => now() - interval '5 minutes', color => true);
 ```
 
-## Color Output
+## Color output
 
 pg_ash can render compact terminal charts with ANSI colors when `color => true`
 or `set ash.color = on` is used.
@@ -60,7 +60,7 @@ For the latest stable v1.5 tag, check out `v1.5` first and use:
 \i sql/ash-install.sql
 ```
 
-## Upgrade To 2.0
+## Upgrade to 2.0
 
 2.0 is a breaking reader-API release. Upgrade scripts are cumulative; run the
 missing scripts in order.
@@ -97,7 +97,7 @@ Full mapping: [`blueprints/AAS_EXAMPLES.md`](blueprints/AAS_EXAMPLES.md).
 
 ## Reader API
 
-Start with `ash.periods()`, then drill with `ash.timeline()` and `ash.top()`.
+Start with `ash.periods()`, then drill down with `ash.timeline()` and `ash.top()`.
 Every reader reports its data source: `raw`, `rollup_1m`, `rollup_1h`, or
 `none`.
 
@@ -131,7 +131,7 @@ Filters are consistent where they apply:
 is usually the right first cut because it surfaces short spikes that averages
 hide.
 
-## Investigation Flow
+## Investigation flow
 
 ### 1. Is it bad now, or was it a spike?
 
@@ -200,7 +200,7 @@ from ash.top(
 );
 ```
 
-Then flip the drill around:
+Then reverse the drill-down:
 
 ```sql
 select *
@@ -211,7 +211,7 @@ from ash.top(
 );
 ```
 
-Combining a query filter with a wait filter needs the raw wait-query tie. If
+Combining a query filter with a wait filter requires the raw wait-to-query link. If
 the window is past raw retention, pg_ash raises with the raw-retention boundary
 instead of returning a fake empty result.
 
@@ -238,7 +238,7 @@ Dump a wider incident window with psql:
 ) to '/tmp/ash-incident.csv' csv header
 ```
 
-## Chart Rendering
+## Chart rendering
 
 `ash.chart()` is for humans. `ash.timeline()` is the typed-data companion.
 
@@ -275,7 +275,7 @@ Then run:
 select * from ash.chart(since => now() - interval '1 hour', color => true) :color
 ```
 
-## Machine Report
+## Machine report
 
 `ash.report()` returns one JSONB payload for monitoring and health-assessment
 systems.
@@ -355,7 +355,7 @@ alter system set cron.log_run = off;
 
 This requires a restart because `cron.log_run` is postmaster-context.
 
-## Retention And Storage
+## Retention and storage
 
 Raw samples use a PGQ-style ring of partitions. Defaults:
 
@@ -374,7 +374,7 @@ select ash.start();
 ```
 
 `rebuild_partitions()` drops all raw samples and query-map partitions. Rollups
-survive. Re-run `ash.grant_reader()` for monitoring roles afterwards because
+survive. Re-run `ash.grant_reader()` for monitoring roles afterward because
 new partitions need fresh grants.
 
 Typical storage at 1-second sampling:
@@ -419,7 +419,7 @@ If `pg_stat_statements` is installed after pg_ash, or moved to another schema:
 select ash._apply_pgss_search_path();
 ```
 
-## Catalog Docs
+## Catalog docs
 
 pg_ash documents itself in the database:
 
@@ -446,7 +446,7 @@ alter system set compute_query_id = 'on';
 select pg_reload_conf();
 ```
 
-## Compared To Alternatives
+## Compared to alternatives
 
 | | pg_ash | pg_wait_sampling / pgsentinel | External sampling |
 |---|---|---|---|
@@ -458,10 +458,10 @@ select pg_reload_conf();
 | Sampling frequency | Usually 1s | Usually 10ms | Usually 15-60s |
 
 pg_ash is not a replacement for in-process 10ms samplers when you control the
-server and need sub-second detail. It is for durable, portable ASH on real
-managed Postgres.
+server and need sub-second detail. It is for durable, portable ASH on managed
+Postgres.
 
-## Known Limits
+## Known limits
 
 - Primary only: pg_ash writes sample and rollup rows.
 - It samples one database installation but sees activity from all databases.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -32,8 +32,8 @@ surface has been replaced by the AAS-oriented 2.0 API:
 - **Upgrade convergence.** The 1.5-to-2.0 wrapper replays the finalized 2.0
   installer, removes stale 1.x and earlier draft reader functions, and preserves
   explicit reader grants where safe.
-- **Default monitoring access.** Fresh installs and upgrades best-effort grant
-  the reader bundle to `pg_monitor`; opt out with
+- **Default monitoring access.** Fresh installs and upgrades grant the reader
+  bundle to `pg_monitor` on a best-effort basis; opt out with
   `select ash.revoke_reader('pg_monitor');`.
 - **Postgres 19 beta support.** CI now covers Postgres 14 through 19, using the
   official `postgres:19beta1` image until the GA `postgres:19` image exists.
@@ -59,7 +59,7 @@ and raw-retention fixes ([PR #86](https://github.com/NikolayS/pg_ash/pull/86),
 
 ## Fixes
 
-- **`wait_event_map` cap enforcement fixed.** `_register_wait()` now checks the exact 32 000th dictionary row instead of trusting stale `pg_class.reltuples`, so the hard cap fires immediately after `TRUNCATE` / restore and increments `register_wait_cap_hits` as documented. (issue #90; [PR #92](https://github.com/NikolayS/pg_ash/pull/92))
+- **`wait_event_map` cap enforcement fixed.** `_register_wait()` now checks the exact 32,000th dictionary row instead of trusting stale `pg_class.reltuples`, so the hard cap fires immediately after `TRUNCATE` / restore and increments `register_wait_cap_hits` as documented. (issue #90; [PR #92](https://github.com/NikolayS/pg_ash/pull/92))
 - **Raw samples are protected during rollup/rotation races.** `rollup_minute()` no longer advances its watermark while a sampler is in flight, and `rotate()` refuses to truncate an endangered raw partition unless pre-truncation rollup succeeds and covers the raw groups in that slot. (issue #81; [PR #86](https://github.com/NikolayS/pg_ash/pull/86))
 - **Raw readers honor rebuilt partition retention.** `_active_slots_for()` and `_active_slots_for_at()` now enumerate every retained raw slot after `rebuild_partitions(N, 'yes')` instead of only current plus previous slot. (issue #83; [PR #85](https://github.com/NikolayS/pg_ash/pull/85))
 - **pg_stat_statements readers ignore spoofed relations and avoid duplicate top-query rows.** pgss-aware readers now require the real `pg_stat_statements` extension before reading query text/metrics, and `top_queries*` aggregates pgss rows by `queryid` so one ASH query cannot fan out into multiple rows. (issue #87; [PR #97](https://github.com/NikolayS/pg_ash/pull/97))
@@ -154,7 +154,7 @@ Three new bigint columns on `ash.config`, all surfaced by `ash.status()`:
 
 - `missed_samples` — bumped when `take_sample()` catches `query_canceled` (statement_timeout or pg_cancel_backend). The sampler emits a `WARNING` and returns `-1` so callers can observe the miss. (issues #27 and #28; [PR #41](https://github.com/NikolayS/pg_ash/pull/41))
 - `insert_errors` — bumped when `take_sample()`'s inner `EXCEPTION WHEN OTHERS` swallows a non-cancel insert error instead of silently dropping data. (M-BUG-4)
-- `register_wait_cap_hits` — bumped when `_register_wait` skips a new `(state, type, event)` because `wait_event_map` has hit its 32 000-row cap. Counter reveals silently-dropped wait registrations. (M-BUG-6 / H-SEC-3)
+- `register_wait_cap_hits` — bumped when `_register_wait` skips a new `(state, type, event)` because `wait_event_map` has hit its 32,000-row cap. The counter reveals silently dropped wait registrations. (M-BUG-6 / H-SEC-3)
 
 `status()` also reports `epoch_seconds_remaining` and the year-2094 horizon when `sample_ts` (int4 epoch offset) overflows — sampling hard-fails with `integer out of range` past that point, NOT silently wraps. (issue #37)
 
@@ -170,14 +170,14 @@ Three new bigint columns on `ash.config`, all surfaced by `ash.status()`:
 ## Fixes
 
 - **No more `integer out of range` on absurd reader inputs.** Both the relative-interval readers (`top_waits('1000 years')`, etc.) and the absolute-timestamp `_at` readers (`top_waits_at('1000-01-01', …)`, etc.) now return empty rows cleanly via clamps in the readers and in `ts_from_timestamptz`. (issues #51 and #63; [PR #57](https://github.com/NikolayS/pg_ash/pull/57), [PR #65](https://github.com/NikolayS/pg_ash/pull/65))
-- **`sample_data_check` constraint aligned across upgrade paths.** Installs upgraded from 1.0 had a looser `array_length(data, 1) >= 2` check that 1.1 silently failed to tighten because of `create table if not exists`. An idempotent DO block in install.sql now drops + re-adds the `>= 3` form. (issue #49; [PR #56](https://github.com/NikolayS/pg_ash/pull/56))
+- **`sample_data_check` constraint aligned across upgrade paths.** Installs upgraded from 1.0 had a looser `array_length(data, 1) >= 2` check that 1.1 silently failed to tighten because of `create table if not exists`. An idempotent DO block in install.sql now drops and re-adds the `>= 3` form. (issue #49; [PR #56](https://github.com/NikolayS/pg_ash/pull/56))
 - **`ash.status()` no longer errors for non-superuser monitoring roles when pg_cron is loaded.** A nested `EXCEPTION WHEN insufficient_privilege` substitutes a fallback row pointing at the missing `GRANT USAGE ON SCHEMA cron`. (issue #61; [PR #62](https://github.com/NikolayS/pg_ash/pull/62))
 
 ## CI / infra
 
 - End-to-end pg_cron firing test passes on every PG 14–18 cron-enabled job. Provisions a `root` PG role + database to satisfy peer auth in the GHA service container; asserts via `ash.sample` row growth with a real `pg_sleep` workload. (issue #46; [PR #73](https://github.com/NikolayS/pg_ash/pull/73))
 - Schema-equivalence CI now diffs `pg_constraint` between fresh-install and chain-upgrade snapshots — catches the class of divergence behind issue #49. (issue #66; [PR #70](https://github.com/NikolayS/pg_ash/pull/70))
-- **Hot-path perf** improvements in `query_waits` / `query_waits_at` (window-based dedup via `named_hits` CTE), `rotate()` (single-statement `truncate ash.sample_N, ash.query_map_N restart identity`), and the `query_map` cap probe (`offset 49999 limit 1` replacing stale `pg_class.reltuples`). ([PR #42](https://github.com/NikolayS/pg_ash/pull/42))
+- **Hot-path performance** improvements in `query_waits` / `query_waits_at` (window-based dedup via `named_hits` CTE), `rotate()` (single-statement `truncate ash.sample_N, ash.query_map_N restart identity`), and the `query_map` cap probe (`offset 49999 limit 1` replacing stale `pg_class.reltuples`). ([PR #42](https://github.com/NikolayS/pg_ash/pull/42))
 - **Supply-chain hardening** for CI: third-party actions pinned to 40-char commit SHAs and least-privilege `permissions:` blocks. ([PR #40](https://github.com/NikolayS/pg_ash/pull/40))
 
 ## Demo

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
-# Security Policy
+# Security policy
 
-## Supported Versions
+## Supported versions
 
 | Version | Supported |
 | ------- | --------- |
@@ -22,7 +22,7 @@ pg_ash is a pure-SQL extension that samples `pg_stat_activity`. Relevant securit
 
 pg_ash uses session-known advisory-lock keys for sampler / rotate / rebuild / rollup coordination. The keys are derived deterministically from string literals in `ash-install.sql` (`hashtext('pg_ash')::int4`, `hashtext('pg_ash_<kind>')::int4`), so any user with `LOGIN` and `EXECUTE` on `pg_advisory_xact_lock` can compute and squat them, halting `take_sample`, `rotate`, `rollup_*`, or `rebuild_partitions` for the duration of their transaction. This is equivalent to the prior literal `(0, …)` / `(1, …)` design — choosing a hashed, ash-scoped namespace improves accidental cross-extension collision hygiene but does not stop a hostile session.
 
-Mitigation: revoke EXECUTE on the entire advisory-lock builtin family from `PUBLIC` (Postgres default grants the whole family broadly, and they all share the same lock namespace — so revoking only one variant is insufficient):
+Mitigation: revoke EXECUTE on the entire advisory-lock builtin family from `PUBLIC` (Postgres grants the whole family broadly by default, and they all share the same lock namespace — so revoking only one variant is insufficient):
 
 ```sql
 revoke execute on function
@@ -47,7 +47,7 @@ from public;
 
 Or run pg_ash in a dedicated database where untrusted roles cannot connect.
 
-## Reporting a Vulnerability
+## Reporting a vulnerability
 
 Use GitHub's [private vulnerability reporting](https://github.com/NikolayS/pg_ash/security/advisories/new) to report security issues privately.
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -1,8 +1,8 @@
 # pg_ash demo recording
 
 This directory contains the experimental animated GIF recorder for pg_ash demos.
-The generated GIF is not embedded in the top-level README until its rendering is
-readable on GitHub desktop and mobile.
+The generated GIF is not embedded in the top-level README until it renders
+readably on GitHub on both desktop and mobile.
 
 | File | What it is |
 |------|-----------|
@@ -17,8 +17,8 @@ readable on GitHub desktop and mobile.
 ## What it shows
 
 The demo reproduces the investigation sequence from the README's **LLM-assisted
-investigation** section on the 2.0 reader API, against a real spike (not canned
-output). Every reader answers in AAS (average active sessions):
+investigation** section using the 2.0 reader API, against a real spike (not
+canned output). Every reader reports in AAS (average active sessions):
 
 1. `ash.status()` — sampling active, version 2.0, pg_cron wired up
 2. `ash.periods()` — triage: last-minute `peak_aas` >> `avg_aas` = a spike, not sustained
@@ -28,10 +28,10 @@ output). Every reader answers in AAS (average active sessions):
 6. `ash.top('wait_event', query_id => <top_query_id>, ...)` — full wait profile of that query, closing the loop
 7. Closing frame (held ~3s) so the GIF loops gracefully in the README
 
-`ash.chart` is the only step that colors: in 2.0 the data readers (`periods`,
-`top`, `timeline`) return typed columns only. `ash.chart` is the sole reader
-that emits ANSI color; `ash.summary` is a render helper too but returns plain
-key/value text.
+`ash.chart` is the only colored step: in 2.0 the data readers (`periods`,
+`top`, `timeline`) return typed columns only, and `ash.chart` is the sole
+reader that emits ANSI color. `ash.summary` is also a render helper but
+returns plain key/value text.
 
 ## The spike
 
@@ -41,8 +41,8 @@ three seconds at a time. Every contender queues on `Lock:tuple` (with a smaller
 `Lock:transactionid` tail) behind the holder — guaranteed, reproducible, no
 host-level privileges required.
 
-Runs inside a plain `postgres:18` container; no kernel tweaks, no cgroup
-tricks, no custom Postgres build.
+Everything runs inside a plain `postgres:18` container; no kernel tweaks, no
+cgroup tricks, no custom Postgres build.
 
 ## Prerequisites
 
@@ -121,7 +121,7 @@ agg --font-size 10 --theme monokai --speed 1.0 --fps-cap 15 \
 The recorder simulates a human at the keyboard rather than pasting commands
 instantly. The `human_type_and_send` helper in `record.sh` walks each command
 string one character at a time, calling `tmux send-keys -l` per character and
-sleeping a randomised interval between keystrokes.
+sleeping a randomized interval between keystrokes.
 
 | Region | Delay |
 |--------|-------|
@@ -162,8 +162,8 @@ TYPE_MIN_MS=10 TYPE_MAX_MS=40  TYPE_PUNCT_MS=80  make record   # faster, breezie
   `~/.psqlrc`, *and* the one colored step — `ash.chart(...)` — passes
   `color => true` so its `chart` column comes back with ANSI codes. (In 2.0
   the data readers `periods` / `top` / `timeline` are presentation-free;
-  `ash.chart` is the only reader that emits color, and `ash.summary` — a render
-  helper too — returns plain key/value text.) The `:color` psql
+  `ash.chart` is the only reader that emits color, and `ash.summary` — also a
+  render helper — returns plain key/value text.) The `:color` psql
   variable (mirroring the README pattern) re-runs the previous query through
   `sed` to convert psql's literalised `\x1B` back into real ESC bytes — without
   this step psql's aligned formatter would mangle the codes. We omit `less -R`
@@ -188,7 +188,7 @@ TYPE_MIN_MS=10 TYPE_MAX_MS=40  TYPE_PUNCT_MS=80  make record   # faster, breezie
 
 **pre-baked build failed** — `record.sh` builds `demos/Dockerfile` (which
 `apt`-installs `postgresql-$PG_MAJOR-cron` from the PGDG mirror) once at the
-start of a run. If that mirror is unreachable the build fails and the recorder
+start of a run. If that mirror is unreachable, the build fails and the recorder
 logs a warning and falls back to the plain `postgres:$PG_MAJOR` base with the
 old runtime install + restart — so recording still proceeds. If the runtime
 fallback also can't fetch the package, temporarily set `ASH_CRON_OPTIONAL=1`


### PR DESCRIPTION
Polish of user-facing prose across the README and supporting docs. This is a copy-editing pass only: American English grammar and style, PostgresAI terminology and binary units, sentence-case headings, and SEO/LLM-friendly opening lines. No code, commands, SQL, config values, or numbers were touched.

## What changed

- **README.md**: H1 is now `pg_ash: Active Session History for Postgres` so the top heading carries the search terms; the intro line is a self-contained sentence usable as a search snippet and LLM summary. Sentence-cased all Title Case H2 headings (Quick start, Color output, Upgrade to 2.0, Investigation flow, Chart rendering, Machine report, Retention and storage, Catalog docs, Compared to alternatives, Known limits) and renamed "Why" to "Why pg_ash". Fixed non-native phrasings: "drill with" to "drill down with", "flip the drill around" to "reverse the drill-down", "needs the raw wait-query tie" to "requires the raw wait-to-query link", British "afterwards" to "afterward", and trimmed "durable, portable ASH on real managed Postgres" to "on managed Postgres".
- **RELEASE_NOTES.md**: reworded "best-effort grant the reader bundle" to "grant the reader bundle ... on a best-effort basis"; added a missing article and fixed an incorrect hyphen in "The counter reveals silently dropped wait registrations"; changed informal "drops + re-adds" to "drops and re-adds"; expanded "Hot-path perf" to "Hot-path performance"; Americanized two thousands separators ("32 000" to "32,000", same value).
- **SECURITY.md**: sentence-cased the three headings (Security policy, Supported versions, Reporting a vulnerability); fixed "Postgres default grants the whole family broadly" to "Postgres grants the whole family broadly by default".
- **demos/README.md**: seven minimal prose fixes, including "until it renders readably on GitHub on both desktop and mobile", "using the 2.0 reader API", "report in AAS", a merged and de-duplicated explanation of `ash.chart` coloring, a subject for the "Everything runs inside a plain postgres:18 container" sentence, British "randomised" to "randomized", and an introductory-clause comma in Troubleshooting.

## Not changed

No code, commands, SQL, config values, function or identifier names, flags, URLs, version numbers, benchmark figures, table values, or quoted output were modified. Existing dashes were preserved (none introduced), and existing Postgres/PostgreSQL and MiB/KiB usage was left as-is. The `sql/migrations/README.md` and `devel/sql/README.md` files were reviewed and needed no changes.

Relates to #157
