### PR TITLE
release: reject inverted reader windows and clarify diagnostics

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3502,6 +3502,367 @@ jobs:
           end $$;
           EOF
 
+      - name: "Test 2.0: until-only windows and inverted-window validation (#165)"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          -- B5 / issue #165. Reproduce the original failure exactly:
+          -- an until-only call ending three hours ago used to be rewritten to
+          -- a one-minute window around now()-1h, where the fixture below is
+          -- IO:DataFileRead at 40.00 AAS / 100.00%.
+          begin;
+          update ash.config
+            set current_slot = 0, sample_interval = '1 second',
+                last_rollup_1m_ts = null, last_rollup_1h_ts = null
+            where singleton;
+          truncate ash.sample_0, ash.sample_1, ash.sample_2;
+          truncate ash.query_map_0, ash.query_map_1, ash.query_map_2;
+          truncate ash.rollup_1m, ash.rollup_1h;
+
+          create temp table b5anchor as
+          select date_trunc('minute', now() - interval '3 hours') as requested_until,
+                 date_trunc('minute', now() - interval '1 hour') as wrong_minute;
+
+          do $$
+          declare
+            v_io smallint;
+            v_datid oid;
+            v_until timestamptz;
+            v_wrong timestamptz;
+            v_intended timestamptz;
+          begin
+            select ash._register_wait('active', 'IO', 'DataFileRead') into v_io;
+            select oid into v_datid from pg_database where datname = current_database();
+            select requested_until, wrong_minute
+              into v_until, v_wrong from b5anchor;
+            v_intended := v_until - interval '30 minutes';
+
+            -- Intended incident: 300 backend-seconds in the hour ending at
+            -- requested_until (5.00 AAS in its minute, 0.08 over the hour).
+            insert into ash.sample (sample_ts, datid, active_count, data, slot)
+            values (
+              ash.ts_from_timestamptz(v_intended), v_datid, 300,
+              array[-v_io::int, 300]
+                || pg_catalog.array_fill(0, array[300]),
+              0
+            );
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values (
+              ash.ts_from_timestamptz(v_intended), v_datid, 1, 300,
+              array[v_io::int, 300], array[]::bigint[]
+            );
+
+            -- Wrong hour: this is what the old degenerate-window clamp read.
+            insert into ash.sample (sample_ts, datid, active_count, data, slot)
+            values (
+              ash.ts_from_timestamptz(v_wrong), v_datid, 2400,
+              array[-v_io::int, 2400]
+                || pg_catalog.array_fill(0, array[2400]),
+              0
+            );
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values (
+              ash.ts_from_timestamptz(v_wrong), v_datid, 1, 2400,
+              array[v_io::int, 2400], array[]::bigint[]
+            );
+          end $$;
+
+          -- Every until-only reader anchors its implicit start to until-1h.
+          do $$
+          declare
+            v_until timestamptz := (select requested_until from b5anchor);
+            a record;
+            r record;
+            j jsonb;
+            v_count int;
+            v_points bigint;
+            v_max numeric;
+            v_value text;
+          begin
+            select * into a from ash.aas(until => v_until);
+            assert a.period_start = v_until - interval '1 hour'
+               and a.period_end = v_until,
+              format('aas until-only bounds: got [%s,%s), want [%s,%s)',
+                     a.period_start, a.period_end,
+                     v_until - interval '1 hour', v_until);
+            assert a.buckets_expected = 60 and a.buckets_with_data = 1
+               and a.avg_aas = 0.08 and a.peak_aas = 5.00
+               and a.p99_aas = 5.00 and a.backend_seconds = 300.00,
+              format('aas until-only values: expected 60/1/0.08/5.00/5.00/300.00, '
+                     'got %s/%s/%s/%s/%s/%s',
+                     a.buckets_expected, a.buckets_with_data, a.avg_aas,
+                     a.peak_aas, a.p99_aas, a.backend_seconds);
+
+            select count(*), sum(data_points), max(avg_aas)
+              into v_count, v_points, v_max
+            from ash.timeline(until => v_until);
+            assert v_count = 60 and v_points = 1 and v_max = 5.00,
+              format('timeline until-only expected rows/points/max 60/1/5.00, '
+                     'got %s/%s/%s', v_count, v_points, v_max);
+
+            select * into r from ash.top('wait_event', until => v_until);
+            assert r.key = 'IO:DataFileRead' and r.avg_aas = 0.08
+               and r.peak_aas = 5.00 and r.p99_aas = 5.00
+               and r.backend_seconds = 300.00 and r.pct = 100.00,
+              format('top until-only expected IO:DataFileRead/0.08/5.00/5.00/'
+                     '300.00/100.00, got %s/%s/%s/%s/%s/%s',
+                     r.key, r.avg_aas, r.peak_aas, r.p99_aas,
+                     r.backend_seconds, r.pct);
+
+            select count(*), max(aas)
+              into v_count, v_max
+            from ash.chart(until => v_until);
+            assert v_count = 61 and v_max = 5.00,
+              format('chart until-only expected legend+60/max 61/5.00, got %s/%s',
+                     v_count, v_max);
+            assert exists (
+              select from ash.chart(until => v_until)
+              where bucket_start is null
+                and position('IO:DataFileRead' in chart) > 0
+            ), 'chart until-only legend must name IO:DataFileRead';
+
+            select count(*) into v_count
+            from ash.samples(until => v_until, n => 500);
+            assert v_count = 300,
+              'samples until-only expected 300 exact backend rows, got ' || v_count;
+            select * into r
+            from ash.samples(until => v_until, n => 500) limit 1;
+            assert r.sample_time = v_until - interval '30 minutes'
+               and r.wait_event = 'IO:DataFileRead',
+              format('samples until-only expected intended minute/IO, got %s/%s',
+                     r.sample_time, r.wait_event);
+
+            j := ash.report(until => v_until);
+            assert j is not null, 'report until-only must read intended rollup_1m';
+            assert (j->'coverage'->>'from')::timestamptz
+                     = v_until - interval '1 hour'
+               and (j->'coverage'->>'to')::timestamptz = v_until
+               and (j->'coverage'->>'minutes_expected')::int = 60
+               and (j->'coverage'->>'minutes_with_data')::int = 1,
+              'report until-only coverage must be exactly the preceding hour: '
+              || j->'coverage';
+            j := ash.report();
+            assert (j->'coverage'->>'from')::timestamptz
+                     = date_trunc('minute', now() - interval '1 day')
+               and (j->'coverage'->>'to')::timestamptz
+                     = date_trunc('minute', now())
+               and (j->'coverage'->>'minutes_expected')::int = 1440
+               and (j->'coverage'->>'minutes_with_data')::int = 2,
+              'report() no-argument default must remain the preceding day: '
+              || j->'coverage';
+
+            select value into v_value
+            from ash.summary(until => v_until) where metric = 'avg_aas';
+            assert v_value = '0.08',
+              'summary until-only avg_aas expected 0.08, got ' || v_value;
+            select value into v_value
+            from ash.summary(until => v_until) where metric = 'top_wait_1';
+            assert v_value = 'IO:DataFileRead (avg_aas 0.08, 100.00%)',
+              'summary until-only top_wait_1 mismatch: ' || v_value;
+            select value into v_value
+            from ash.summary(until => v_until) where metric = 'period_start';
+            assert v_value::timestamptz = v_until - interval '1 hour',
+              'summary until-only period_start mismatch: ' || v_value;
+
+            -- periods() was already correct and is the family-wide reference.
+            select * into r from ash.periods(v_until) where period = '1h';
+            assert r.period_start = v_until - interval '1 hour'
+               and r.period_end = v_until and r.buckets_with_data = 1
+               and r.avg_aas = 0.08 and r.peak_aas = 5.00,
+              format('periods reference expected anchored 1h/1/0.08/5.00, '
+                     'got [%s,%s)/%s/%s/%s', r.period_start, r.period_end,
+                     r.buckets_with_data, r.avg_aas, r.peak_aas);
+
+            -- compare has required bounds, but NULL since_N means the same
+            -- until-only default for each delegated reader window.
+            select * into r
+            from ash.compare(null, v_until, null, v_until);
+            assert r.key = 'overall' and r.avg_aas_1 = 0.08
+               and r.avg_aas_2 = 0.08 and r.avg_delta = 0.00
+               and r.peak_aas_1 = 5.00 and r.peak_aas_2 = 5.00,
+              format('compare NULL-since windows expected .08/.08/.00/5/5, '
+                     'got %s/%s/%s/%s/%s',
+                     r.avg_aas_1, r.avg_aas_2, r.avg_delta,
+                     r.peak_aas_1, r.peak_aas_2);
+
+            raise notice 'B5 until-only reader windows PASSED';
+          end $$;
+
+          -- Explicit since > until must raise in every public reader's frame.
+          do $$
+          declare
+            v_until timestamptz := (select requested_until from b5anchor);
+            v_later timestamptz :=
+              (select requested_until + interval '40 seconds' from b5anchor);
+            v_earlier timestamptz :=
+              (select requested_until + interval '20 seconds' from b5anchor);
+            v_raised boolean;
+            a record;
+          begin
+            -- A chronological sub-minute window and an equal-bound window
+            -- remain legitimate degenerate windows. Minute flooring makes
+            -- each empty, then the #63 guard safely expands it to one minute.
+            select * into a from ash.aas(v_earlier, v_later);
+            assert a.period_start = v_until
+               and a.period_end = v_until + interval '1 minute',
+              'chronological sub-minute window must retain the #63 clamp';
+            select * into a from ash.aas(v_until, v_until);
+            assert a.period_start = v_until
+               and a.period_end = v_until + interval '1 minute',
+              'equal window must retain the #63 clamp';
+
+            v_raised := false;
+            begin perform * from ash.aas(v_later, v_earlier);
+            exception when others then
+              if sqlerrm = 'ash.aas: since must be less than or equal to until'
+                then v_raised := true; else raise; end if;
+            end;
+            assert v_raised, 'ash.aas must reject since > until';
+
+            v_raised := false;
+            begin perform * from ash.timeline(v_later, v_earlier);
+            exception when others then
+              if sqlerrm = 'ash.timeline: since must be less than or equal to until'
+                then v_raised := true; else raise; end if;
+            end;
+            assert v_raised, 'ash.timeline must reject since > until';
+
+            v_raised := false;
+            begin perform * from ash.top('wait_event', v_later, v_earlier);
+            exception when others then
+              if sqlerrm = 'ash.top: since must be less than or equal to until'
+                then v_raised := true; else raise; end if;
+            end;
+            assert v_raised, 'ash.top must reject since > until';
+
+            v_raised := false;
+            begin perform ash.report(v_later, v_earlier);
+            exception when others then
+              if sqlerrm = 'ash.report: since must be less than or equal to until'
+                then v_raised := true; else raise; end if;
+            end;
+            assert v_raised, 'ash.report must reject since > until';
+
+            v_raised := false;
+            begin perform * from ash.chart(v_later, v_earlier);
+            exception when others then
+              if sqlerrm = 'ash.chart: since must be less than or equal to until'
+                then v_raised := true; else raise; end if;
+            end;
+            assert v_raised, 'ash.chart must reject since > until';
+
+            v_raised := false;
+            begin perform * from ash.samples(v_later, v_earlier);
+            exception when others then
+              if sqlerrm = 'ash.samples: since must be less than or equal to until'
+                then v_raised := true; else raise; end if;
+            end;
+            assert v_raised, 'ash.samples must reject since > until';
+
+            v_raised := false;
+            begin perform * from ash.summary(v_later, v_earlier);
+            exception when others then
+              if sqlerrm = 'ash.summary: since must be less than or equal to until'
+                then v_raised := true; else raise; end if;
+            end;
+            assert v_raised, 'ash.summary must reject since > until';
+
+            v_raised := false;
+            begin
+              perform * from ash.compare(
+                v_later, v_earlier, v_until - interval '1 hour', v_until);
+            exception when others then
+              if sqlerrm =
+                   'ash.compare: since_1 must be less than or equal to until_1'
+                then v_raised := true; else raise; end if;
+            end;
+            assert v_raised, 'ash.compare must reject inverted window 1';
+
+            v_raised := false;
+            begin
+              perform * from ash.compare(
+                v_until - interval '1 hour', v_until, v_later, v_earlier);
+            exception when others then
+              if sqlerrm =
+                   'ash.compare: since_2 must be less than or equal to until_2'
+                then v_raised := true; else raise; end if;
+            end;
+            assert v_raised, 'ash.compare must reject inverted window 2';
+
+            raise notice 'B5 inverted-window validation PASSED';
+          end $$;
+
+          -- #63 remains effective for a chronological window whose real span
+          -- cannot fit in int4 seconds: conversions clamp both endpoints
+          -- before any int4 subtraction/cast can overflow.
+          truncate ash.sample_0, ash.sample_1, ash.sample_2;
+          truncate ash.rollup_1m, ash.rollup_1h;
+          do $$
+          declare
+            a record;
+            r record;
+            v_count int;
+            v_value text;
+          begin
+            assert extract(epoch from (
+              '3000-01-01'::timestamptz - '1000-01-01'::timestamptz
+            )) > 2147483647,
+              'test setup: cross-horizon span must overflow int4 seconds';
+
+            select * into a
+            from ash.aas('1000-01-01'::timestamptz,
+                         '3000-01-01'::timestamptz);
+            assert a.period_start = ash.epoch()
+               and a.period_end = ash.ts_to_timestamptz(2147483640)
+               and a.source = 'none'
+               and a.buckets_expected = 35791394
+               and a.buckets_with_data = 0 and a.avg_aas = 0
+               and a.peak_aas = 0 and a.p99_aas = 0
+               and a.backend_seconds = 0,
+              'cross-horizon aas must clamp safely with exact zero values';
+
+            select count(*) into v_count
+            from ash.timeline('1000-01-01'::timestamptz,
+                              '3000-01-01'::timestamptz);
+            assert v_count = 24856,
+              'cross-horizon timeline expected 24856 safe daily buckets, got '
+              || v_count;
+            select count(*) into v_count
+            from ash.top('wait_event', '1000-01-01'::timestamptz,
+                         '3000-01-01'::timestamptz);
+            assert v_count = 0, 'cross-horizon top must return 0 rows';
+            select count(*) into v_count
+            from ash.samples('1000-01-01'::timestamptz,
+                             '3000-01-01'::timestamptz);
+            assert v_count = 0, 'cross-horizon samples must return 0 rows';
+            assert ash.report('1000-01-01'::timestamptz,
+                              '3000-01-01'::timestamptz) is null,
+              'cross-horizon report must return NULL';
+            select count(*) into v_count
+            from ash.chart('1000-01-01'::timestamptz,
+                           '3000-01-01'::timestamptz);
+            assert v_count = 0, 'cross-horizon chart must return 0 rows';
+            select value into v_value
+            from ash.summary('1000-01-01'::timestamptz,
+                             '3000-01-01'::timestamptz)
+            where metric = 'status';
+            assert v_value = 'no data in this time range',
+              'cross-horizon summary must report no data';
+            select * into r from ash.compare(
+              '1000-01-01'::timestamptz, '3000-01-01'::timestamptz,
+              '1000-01-01'::timestamptz, '3000-01-01'::timestamptz);
+            assert r.key = 'overall' and r.avg_aas_1 is null
+               and r.avg_aas_2 is null and r.avg_delta is null,
+              'cross-horizon compare must preserve uncovered NULL semantics';
+
+            raise notice 'B5 #63 cross-horizon clamp PASSED';
+           end $$;
+           rollback;
+          EOF
+
       - name: "Test 2.0: pg_stat_statements fan-out and reader edges"
         env:
           PGPASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,30 @@ jobs:
           grep -q "ash.grant_reader" README.md
           grep -q "SECURITY.md#advisory-lock-squat-dos" README.md
           grep -q "SECURITY.md#advisory-lock-squat-dos" RELEASE_NOTES.md
+
+          # Release-stamped operator wording is two-sided: require the corrected
+          # contract and forbid the precise overclaim/misstatement it replaced.
+          grep -Fq \
+            "To opt out, run this after installation and after every installer re-apply" \
+            sql/ash-install.sql
+          if grep -Fq "Opt out at any time" sql/ash-install.sql; then
+            echo "pg_monitor opt-out wording must disclose installer re-apply" >&2
+            exit 1
+          fi
+          grep -Fq "operator-narrowed table privileges" RELEASE_NOTES.md
+          if grep -Fq "preserves explicit reader grants" RELEASE_NOTES.md; then
+            echo "Release notes must not claim narrowed reader grants are preserved" >&2
+            exit 1
+          fi
+          grep -Fq \
+            'named by `cron.database_name`; it still observes activity from every database.' \
+            README.md
+          grep -Fq "function signatures are unchanged; parameter" RELEASE_NOTES.md
+          grep -Fq "names were de-prefixed." RELEASE_NOTES.md
+          if grep -Fq "lifecycle/admin functions remain compatible" RELEASE_NOTES.md; then
+            echo "Release notes must disclose de-prefixed parameter names" >&2
+            exit 1
+          fi
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -3861,6 +3885,240 @@ jobs:
             raise notice 'B5 #63 cross-horizon clamp PASSED';
            end $$;
            rollback;
+          EOF
+
+      - name: "Test 2.0: release-stamped diagnostics and privilege disclosures"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          set -euo pipefail
+
+          # Catalog/function text is user-visible. Assert both sides so the
+          # corrected wording cannot coexist with the old false statement.
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          do $$
+          declare
+            v_start_def text :=
+              pg_get_functiondef('ash.start(interval)'::regprocedure);
+            v_report_comment text :=
+              obj_description(
+                'ash.report(timestamptz,timestamptz,integer,integer)'::regprocedure);
+          begin
+            assert position(
+              'pg_cron is not available in this database.' in v_start_def
+            ) > 0, 'ash.start must say pg_cron is unavailable in this database';
+            assert position(
+              'current_setting(''cron.database_name'', true)' in v_start_def
+            ) > 0, 'ash.start must hint cron.database_name';
+            assert position('pg_cron is not installed' in v_start_def) = 0,
+              'ash.start must not claim pg_cron is absent from the cluster';
+
+            assert position(
+              'Reads ash.rollup_1m only.' in v_report_comment
+            ) > 0, 'ash.report catalog comment must disclose rollup_1m-only input';
+            assert position(
+              'raw or rollup_1h has coverage' in v_report_comment
+            ) > 0, 'ash.report comment must distinguish alternate coverage';
+            assert position(
+              'Returns null when the window has no coverage' in v_report_comment
+            ) = 0, 'ash.report comment must remove the ambiguous old NULL wording';
+            raise notice 'release-stamped catalog wording PASSED';
+          end $$;
+          EOF
+
+          # N5 / C1: report remains SQL NULL and never reads another source,
+          # while its NOTICE names raw and rollup_1h coverage exactly.
+          n5_out="$(
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 2>&1 << 'EOF'
+          begin;
+          update ash.config
+            set current_slot = 0, sample_interval = '1 second'
+            where singleton;
+          truncate ash.sample_0, ash.sample_1, ash.sample_2;
+          truncate ash.rollup_1m, ash.rollup_1h;
+
+          do $$
+          declare
+            v_cpu smallint;
+            v_datid oid;
+            v_raw_min timestamptz :=
+              date_trunc('minute', now() - interval '20 minutes');
+            v_hour timestamptz :=
+              date_trunc('hour', now() - interval '2 hours');
+            a record;
+          begin
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+            select oid into v_datid
+            from pg_database where datname = current_database();
+
+            -- Raw-only coverage.
+            insert into ash.sample (
+              sample_ts, datid, active_count, data, slot
+            ) values (
+              ash.ts_from_timestamptz(v_raw_min), v_datid, 3,
+              array[-v_cpu::int, 3, 0, 0, 0], 0
+            );
+            select * into a
+            from ash.aas(v_raw_min, v_raw_min + interval '1 minute');
+            assert a.source = 'raw' and a.buckets_expected = 1
+               and a.buckets_with_data = 1 and a.avg_aas = 0.05
+               and a.peak_aas = 0.05 and a.p99_aas = 0.05
+               and a.backend_seconds = 3.00,
+              format('raw-only setup mismatch: %s/%s/%s/%s/%s/%s/%s',
+                     a.source, a.buckets_expected, a.buckets_with_data,
+                     a.avg_aas, a.peak_aas, a.p99_aas, a.backend_seconds);
+            assert ash.report(
+              v_raw_min, v_raw_min + interval '1 minute'
+            ) is null, 'raw-only report must remain SQL NULL';
+
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+
+            -- rollup_1h-only coverage, with real per-minute totals.
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends, wait_counts, query_counts,
+              minute_counts
+            ) values (
+              ash.ts_from_timestamptz(v_hour), v_datid, 60, 60,
+              array[v_cpu::int, 3600], array[]::bigint[],
+              pg_catalog.array_fill(60, array[60])
+            );
+            select * into a
+            from ash.aas(v_hour, v_hour + interval '1 hour');
+            assert a.source = 'rollup_1h' and a.buckets_expected = 60
+               and a.buckets_with_data = 60 and a.avg_aas = 1.00
+               and a.peak_aas = 1.00 and a.p99_aas = 1.00
+               and a.backend_seconds = 3600.00,
+              format('rollup_1h-only setup mismatch: %s/%s/%s/%s/%s/%s/%s',
+                     a.source, a.buckets_expected, a.buckets_with_data,
+                     a.avg_aas, a.peak_aas, a.p99_aas, a.backend_seconds);
+            assert ash.report(v_hour, v_hour + interval '1 hour') is null,
+              'rollup_1h-only report must remain SQL NULL';
+
+            -- An overlapping hour row is not coverage when minute_counts has
+            -- no value for the requested minute. This must stay silent.
+            truncate ash.rollup_1h;
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends, wait_counts, query_counts,
+              minute_counts
+            ) values (
+              ash.ts_from_timestamptz(v_hour), v_datid, 1, 1,
+              array[v_cpu::int, 1], array[]::bigint[],
+              array[60] || pg_catalog.array_fill(null::int, array[59])
+            );
+            select * into a
+            from ash.aas(
+              v_hour + interval '1 minute',
+              v_hour + interval '2 minutes'
+            );
+            assert a.source = 'rollup_1h' and a.buckets_with_data = 0,
+              'sparse rollup_1h setup must have no requested-minute coverage';
+            assert ash.report(
+              v_hour + interval '1 minute',
+              v_hour + interval '2 minutes'
+            ) is null, 'sparse rollup_1h report must remain silent SQL NULL';
+
+            -- With no source at all, NULL remains silent and non-raising.
+            truncate ash.rollup_1h;
+            assert ash.report(v_hour, v_hour + interval '1 hour') is null,
+              'uncovered report must remain SQL NULL';
+            raise notice 'ash.report alternate-source NULL behavior PASSED';
+          end $$;
+          rollback;
+          EOF
+          )"
+          printf '%s\n' "$n5_out"
+          if ! printf '%s\n' "$n5_out" | grep -Fq \
+              "raw has coverage, but report reads rollup_1m only and returns NULL"; then
+            echo "FAIL: ash.report raw-only NOTICE missing" >&2
+            exit 1
+          fi
+          if [ "$(printf '%s\n' "$n5_out" | grep -Fc \
+              "raw has coverage, but report reads rollup_1m only and returns NULL")" \
+              -ne 1 ]; then
+            echo "FAIL: ash.report raw-only NOTICE must occur exactly once" >&2
+            exit 1
+          fi
+          if ! printf '%s\n' "$n5_out" | grep -Fq \
+              "rollup_1h has coverage, but report reads rollup_1m only and returns NULL"; then
+            echo "FAIL: ash.report rollup_1h-only NOTICE missing" >&2
+            exit 1
+          fi
+          if [ "$(printf '%s\n' "$n5_out" | grep -Fc \
+              "rollup_1h has coverage, but report reads rollup_1m only and returns NULL")" \
+              -ne 1 ]; then
+            echo "FAIL: ash.report must not claim sparse rollup_1h coverage" >&2
+            exit 1
+          fi
+
+          # N3/N4: a full-function reader with narrowed table ACLs is restored
+          # to the complete bundle on re-apply, and the WARNING names it.
+          # Revoke pg_monitor first so the warning's affected-role list is
+          # deterministic; the default grant must return after re-apply.
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          do $$
+          begin
+            if exists (
+              select from pg_roles where rolname = 'ash_n4_reader'
+            ) then
+              perform ash.revoke_reader('ash_n4_reader');
+              execute 'drop role ash_n4_reader';
+            end if;
+            create role ash_n4_reader;
+          end $$;
+          select ash.grant_reader('ash_n4_reader');
+          select ash.revoke_reader('pg_monitor');
+          revoke select on ash.sample, ash.config from ash_n4_reader;
+          do $$
+          begin
+            assert has_function_privilege(
+              'ash_n4_reader',
+              'ash.aas(timestamptz,timestamptz,text,text,bigint,name,interval)',
+              'EXECUTE'
+            ), 'N4 setup: full reader-function bundle must remain';
+            assert not has_table_privilege(
+              'ash_n4_reader', 'ash.sample', 'SELECT'
+            ), 'N4 setup: sample SELECT must be narrowed';
+            assert not has_table_privilege(
+              'ash_n4_reader', 'ash.config', 'SELECT'
+            ), 'N4 setup: config SELECT must be narrowed';
+            assert not has_schema_privilege('pg_monitor', 'ash', 'USAGE'),
+              'N3 setup: pg_monitor must be opted out before re-apply';
+          end $$;
+          EOF
+
+          reapply_out="$(
+            psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
+              -f "$(python3 devel/scripts/ash_sql_chain.py fresh-install-path)" 2>&1
+          )"
+          printf '%s\n' "$reapply_out"
+          if ! printf '%s\n' "$reapply_out" \
+              | grep -F \
+                  "WARNING:  pg_ash installer: restoring the full reader bundle for role(s)" \
+              | grep -Fq "ash_n4_reader"; then
+            echo "FAIL: installer WARNING did not list ash_n4_reader" >&2
+            exit 1
+          fi
+
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          do $$
+          begin
+            assert has_table_privilege(
+              'ash_n4_reader', 'ash.sample', 'SELECT'
+            ), 'N4 documented behavior: sample SELECT must be re-granted';
+            assert has_table_privilege(
+              'ash_n4_reader', 'ash.config', 'SELECT'
+            ), 'N4 documented behavior: config SELECT must be re-granted';
+            assert has_schema_privilege('pg_monitor', 'ash', 'USAGE'),
+              'N3 documented behavior: re-apply must restore pg_monitor';
+            assert has_function_privilege(
+              'pg_monitor',
+              'ash.aas(timestamptz,timestamptz,text,text,bigint,name,interval)',
+              'EXECUTE'
+            ), 'N3 documented behavior: pg_monitor reader bundle must return';
+            raise notice 'installer re-grant disclosure behavior PASSED';
+          end $$;
+          select ash.revoke_reader('ash_n4_reader');
+          drop role ash_n4_reader;
           EOF
 
       - name: "Test 2.0: pg_stat_statements fan-out and reader edges"
@@ -10697,7 +10955,8 @@ jobs:
             -c "drop extension if exists pg_cron cascade"
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f "$(python3 devel/scripts/ash_sql_chain.py fresh-install-path)" > /dev/null
 
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          cronless_out="$(
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 2>&1 << 'EOF'
           do $$
           declare
             v_rec record;
@@ -10739,6 +10998,23 @@ jobs:
 
           select ash.uninstall('yes');
           EOF
+          )"
+          printf '%s\n' "$cronless_out"
+          if ! printf '%s\n' "$cronless_out" | grep -Fq \
+              "pg_cron is not available in this database."; then
+            echo "FAIL: ash.start database-scoped pg_cron NOTICE missing" >&2
+            exit 1
+          fi
+          if ! printf '%s\n' "$cronless_out" | grep -Fq \
+              "current_setting('cron.database_name', true)"; then
+            echo "FAIL: ash.start cron.database_name hint missing" >&2
+            exit 1
+          fi
+          if printf '%s\n' "$cronless_out" | grep -Fq \
+              "pg_cron is not installed"; then
+            echo "FAIL: ash.start emitted the old cluster-wide pg_cron claim" >&2
+            exit 1
+          fi
 
       - name: Final summary
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,8 @@ jobs:
           grep -Fq \
             'named by `cron.database_name`; it still observes activity from every database.' \
             README.md
+          grep -Fq '`ash.report()` reads `ash.rollup_1m` only.' README.md
+          grep -Fq 'it returns SQL `NULL` and emits a NOTICE' README.md
           grep -Fq "function signatures are unchanged; parameter" RELEASE_NOTES.md
           grep -Fq "names were de-prefixed." RELEASE_NOTES.md
           if grep -Fq "lifecycle/admin functions remain compatible" RELEASE_NOTES.md; then
@@ -10957,6 +10959,7 @@ jobs:
       - name: "Degraded mode: without pg_cron"
         env:
           PGPASSWORD: postgres
+          CRON: ${{ matrix.cron }}
         run: |
           # Install pg_ash fresh without pg_cron.
           # `drop extension if exists` is a no-op when pg_cron isn't installed
@@ -10979,6 +10982,23 @@ jobs:
             where job_type = 'sampler';
             assert v_status_val like '%schedule externally%',
               'start() without pg_cron should say schedule externally, got: ' || v_status_val;
+
+            /*
+             * A preloaded pg_cron registers cron.database_name as
+             * postmaster-only even after DROP EXTENSION. Exercise mutable
+             * placeholder values only on the dedicated cron-off axis, where
+             * the setting starts absent.
+             */
+            if current_setting('cron.database_name', true) is null then
+              perform set_config(
+                'cron.database_name', current_database(), false
+              );
+              perform * from ash.start('1 second');
+              perform set_config(
+                'cron.database_name', 'cron_control', false
+              );
+              perform * from ash.start('1 second');
+            end if;
 
             -- stop() should work without pg_cron
             select status into v_status_val
@@ -11017,8 +11037,25 @@ jobs:
             exit 1
           fi
           if ! printf '%s\n' "$cronless_out" | grep -Fq \
-              "current_setting('cron.database_name', true)"; then
-            echo "FAIL: ash.start cron.database_name hint missing" >&2
+              "current_setting('cron.database_name', true) = postgres names this database"; then
+            echo "FAIL: ash.start local cron.database_name guidance missing" >&2
+            exit 1
+          fi
+          if [ "$CRON" = "off" ]; then
+            if ! printf '%s\n' "$cronless_out" | grep -Fq \
+                "current_setting('cron.database_name', true) is not set; configure pg_cron"; then
+              echo "FAIL: ash.start unset cron.database_name guidance missing" >&2
+              exit 1
+            fi
+            if ! printf '%s\n' "$cronless_out" | grep -Fq \
+                "current_setting('cron.database_name', true) = cron_control; install pg_ash in that database"; then
+              echo "FAIL: ash.start remote cron.database_name guidance missing" >&2
+              exit 1
+            fi
+          fi
+          if printf '%s\n' "$cronless_out" | grep -Fq \
+              "install pg_ash in (not set)"; then
+            echo "FAIL: ash.start recommended an impossible pg_ash target" >&2
             exit 1
           fi
           if printf '%s\n' "$cronless_out" | grep -Fq \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3883,8 +3883,8 @@ jobs:
               'cross-horizon compare must preserve uncovered NULL semantics';
 
             raise notice 'B5 #63 cross-horizon clamp PASSED';
-           end $$;
-           rollback;
+          end $$;
+          rollback;
           EOF
 
       - name: "Test 2.0: release-stamped diagnostics and privilege disclosures"
@@ -3994,8 +3994,10 @@ jobs:
             assert ash.report(v_hour, v_hour + interval '1 hour') is null,
               'rollup_1h-only report must remain SQL NULL';
 
-            -- An overlapping hour row is not coverage when minute_counts has
-            -- no value for the requested minute. This must stay silent.
+            -- Invalid/partial minute_counts is honestly disclosed as one flat
+            -- hour-grain datum by the aggregate readers. It is still not
+            -- per-minute coverage for report's requested minute, so report
+            -- must stay silent.
             truncate ash.rollup_1h;
             insert into ash.rollup_1h (
               ts, datid, samples, peak_backends, wait_counts, query_counts,
@@ -4010,8 +4012,17 @@ jobs:
               v_hour + interval '1 minute',
               v_hour + interval '2 minutes'
             );
-            assert a.source = 'rollup_1h' and a.buckets_with_data = 0,
-              'sparse rollup_1h setup must have no requested-minute coverage';
+            assert a.source = 'rollup_1h_flat'
+               and a.period_start = v_hour
+               and a.period_end = v_hour + interval '1 hour'
+               and a.effective_bucket = interval '1 hour'
+               and a.buckets_expected = 1
+               and a.buckets_with_data = 1,
+              format(
+                'partial hour must disclose flat hour plan, got %s/[%,%)/%s/%s/%s',
+                a.source, a.period_start, a.period_end, a.effective_bucket,
+                a.buckets_expected, a.buckets_with_data
+              );
             assert ash.report(
               v_hour + interval '1 minute',
               v_hour + interval '2 minutes'

--- a/README.md
+++ b/README.md
@@ -337,7 +337,9 @@ Only `ash.rebuild_partitions` and `ash.uninstall` require the exact `'yes'` conf
 
 ## Scheduling
 
-pg_cron is optional. With pg_cron installed, `ash.start('1 second')` schedules:
+pg_cron is optional. For pg_cron scheduling, install pg_ash in the database
+named by `cron.database_name`; it still observes activity from every database.
+With pg_cron installed, `ash.start('1 second')` schedules:
 
 - sampling
 - raw partition rotation

--- a/README.md
+++ b/README.md
@@ -312,6 +312,10 @@ It includes:
 - `top_queryids_available`, so scrapers can branch without guessing
 - `coverage`, so consumers can reconcile against `ash.aas()` and `ash.top()`
 
+`ash.report()` reads `ash.rollup_1m` only. If a requested window exists only
+in raw samples or `ash.rollup_1h`, it returns SQL `NULL` and emits a NOTICE
+naming that alternate source; it does not synthesize per-minute class data.
+
 The payload contract is stable for the 2.0 minor line: keys may be added, not
 renamed or removed.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,8 +7,9 @@ migrations. Root-level `sql/ash-X.Y-to-A.B.sql` wrappers remain for
 compatibility.
 
 This is a breaking reader-API release. Sampling, storage, rollups, scheduler
-functions, and lifecycle/admin functions remain compatible, but the 1.x reader
-surface has been replaced by the AAS-oriented 2.0 API:
+functions, and lifecycle/admin function signatures are unchanged; parameter
+names were de-prefixed. The 1.x reader surface has been replaced by the
+AAS-oriented 2.0 API:
 
 | 1.x | 2.0 |
 |---|---|
@@ -30,8 +31,10 @@ surface has been replaced by the AAS-oriented 2.0 API:
   incident automation, dashboards, and AI/database copilots. The 2.0 minor line
   may add keys, but existing keys are not renamed or removed.
 - **Upgrade convergence.** The 1.5-to-2.0 wrapper replays the finalized 2.0
-  installer, removes stale 1.x and earlier draft reader functions, and preserves
-  explicit reader grants where safe.
+  installer, removes stale 1.x and earlier draft reader functions, and restores
+  eligible explicit reader-function grants. Roles that held the full
+  reader-function bundle receive the full current reader bundle; the installer
+  warns that this can re-grant operator-narrowed table privileges.
 - **Default monitoring access.** Fresh installs and upgrades grant the reader
   bundle to `pg_monitor` on a best-effort basis; opt out with
   `select ash.revoke_reader('pg_monitor');`.
@@ -41,6 +44,10 @@ surface has been replaced by the AAS-oriented 2.0 API:
 
 ## Fixes since 2.0 beta 1
 
+- **Reader windows and diagnostics are now explicit.** Reader functions reject
+  inverted windows and anchor an `until`-only call to the preceding hour.
+  Installer re-apply, report coverage, and pg_cron availability messages now
+  describe their actual behavior. (issues #165, #170, #171, #172, #173, #174)
 - **Malformed decoder input is rejected consistently.** `ash.decode_sample()`
   now returns zero rows with a position-specific warning when a packed sample
   array contains a NULL wait marker, count, or query-map id, matching the

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -1985,6 +1985,7 @@ declare
   v_skip_nodename_update boolean := false;
   v_debug_logging boolean := false;
   v_pg_cron_available boolean;
+  v_cron_database text;
 begin
   /*
    * Read debug_logging flag so we can trace the pg_cron detection /
@@ -2152,11 +2153,24 @@ begin
     raise notice
       'pg_cron is not available in this database. To sample, call '
       'ash.take_sample() from an external scheduler:';
-    raise notice
-      '  hint: current_setting(''cron.database_name'', true) = %; install '
-      'pg_ash in that database to use pg_cron scheduling.',
-      coalesce(nullif(current_setting('cron.database_name', true), ''),
-               '(not set)');
+    v_cron_database :=
+      nullif(current_setting('cron.database_name', true), '');
+    if v_cron_database is null then
+      raise notice
+        '  hint: current_setting(''cron.database_name'', true) is not set; '
+        'configure pg_cron for this database or use the external scheduler below';
+    elsif v_cron_database <> current_database() then
+      raise notice
+        '  hint: current_setting(''cron.database_name'', true) = %; install '
+        'pg_ash in that database to use pg_cron scheduling.',
+        v_cron_database;
+    else
+      raise notice
+        '  hint: current_setting(''cron.database_name'', true) = % names this '
+        'database, but pg_cron is unavailable here; install or configure '
+        'pg_cron here, or use the external scheduler below.',
+        v_cron_database;
+    end if;
     raise notice
       '  system cron:    * * * * * psql -qAtX -c '
       '"select ash.take_sample()" (for per-second, use a loop)';

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -4368,7 +4368,8 @@ set jit = off
 set search_path = pg_catalog, ash
 as $$
 declare
-  v_from timestamptz := coalesce(since, now() - interval '1 hour');
+  v_from timestamptz := coalesce(
+    since, until - interval '1 hour', now() - interval '1 hour');
   v_to timestamptz := coalesce(until, now());
   v_start_ts int4;
   v_end_ts int4;
@@ -4382,6 +4383,11 @@ declare
   v_extrema_supported boolean;
   v_raw_start timestamptz;
 begin
+  if v_from > v_to then
+    raise exception
+      'ash.aas: since must be less than or equal to until';
+  end if;
+
   v_requested_bucket_secs := extract(epoch from bucket);
   if v_requested_bucket_secs is null or v_requested_bucket_secs < 60 then
     raise exception 'bucket must be at least 1 minute, got %', bucket;
@@ -4546,7 +4552,8 @@ set jit = off
 set search_path = pg_catalog, ash
 as $$
 declare
-  v_from timestamptz := coalesce(since, now() - interval '1 hour');
+  v_from timestamptz := coalesce(
+    since, until - interval '1 hour', now() - interval '1 hour');
   v_to timestamptz := coalesce(until, now());
   v_start_ts int4;
   v_end_ts int4;
@@ -4561,6 +4568,11 @@ declare
   v_extrema_supported boolean;
   v_raw_start timestamptz;
 begin
+  if v_from > v_to then
+    raise exception
+      'ash.timeline: since must be less than or equal to until';
+  end if;
+
   v_start_ts := (ash.ts_from_timestamptz(v_from) / 60) * 60;
   v_end_ts := (ash.ts_from_timestamptz(v_to) / 60) * 60;
   -- overflow-safe empty/degenerate-window guard (#63).
@@ -5079,7 +5091,8 @@ set jit = off
 set search_path = pg_catalog, ash, public
 as $$
 declare
-  v_from timestamptz := coalesce(since, now() - interval '1 hour');
+  v_from timestamptz := coalesce(
+    since, until - interval '1 hour', now() - interval '1 hour');
   v_to timestamptz := coalesce(until, now());
   v_start_ts int4;
   v_end_ts int4;
@@ -5096,6 +5109,11 @@ declare
   v_pgss_schema text;
   v_key_num bigint;
 begin
+  if v_from > v_to then
+    raise exception
+      'ash.top: since must be less than or equal to until';
+  end if;
+
   if dimension not in (
        'wait_event_type', 'wait_event', 'query_id', 'database'
      ) then
@@ -5391,6 +5409,12 @@ set jit = off
 set search_path = pg_catalog, ash, public
 as $$
 declare
+  v_from1 timestamptz := coalesce(
+    since_1, until_1 - interval '1 hour', now() - interval '1 hour');
+  v_to1 timestamptz := coalesce(until_1, now());
+  v_from2 timestamptz := coalesce(
+    since_2, until_2 - interval '1 hour', now() - interval '1 hour');
+  v_to2 timestamptz := coalesce(until_2, now());
   v_aas1 record;
   v_aas2 record;
   v_cov1 boolean;
@@ -5424,6 +5448,14 @@ begin
       'wait_event_type|wait_event|query_id|database '
       '(or null for one overall row)', dimension;
   end if;
+  if v_from1 > v_to1 then
+    raise exception
+      'ash.compare: since_1 must be less than or equal to until_1';
+  end if;
+  if v_from2 > v_to2 then
+    raise exception
+      'ash.compare: since_2 must be less than or equal to until_2';
+  end if;
 
   /*
    * Per-window coverage probe (rollup-backed, cheap). buckets_with_data = 0
@@ -5431,9 +5463,9 @@ begin
    * caller is warned: comparing against an uncovered window says nothing
    * about a regression.
    */
-  select * into v_aas1 from ash.aas(since_1, until_1,
+  select * into v_aas1 from ash.aas(v_from1, v_to1,
     wait_event_type, wait_event, query_id, database, bucket);
-  select * into v_aas2 from ash.aas(since_2, until_2,
+  select * into v_aas2 from ash.aas(v_from2, v_to2,
     wait_event_type, wait_event, query_id, database, bucket);
   v_cov1 := v_aas1.buckets_with_data > 0;
   v_cov2 := v_aas2.buckets_with_data > 0;
@@ -5612,11 +5644,11 @@ begin
 
   return query
   with window1 as (
-    select * from ash.top(dimension, since_1, until_1,
+    select * from ash.top(dimension, v_from1, v_to1,
       wait_event_type, wait_event, query_id, database, 2147483647, bucket)
   ),
   window2 as (
-    select * from ash.top(dimension, since_2, until_2,
+    select * from ash.top(dimension, v_from2, v_to2,
       wait_event_type, wait_event, query_id, database, 2147483647, bucket)
   )
   select
@@ -5731,7 +5763,8 @@ set jit = off
 set search_path = pg_catalog, ash, public
 as $$
 declare
-  v_from timestamptz := coalesce(since, now() - interval '1 hour');
+  v_from timestamptz := coalesce(
+    since, until - interval '1 hour', now() - interval '1 hour');
   v_to timestamptz := coalesce(until, now());
   v_start int4;
   v_end int4;
@@ -5740,6 +5773,11 @@ declare
   v_has_pgss boolean := false;
   v_pgss_schema text;
 begin
+  if v_from > v_to then
+    raise exception
+      'ash.samples: since must be less than or equal to until';
+  end if;
+
   v_start := ash.ts_from_timestamptz(v_from);
   v_end := ash.ts_from_timestamptz(v_to);
   v_slots := ash._active_slots_for_at(v_from, v_to);
@@ -5986,7 +6024,8 @@ set jit = off
 set search_path = pg_catalog, ash
 as $$
 declare
-  v_from timestamptz := coalesce(since, now() - interval '1 day');
+  v_from timestamptz := coalesce(
+    since, until - interval '1 hour', now() - interval '1 day');
   v_to timestamptz := coalesce(until, now());
   v_start_ts int4;
   v_end_ts int4;
@@ -6022,6 +6061,11 @@ declare
   v_t99_thr numeric;
   v_t999_thr numeric;
 begin
+  if v_from > v_to then
+    raise exception
+      'ash.report: since must be less than or equal to until';
+  end if;
+
   v_start_ts := (ash.ts_from_timestamptz(v_from) / 60) * 60;
   v_end_ts := (ash.ts_from_timestamptz(v_to) / 60) * 60;
   -- overflow-safe empty/degenerate-window guard (#63).
@@ -6385,7 +6429,8 @@ set jit = off
 set search_path = pg_catalog, ash
 as $$
 declare
-  v_from timestamptz := coalesce(since, now() - interval '1 hour');
+  v_from timestamptz := coalesce(
+    since, until - interval '1 hour', now() - interval '1 hour');
   v_to timestamptz := coalesce(until, now());
   v_start_ts int4;
   v_end_ts int4;
@@ -6410,6 +6455,11 @@ declare
   v_i int;
   v_char_count int;
 begin
+  if v_from > v_to then
+    raise exception
+      'ash.chart: since must be less than or equal to until';
+  end if;
+
   width := least(greatest(width, 1), 500);
   v_start_ts := (ash.ts_from_timestamptz(v_from) / 60) * 60;
   v_end_ts := (ash.ts_from_timestamptz(v_to) / 60) * 60;
@@ -6631,7 +6681,8 @@ set jit = off
 set search_path = pg_catalog, ash, public
 as $$
 declare
-  v_from timestamptz := coalesce(since, now() - interval '1 hour');
+  v_from timestamptz := coalesce(
+    since, until - interval '1 hour', now() - interval '1 hour');
   v_to timestamptz := coalesce(until, now());
   v_aas record;
   v_rec record;
@@ -6641,6 +6692,11 @@ declare
   v_drill_period_end timestamptz;
   v_drill_effective_bucket interval;
 begin
+  if v_from > v_to then
+    raise exception
+      'ash.summary: since must be less than or equal to until';
+  end if;
+
   select * into v_aas from ash.aas(v_from, v_to);
   if v_aas.buckets_with_data = 0 then
     return query select 'status'::text, 'no data in this time range'::text;

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -71,10 +71,14 @@ begin
    * restore, which grants the complete current closure. Detection uses the
    * snapshotted explicit aclitems, not has_function_privilege(), so
    * superusers and role-membership shortcuts never qualify; roles holding
-   * only partial manual grants keep the exact-signature restore path and
-   * are never widened. ash._admin_funcs() may not exist yet (fresh install,
-   * or upgrade from a version predating the #45 hardening — which also
-   * predates grant_reader, so there are no reader bundles to detect).
+   * only partial manual FUNCTION grants keep the exact-signature restore
+   * path and are not widened. Table ACLs are not snapshotted: a role with
+   * the full function bundle is classified as a reader even if an operator
+   * narrowed its table access, so the full-bundle restore below re-grants
+   * that access and emits a WARNING. ash._admin_funcs() may not exist yet
+   * (fresh install, or upgrade from a version predating the #45 hardening —
+   * which also predates grant_reader, so there are no reader bundles to
+   * detect).
    */
   drop table if exists pg_temp._ash_install_reader_roles;
   create temp table _ash_install_reader_roles (rolname name primary key);
@@ -2146,8 +2150,13 @@ begin
     return next;
 
     raise notice
-      'pg_cron is not installed. To sample, call ash.take_sample() '
-      'from an external scheduler:';
+      'pg_cron is not available in this database. To sample, call '
+      'ash.take_sample() from an external scheduler:';
+    raise notice
+      '  hint: current_setting(''cron.database_name'', true) = %; install '
+      'pg_ash in that database to use pg_cron scheduling.',
+      coalesce(nullif(current_setting('cron.database_name', true), ''),
+               '(not set)');
     raise notice
       '  system cron:    * * * * * psql -qAtX -c '
       '"select ash.take_sample()" (for per-second, use a loop)';
@@ -6060,6 +6069,9 @@ declare
   v_t999_mins int4[];
   v_t99_thr numeric;
   v_t999_thr numeric;
+  v_available_source text;
+  v_active_slots smallint[];
+  v_raw_retention_start timestamptz;
 begin
   if v_from > v_to then
     raise exception
@@ -6079,6 +6091,53 @@ begin
   from (select distinct ts from ash.rollup_1m
         where ts >= v_start_ts and ts < v_end_ts) as covered;
   if v_n = 0 then
+    /*
+     * report's per-class minute payload is rollup_1m-only. Do not synthesize
+     * it from another source; just distinguish "pg_ash has no data" from
+     * "another reader source holds this window" before returning the same
+     * SQL NULL as before.
+     */
+    select
+      array(
+        select (
+          (config.current_slot - slot_offset.i + config.num_partitions)
+          % config.num_partitions
+        )::smallint
+        from generate_series(0, config.num_partitions - 2) as slot_offset(i)
+        order by slot_offset.i
+      ),
+      now() - (config.num_partitions - 2) * config.rotation_period
+    into v_active_slots, v_raw_retention_start
+    from ash.config as config
+    where config.singleton;
+
+    if ash.ts_to_timestamptz(v_end_ts) > v_raw_retention_start
+       and ash.ts_to_timestamptz(v_start_ts) <= now()
+       and exists (
+         select
+         from ash.sample as sample_row
+         where sample_row.slot = any(v_active_slots)
+           and sample_row.sample_ts >= v_start_ts
+           and sample_row.sample_ts < v_end_ts
+       ) then
+      v_available_source := 'raw';
+    elsif exists (
+      select
+      from ash._grain_counts(
+        v_start_ts, v_end_ts, 'rollup_1h_minutes'
+      )
+    ) then
+      v_available_source := 'rollup_1h';
+    end if;
+
+    if v_available_source is not null then
+      raise notice
+        'ash.report: no rollup_1m coverage for [%, %); % has coverage, '
+        'but report reads rollup_1m only and returns NULL',
+        ash.ts_to_timestamptz(v_start_ts),
+        ash.ts_to_timestamptz(v_end_ts),
+        v_available_source;
+    end if;
     return null;
   end if;
 
@@ -6793,7 +6852,7 @@ comment on function ash.samples(timestamptz, timestamptz, int, text, text, bigin
 $$Decoded raw sample rows, newest first (US-5 raw evidence) over [since, until) (default last 1 hour), up to n. Uniform filters wait_event_type/wait_event/query_id/database. Columns (sample_time, database_name, active_backends, wait_event, query_id, query_text). query_text needs pg_stat_statements AND that the caller holds pg_read_all_stats (e.g. via pg_monitor membership); it is null otherwise — a plain ash.grant_reader() role without pg_read_all_stats sees null even with pgss installed, because pgss restricts query text to the owning role. When pgss lives outside public, the caller also needs USAGE on that schema, else query_text is null. Reads ash.sample directly (raw retention only).$$;
 
 comment on function ash.report(timestamptz, timestamptz, int, int) is
-$$Machine-readable load report as one jsonb (US-8) for [since, until) (default last 1 day). Per wait class (cpu=CPU*, io=IO, ipc=IPC, lock=Lock, lwlock=LWLock; total = their sum) at 1-minute resolution: aas_avg / aas_worst1m / aas_p99 / aas_p999. Plus top_events_{worst1m,p99,p999} (keys io/ipc/lock/lwlock, entries "event(aas)") and top_queryids_{worst1m,p99,p999} (keys total+the four non-cpu classes, entries "queryid(aas)"). Query attribution is decided per extreme minute: a top_queryids key appears when raw samples still cover that class's worst/percentile minute(s), even if the window start predates raw retention (percentile sets attribute over their raw-covered minutes). top_queryids_available (boolean, always present) says whether any attribution was possible — branch on it, not on key absence. coverage {from, to, source, minutes_expected, minutes_with_data, raw_retention_start} reconciles the payload against ash.aas()/ash.top() and flags degraded resolution; raw_retention_start is the logical planning/loss boundary, not the physical query-attribution cutoff. vcpus (echoed, never used) and cluster_name are pass-throughs. Returns null when the window has no coverage; never raises. Payload contract is frozen per 2.0 minor line (keys only added, never renamed/removed); scoring/normalization is the consumer's job.$$;
+$$Machine-readable load report as one jsonb (US-8) for [since, until) (no bounds: last 1 day; until-only: preceding 1 hour). Per wait class (cpu=CPU*, io=IO, ipc=IPC, lock=Lock, lwlock=LWLock; total = their sum) at 1-minute resolution: aas_avg / aas_worst1m / aas_p99 / aas_p999. Plus top_events_{worst1m,p99,p999} (keys io/ipc/lock/lwlock, entries "event(aas)") and top_queryids_{worst1m,p99,p999} (keys total+the four non-cpu classes, entries "queryid(aas)"). Query attribution is decided per extreme minute: a top_queryids key appears when raw samples still cover that class's worst/percentile minute(s), even if the window start predates raw retention (percentile sets attribute over their raw-covered minutes). top_queryids_available (boolean, always present) says whether any attribution was possible — branch on it, not on key absence. coverage {from, to, source, minutes_expected, minutes_with_data, raw_retention_start} reconciles the payload against ash.aas()/ash.top() and flags degraded resolution; raw_retention_start is the logical planning/loss boundary, not the physical query-attribution cutoff. vcpus (echoed, never used) and cluster_name are pass-throughs. Reads ash.rollup_1m only. If it has no coverage for the window, returns null even when raw or rollup_1h has coverage, emits a NOTICE naming that source, and never raises for missing coverage. Payload contract is frozen per 2.0 minor line (keys only added, never renamed/removed); scoring/normalization is the consumer's job.$$;
 
 comment on function ash.chart(timestamptz, timestamptz, interval, int, int, boolean) is
 $$Human render helper: stacked ASCII per-bucket AAS chart over [since, until) (default last 1 hour). Series/legend = the window-wide top n wait events PLUS any event that is top-1 in at least one bucket, plus Other. bucket => null auto-selects grain by span. On rollup_1h the chart snaps partial bounds/buckets outward and emits a NOTICE naming source and effective plan; it never silently falls through to unavailable rollup_1m data. Presentation-only (bucket_start, aas, detail, chart); for typed data use ash.timeline(). Enable ANSI color with color => true or "set ash.color = on".$$;
@@ -7353,17 +7412,20 @@ end $$;
  *     name.
  * This mirrors what CREATE OR REPLACE would have preserved: function names
  * that no longer exist (removed/renamed) are skipped, roles dropped
- * mid-script are skipped, and a partially-granted role's reach is never
- * widened. Roles that held the FULL pre-upgrade reader bundle (detected in
- * the snapshot block at the top of this script) are additionally re-run
- * through ash.grant_reader() afterwards, so they can also execute helpers
- * introduced by this version — otherwise the readers they kept would fail
- * mid-call on the first new internal helper.
+ * mid-script are skipped, and a role with only partial FUNCTION grants is
+ * not widened. Roles that held the FULL pre-upgrade reader-function bundle
+ * (detected in the snapshot block at the top of this script) are additionally
+ * re-run through ash.grant_reader() afterwards, so they can also execute
+ * helpers introduced by this version — otherwise the readers they kept would
+ * fail mid-call on the first new internal helper. This classification does
+ * not snapshot table ACLs, so the full-bundle replay can restore table access
+ * an operator narrowed; the WARNING below lists every affected role.
  */
 do $$
 declare
   v_rec record;
   v_admin_funcs constant text[] := ash._admin_funcs();
+  v_reader_roles text;
 begin
   for v_rec in
     select distinct func_acl.grantee, func_acl.grantable, proc.proname,
@@ -7397,11 +7459,29 @@ begin
                         else '' end);
   end loop;
 
+  select string_agg(
+           pg_catalog.quote_ident(reader_role.rolname),
+           ', ' order by reader_role.rolname
+         )
+  into v_reader_roles
+  from pg_temp._ash_install_reader_roles as reader_role
+  join pg_catalog.pg_roles as role_row
+    on role_row.rolname = reader_role.rolname;
+
+  if v_reader_roles is not null then
+    raise warning
+      'pg_ash installer: restoring the full reader bundle for role(s) %; '
+      'any operator-narrowed table privileges will be re-granted',
+      v_reader_roles;
+  end if;
+
   /*
    * Preserved reader roles: grant the full CURRENT reader closure. The
    * exact-signature loop above only replays pre-upgrade grants, so helpers
    * new in this version would stay denied for these roles. grant_reader()
-   * excludes the admin set, so this never widens beyond reader access.
+   * excludes the admin set, so this never widens beyond reader access, but it
+   * can restore manually revoked reader-table access because the detection
+   * snapshot records function grants only.
    *
    * _admin_funcs() moved from the reader set into the admin set in #166.
    * CREATE OR REPLACE preserves its old ACL, so explicitly remove that one
@@ -7435,7 +7515,8 @@ end $$;
  * nothing they could not already see, and it makes monitoring tools running
  * as pg_monitor members (Grafana, exporters) work out of the box.
  *
- * Opt out at any time (the grant is a plain ash.grant_reader() bundle):
+ * To opt out, run this after installation and after every installer re-apply
+ * (including upgrades, which restore the default grant):
  *   select ash.revoke_reader('pg_monitor');
  *
  * Best-effort: this must NEVER abort the install. On a locked-down managed

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -5428,10 +5428,6 @@ declare
   v_aas2 record;
   v_cov1 boolean;
   v_cov2 boolean;
-  v_from1 timestamptz := coalesce(since_1, now() - interval '1 hour');
-  v_to1 timestamptz := coalesce(until_1, now());
-  v_from2 timestamptz := coalesce(since_2, now() - interval '1 hour');
-  v_to2 timestamptz := coalesce(until_2, now());
   v_start1 int4;
   v_end1 int4;
   v_start2 int4;
@@ -6070,7 +6066,6 @@ declare
   v_t99_thr numeric;
   v_t999_thr numeric;
   v_available_source text;
-  v_active_slots smallint[];
   v_raw_retention_start timestamptz;
 begin
   if v_from > v_to then
@@ -6097,26 +6092,20 @@ begin
      * "another reader source holds this window" before returning the same
      * SQL NULL as before.
      */
-    select
-      array(
-        select (
-          (config.current_slot - slot_offset.i + config.num_partitions)
-          % config.num_partitions
-        )::smallint
-        from generate_series(0, config.num_partitions - 2) as slot_offset(i)
-        order by slot_offset.i
-      ),
-      now() - (config.num_partitions - 2) * config.rotation_period
-    into v_active_slots, v_raw_retention_start
-    from ash.config as config
-    where config.singleton;
+    /*
+     * Reuse the B3 boundary split: _raw_retention_start() is the logical
+     * planning boundary, while the row probe below proves physical coverage.
+     * _active_slots() excludes the ring slot that readers must not expose.
+     */
+    v_raw_retention_start := ash._raw_retention_start();
 
-    if ash.ts_to_timestamptz(v_end_ts) > v_raw_retention_start
+    if v_raw_retention_start is not null
+       and ash.ts_to_timestamptz(v_end_ts) > v_raw_retention_start
        and ash.ts_to_timestamptz(v_start_ts) <= now()
        and exists (
          select
          from ash.sample as sample_row
-         where sample_row.slot = any(v_active_slots)
+         where sample_row.slot = any(ash._active_slots())
            and sample_row.sample_ts >= v_start_ts
            and sample_row.sample_ts < v_end_ts
        ) then


### PR DESCRIPTION
## Summary

- Reject inverted windows in `ash.aas`, `timeline`, `top`, `report`, `chart`, `samples`, `summary`, and both `compare` windows; anchor an `until`-only call to the preceding hour while retaining the #63 overflow/degenerate clamp. Closes #165.
- Correct the pg_monitor opt-out and reader re-apply documentation, and warn with the roles whose complete reader bundle is restored. Closes #170 and #171.
- Document the `rollup_1m`-only report contract in the catalog and README and emit a NOTICE naming raw or `rollup_1h` alternate coverage without changing the SQL NULL return behavior. This implements C1 Option A. Closes #172; refs #167.
- Correct the pg_cron database-scoping diagnostic and distinguish unset, current-database, and alternate-database targets. Closes #173.
- Clarify that lifecycle/admin signatures are unchanged while parameter names were de-prefixed. Closes #174.
- Append the user-visible changes to the release notes.

## Rebase resolution

Hand-rebased onto main `c28fce3`. The resolution preserves #181's dynamic reader/helper grants, #182's honest `rollup_1h_flat` planning, and #189's logical/physical raw-retention boundary and active-slot exclusion. No new reader helper was introduced.

## Validation

- Current main RED: until-only calls answered a now-relative window, and every affected reader accepted explicit inverted bounds.
- Rebased head GREEN: exact B5 defaults/errors for all readers and both compare windows; #63 horizon clamps remain intact.
- Alternate raw/hourly coverage NOTICEs occur exactly once while `ash.report()` remains SQL NULL; uncovered and sparse invalid-hour windows remain silent.
- Installer re-grant warning and pg_monitor behavior pass; #181 helper bundle remains complete.
- #182 grain/source behavior and #189 retention/active-slot probes pass.
- PG17 cron-off and real pg_cron-preloaded cron-on diagnostic branches pass; the postmaster-only GUC is never mutated on cron-enabled servers.
- YAML parse, documentation guards, fresh install, and `git diff --check` pass.
- Codex review (standing in for REV): final pass, no actionable regressions.
