### PR TITLE
release: fix reader privilege blockers and sample slot race

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -954,6 +954,432 @@ jobs:
           drop role ash_pgmon_outsider;
           EOF
 
+      - name: "Issue #164: rebuild_partitions preserves reader ACLs"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          do $$
+          begin
+            if not exists (
+              select from pg_roles where rolname = 'ash_b4_reader'
+            ) then
+              create role ash_b4_reader login password 'x';
+            end if;
+            if not exists (
+              select from pg_roles where rolname = 'ash_b4_pgmon_member'
+            ) then
+              create role ash_b4_pgmon_member login password 'x';
+            end if;
+          end $$;
+
+          grant pg_monitor to ash_b4_pgmon_member;
+          select ash.grant_reader('ash_b4_reader');
+
+          -- Seed one exact query-map-backed row before the rebuild. This proves
+          -- both a configured reader and a plain pg_monitor member can traverse
+          -- query_map_all; the member itself has no direct ash ACL.
+          do $$
+          declare
+            v_wait_id smallint;
+            v_map_id int4;
+            v_datid oid;
+          begin
+            truncate ash.sample, ash.query_map_0, ash.query_map_1, ash.query_map_2
+              restart identity;
+            update ash.config
+            set current_slot = 0,
+              sampling_enabled = true
+            where singleton;
+
+            select ash._register_wait('active', 'B4Test', 'B4Wait')
+              into v_wait_id;
+            insert into ash.query_map_0 (query_id)
+            values (164000000001)
+            returning id into v_map_id;
+            select oid into v_datid
+            from pg_database
+            where datname = current_database();
+            insert into ash.sample (
+              sample_ts,
+              datid,
+              active_count,
+              data,
+              slot
+            )
+            values (
+              ash.ts_from_timestamptz(
+                date_trunc('minute', now()) - interval '2 minutes'
+              ),
+              v_datid,
+              1,
+              array[-v_wait_id, 1, v_map_id]::integer[],
+              0
+            );
+          end $$;
+
+          select
+            'before rebuild' as phase,
+            rel.relname,
+            rel.relacl,
+            aclcontains(
+              rel.relacl,
+              makeaclitem(reader_role.oid, rel.relowner, 'SELECT', false)
+            ) as custom_direct,
+            aclcontains(
+              rel.relacl,
+              makeaclitem(pg_monitor.oid, rel.relowner, 'SELECT', false)
+            ) as pg_monitor_direct,
+            coalesce(
+              aclcontains(
+                rel.relacl,
+                makeaclitem(member_role.oid, rel.relowner, 'SELECT', false)
+              ),
+              false
+            ) as member_direct
+          from pg_class as rel
+          join pg_namespace as nsp on nsp.oid = rel.relnamespace
+          cross join pg_roles as reader_role
+          cross join pg_roles as pg_monitor
+          cross join pg_roles as member_role
+          where nsp.nspname = 'ash'
+            and rel.relname in ('query_map_all', 'query_map_0', 'sample_0')
+            and reader_role.rolname = 'ash_b4_reader'
+            and pg_monitor.rolname = 'pg_monitor'
+            and member_role.rolname = 'ash_b4_pgmon_member'
+          order by rel.relname;
+
+          do $$
+          declare
+            v_direct_acl_count int;
+            v_member_acl_count int;
+          begin
+            select count(*) into v_direct_acl_count
+            from pg_class as rel
+            join pg_namespace as nsp on nsp.oid = rel.relnamespace
+            cross join pg_roles as grantee_role
+            where nsp.nspname = 'ash'
+              and rel.relname in ('query_map_all', 'query_map_0', 'sample_0')
+              and grantee_role.rolname in ('ash_b4_reader', 'pg_monitor')
+              and coalesce(
+                aclcontains(
+                  rel.relacl,
+                  makeaclitem(
+                    grantee_role.oid,
+                    rel.relowner,
+                    'SELECT',
+                    false
+                  )
+                ),
+                false
+              );
+            assert v_direct_acl_count = 6,
+              format(
+                '#164: expected 6 direct reader ACLs before rebuild, got %s',
+                v_direct_acl_count
+              );
+
+            select count(*) into v_member_acl_count
+            from pg_class as rel
+            join pg_namespace as nsp on nsp.oid = rel.relnamespace
+            cross join pg_roles as member_role
+            where nsp.nspname = 'ash'
+              and rel.relname in ('query_map_all', 'query_map_0', 'sample_0')
+              and member_role.rolname = 'ash_b4_pgmon_member'
+              and coalesce(
+                aclcontains(
+                  rel.relacl,
+                  makeaclitem(
+                    member_role.oid,
+                    rel.relowner,
+                    'SELECT',
+                    false
+                  )
+                ),
+                false
+              );
+            assert v_member_acl_count = 0,
+              format(
+                '#164: pg_monitor member must have 0 direct ACLs, got %s',
+                v_member_acl_count
+              );
+          end $$;
+
+          set role ash_b4_reader;
+          do $$
+          declare
+            v_keys text[];
+          begin
+            select coalesce(array_agg(key order by key), '{}'::text[])
+              into v_keys
+            from ash.top(
+              'query_id',
+              now() - interval '10 minutes',
+              now() + interval '1 minute'
+            );
+            assert v_keys = array['164000000001'],
+              format(
+                '#164: custom reader pre-rebuild keys expected {164000000001}, got %s',
+                v_keys
+              );
+          end $$;
+          reset role;
+
+          set role ash_b4_pgmon_member;
+          do $$
+          declare
+            v_keys text[];
+          begin
+            select coalesce(array_agg(key order by key), '{}'::text[])
+              into v_keys
+            from ash.top(
+              'query_id',
+              now() - interval '10 minutes',
+              now() + interval '1 minute'
+            );
+            assert v_keys = array['164000000001'],
+              format(
+                '#164: pg_monitor member pre-rebuild keys expected {164000000001}, got %s',
+                v_keys
+              );
+          end $$;
+          reset role;
+
+          select ash.rebuild_partitions(6, 'yes');
+
+          -- The broken implementation passes this empty-storage smoke test.
+          -- The permission failure is delayed until a query-map-backed sample
+          -- makes the reader traverse the recreated query_map_all view.
+          set role ash_b4_reader;
+          do $$
+          declare
+            v_keys text[];
+          begin
+            select coalesce(array_agg(key order by key), '{}'::text[])
+              into v_keys
+            from ash.top(
+              'query_id',
+              now() - interval '10 minutes',
+              now() + interval '1 minute'
+            );
+            assert v_keys = '{}'::text[],
+              format(
+                '#164: immediate custom-reader keys expected {}, got %s',
+                v_keys
+              );
+          end $$;
+          reset role;
+
+          set role ash_b4_pgmon_member;
+          do $$
+          declare
+            v_keys text[];
+          begin
+            select coalesce(array_agg(key order by key), '{}'::text[])
+              into v_keys
+            from ash.top(
+              'query_id',
+              now() - interval '10 minutes',
+              now() + interval '1 minute'
+            );
+            assert v_keys = '{}'::text[],
+              format(
+                '#164: immediate pg_monitor-member keys expected {}, got %s',
+                v_keys
+              );
+          end $$;
+          reset role;
+
+          do $$
+          declare
+            v_wait_id smallint;
+            v_map_id int4;
+            v_datid oid;
+          begin
+            select ash._register_wait('active', 'B4Test', 'B4Wait')
+              into v_wait_id;
+            insert into ash.query_map_0 (query_id)
+            values (164000000002)
+            returning id into v_map_id;
+            select oid into v_datid
+            from pg_database
+            where datname = current_database();
+            insert into ash.sample (
+              sample_ts,
+              datid,
+              active_count,
+              data,
+              slot
+            )
+            values (
+              ash.ts_from_timestamptz(
+                date_trunc('minute', now()) - interval '2 minutes'
+              ),
+              v_datid,
+              1,
+              array[-v_wait_id, 1, v_map_id]::integer[],
+              0
+            );
+          end $$;
+
+          select
+            'after rebuild' as phase,
+            rel.relname,
+            rel.relacl,
+            coalesce(
+              aclcontains(
+                rel.relacl,
+                makeaclitem(reader_role.oid, rel.relowner, 'SELECT', false)
+              ),
+              false
+            ) as custom_direct,
+            coalesce(
+              aclcontains(
+                rel.relacl,
+                makeaclitem(pg_monitor.oid, rel.relowner, 'SELECT', false)
+              ),
+              false
+            ) as pg_monitor_direct,
+            coalesce(
+              aclcontains(
+                rel.relacl,
+                makeaclitem(member_role.oid, rel.relowner, 'SELECT', false)
+              ),
+              false
+            ) as member_direct
+          from pg_class as rel
+          join pg_namespace as nsp on nsp.oid = rel.relnamespace
+          cross join pg_roles as reader_role
+          cross join pg_roles as pg_monitor
+          cross join pg_roles as member_role
+          where nsp.nspname = 'ash'
+            and rel.relname in ('query_map_all', 'query_map_0', 'sample_0')
+            and reader_role.rolname = 'ash_b4_reader'
+            and pg_monitor.rolname = 'pg_monitor'
+            and member_role.rolname = 'ash_b4_pgmon_member'
+          order by rel.relname;
+
+          create temp table b4_probe_results (
+            role_name name primary key,
+            keys text[],
+            error_message text
+          );
+          grant insert on b4_probe_results
+            to ash_b4_reader, ash_b4_pgmon_member;
+
+          set role ash_b4_reader;
+          do $$
+          declare
+            v_keys text[];
+          begin
+            begin
+              select coalesce(array_agg(key order by key), '{}'::text[])
+                into v_keys
+              from ash.top(
+                'query_id',
+                now() - interval '10 minutes',
+                now() + interval '1 minute'
+              );
+              insert into b4_probe_results (role_name, keys, error_message)
+              values (current_user, v_keys, null);
+            exception when insufficient_privilege then
+              insert into b4_probe_results (role_name, keys, error_message)
+              values (current_user, null, sqlerrm);
+            end;
+          end $$;
+          reset role;
+
+          set role ash_b4_pgmon_member;
+          do $$
+          declare
+            v_keys text[];
+          begin
+            begin
+              select coalesce(array_agg(key order by key), '{}'::text[])
+                into v_keys
+              from ash.top(
+                'query_id',
+                now() - interval '10 minutes',
+                now() + interval '1 minute'
+              );
+              insert into b4_probe_results (role_name, keys, error_message)
+              values (current_user, v_keys, null);
+            exception when insufficient_privilege then
+              insert into b4_probe_results (role_name, keys, error_message)
+              values (current_user, null, sqlerrm);
+            end;
+          end $$;
+          reset role;
+
+          table b4_probe_results;
+
+          do $$
+          declare
+            v_acl_count int;
+            v_error_count int;
+            v_errors text;
+            v_exact_key_count int;
+          begin
+            select count(*) into v_acl_count
+            from pg_class as rel
+            join pg_namespace as nsp on nsp.oid = rel.relnamespace
+            cross join pg_roles as grantee_role
+            where nsp.nspname = 'ash'
+              and rel.relname in ('query_map_all', 'query_map_0', 'sample_0')
+              and grantee_role.rolname in ('ash_b4_reader', 'pg_monitor')
+              and coalesce(
+                aclcontains(
+                  rel.relacl,
+                  makeaclitem(
+                    grantee_role.oid,
+                    rel.relowner,
+                    'SELECT',
+                    false
+                  )
+                ),
+                false
+              );
+            assert v_acl_count = 6,
+              format(
+                '#164: expected 6 direct reader ACLs after rebuild, got %s',
+                v_acl_count
+              );
+
+            select
+              count(*) filter (where error_message is not null),
+              string_agg(
+                format('%s -> %s', role_name, error_message),
+                '; '
+                order by role_name
+              ),
+              count(*) filter (
+                where keys = array['164000000002']
+                  and error_message is null
+              )
+            into v_error_count, v_errors, v_exact_key_count
+            from b4_probe_results;
+            assert v_error_count = 0,
+              format('#164: post-rebuild reader errors: %s', v_errors);
+            assert v_exact_key_count = 2,
+              format(
+                '#164: expected exact keys for 2 readers after rebuild, got %s',
+                v_exact_key_count
+              );
+          end $$;
+
+          drop table b4_probe_results;
+          select ash.rebuild_partitions(3, 'yes');
+          update ash.config set sampling_enabled = true where singleton;
+          delete from ash.wait_event_map
+          where state = 'active'
+            and type = 'B4Test'
+            and event = 'B4Wait';
+          select ash.revoke_reader('ash_b4_reader');
+          revoke pg_monitor from ash_b4_pgmon_member;
+          drop role ash_b4_reader;
+          drop role ash_b4_pgmon_member;
+          EOF
+
       - name: "Test 2.0: grant_reader NOTICEs missing pg_read_all_stats; query_text needs it (final re-test papercut)"
         env:
           PGPASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -971,10 +971,48 @@ jobs:
             ) then
               create role ash_b4_pgmon_member login password 'x';
             end if;
+            if not exists (
+              select from pg_roles where rolname = 'ash_b4_function_only'
+            ) then
+              create role ash_b4_function_only nologin;
+            end if;
           end $$;
 
           grant pg_monitor to ash_b4_pgmon_member;
           select ash.grant_reader('ash_b4_reader');
+
+          /*
+           * A manual function-only grant is not a complete reader bundle.
+           * Rebuild must not promote it to schema/table access.
+           */
+          do $$
+          declare
+            v_rec record;
+            v_admin_funcs constant text[] := ash._admin_funcs();
+          begin
+            for v_rec in
+              select proc.proname,
+                     pg_get_function_identity_arguments(proc.oid) as args
+              from pg_proc as proc
+              join pg_namespace as nsp on nsp.oid = proc.pronamespace
+              where nsp.nspname = 'ash'
+                and proc.prokind = 'f'
+                and proc.proname::text <> all (v_admin_funcs)
+            loop
+              execute format(
+                'grant execute on function ash.%I(%s) to ash_b4_function_only',
+                v_rec.proname,
+                v_rec.args
+              );
+            end loop;
+
+            assert not has_schema_privilege(
+              'ash_b4_function_only', 'ash', 'USAGE'
+            ), '#164: function-only precondition unexpectedly has schema USAGE';
+            assert not has_table_privilege(
+              'ash_b4_function_only', 'ash.query_map_all', 'SELECT'
+            ), '#164: function-only precondition unexpectedly has table SELECT';
+          end $$;
 
           -- Seed one exact query-map-backed row before the rebuild. This proves
           -- both a configured reader and a plain pg_monitor member can traverse
@@ -1146,6 +1184,16 @@ jobs:
           reset role;
 
           select ash.rebuild_partitions(6, 'yes');
+
+          do $$
+          begin
+            assert not has_schema_privilege(
+              'ash_b4_function_only', 'ash', 'USAGE'
+            ), '#164: rebuild widened function-only role to schema USAGE';
+            assert not has_table_privilege(
+              'ash_b4_function_only', 'ash.query_map_all', 'SELECT'
+            ), '#164: rebuild widened function-only role to table SELECT';
+          end $$;
 
           -- The broken implementation passes this empty-storage smoke test.
           -- The permission failure is delayed until a query-map-backed sample
@@ -1376,8 +1424,10 @@ jobs:
             and event = 'B4Wait';
           select ash.revoke_reader('ash_b4_reader');
           revoke pg_monitor from ash_b4_pgmon_member;
+          drop owned by ash_b4_function_only;
           drop role ash_b4_reader;
           drop role ash_b4_pgmon_member;
+          drop role ash_b4_function_only;
           EOF
 
       - name: "Issue #166: revoke_reader refuses protected roles"
@@ -1388,7 +1438,7 @@ jobs:
             psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
               -c "drop database if exists ash_b6_owner_test with (force);"
             psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
-              -c "drop role if exists ash_b6_reader, ash_b6_current, ash_b6_owner;"
+              -c "drop role if exists ash_b6_delegated, ash_b6_reader, ash_b6_current, ash_b6_owner;"
           }
           trap cleanup_b6 EXIT
           cleanup_b6
@@ -1398,7 +1448,9 @@ jobs:
             login password 'b6'
             nosuperuser nocreatedb nocreaterole;
           create role ash_b6_reader nologin;
+          create role ash_b6_delegated nologin;
           create role ash_b6_current nologin;
+          grant ash_b6_reader to ash_b6_owner;
           grant ash_b6_current to ash_b6_owner;
           create database ash_b6_owner_test
             owner ash_b6_owner
@@ -1557,7 +1609,13 @@ jobs:
            * legacy bundle grant rather than merely stop issuing new ones.
            */
           grant execute on function ash._admin_funcs()
-            to ash_b6_reader, pg_monitor;
+            to ash_b6_reader with grant option;
+          grant execute on function ash._admin_funcs()
+            to pg_monitor;
+          set role ash_b6_reader;
+          grant execute on function ash._admin_funcs()
+            to ash_b6_delegated;
+          reset role;
           do $$
           begin
             assert has_function_privilege(
@@ -1572,6 +1630,12 @@ jobs:
               'EXECUTE'
             ) = true,
               '#166: legacy pg_monitor precondition must hold _admin_funcs EXECUTE';
+            assert has_function_privilege(
+              'ash_b6_delegated',
+              'ash._admin_funcs()',
+              'EXECUTE'
+            ) = true,
+              '#166: delegated legacy precondition must hold _admin_funcs EXECUTE';
           end $$;
           \i :install_path
           do $$
@@ -1588,6 +1652,12 @@ jobs:
               'EXECUTE'
             ) = false,
               '#166: re-apply must scrub legacy pg_monitor _admin_funcs EXECUTE';
+            assert has_function_privilege(
+              'ash_b6_delegated',
+              'ash._admin_funcs()',
+              'EXECUTE'
+            ) = false,
+              '#166: re-apply must cascade legacy delegated _admin_funcs EXECUTE';
             raise notice '#166 legacy reader ACL scrub PASSED';
           end $$;
           select ash.revoke_reader('ash_b6_reader');

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1380,6 +1380,337 @@ jobs:
           drop role ash_b4_pgmon_member;
           EOF
 
+      - name: "Issue #166: revoke_reader refuses protected roles"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          cleanup_b6() {
+            psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
+              -c "drop database if exists ash_b6_owner_test with (force);"
+            psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
+              -c "drop role if exists ash_b6_reader, ash_b6_current, ash_b6_owner;"
+          }
+          trap cleanup_b6 EXIT
+          cleanup_b6
+
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          create role ash_b6_owner
+            login password 'b6'
+            nosuperuser nocreatedb nocreaterole;
+          create role ash_b6_reader nologin;
+          create role ash_b6_current nologin;
+          grant ash_b6_current to ash_b6_owner;
+          create database ash_b6_owner_test
+            owner ash_b6_owner
+            template template0;
+          EOF
+
+          PGPASSWORD=b6 psql \
+            -h localhost \
+            -U ash_b6_owner \
+            -d ash_b6_owner_test \
+            -v ON_ERROR_STOP=1 \
+            -f "$(python3 devel/scripts/ash_sql_chain.py fresh-install-path)"
+
+          PGPASSWORD=b6 psql \
+            -h localhost \
+            -U ash_b6_owner \
+            -d ash_b6_owner_test \
+            -v ON_ERROR_STOP=1 \
+            -v install_path="$(
+              python3 devel/scripts/ash_sql_chain.py fresh-install-path
+            )" << 'EOF'
+          select
+            current_user,
+            owner_role.rolsuper,
+            nsp.nspowner::regrole as ash_owner,
+            has_schema_privilege(current_user, 'ash', 'USAGE') as ash_usage,
+            has_function_privilege(
+              current_user,
+              'ash._admin_funcs()',
+              'EXECUTE'
+            ) as admin_funcs_execute
+          from pg_roles as owner_role
+          join pg_namespace as nsp on nsp.nspname = 'ash'
+          where owner_role.rolname = current_user;
+
+          /*
+           * On broken code the revoke returns successfully. Capture the exact
+           * two-stage failure: schema USAGE blocks every documented entry
+           * point, then restoring USAGE alone exposes the stripped
+           * _admin_funcs() EXECUTE privilege underneath.
+           */
+          do $$
+          declare
+            v_expected_message constant text :=
+              'ash.revoke_reader: refusing protected role ash_b6_owner '
+              '(schema owner, current user, or superuser)';
+            v_grant_after_usage_message text;
+            v_grant_message text;
+            v_refused boolean := false;
+            v_refusal_message text;
+            v_status_message text;
+            v_take_sample_message text;
+          begin
+            begin
+              perform ash.revoke_reader(current_user::name);
+            exception when others then
+              v_refused := true;
+              v_refusal_message := sqlerrm;
+            end;
+
+            if not v_refused then
+              begin
+                perform ash.take_sample();
+              exception when insufficient_privilege then
+                v_take_sample_message := sqlerrm;
+              end;
+
+              begin
+                perform * from ash.status();
+              exception when insufficient_privilege then
+                v_status_message := sqlerrm;
+              end;
+
+              begin
+                perform ash.grant_reader(current_user::name);
+              exception when insufficient_privilege then
+                v_grant_message := sqlerrm;
+              end;
+
+              execute format(
+                'grant usage on schema ash to %I',
+                current_user
+              );
+              begin
+                perform ash.grant_reader(current_user::name);
+              exception when insufficient_privilege then
+                v_grant_after_usage_message := sqlerrm;
+              end;
+
+              raise notice
+                '#166 RED: take_sample=[%], status=[%], grant_reader=[%], '
+                'USAGE + grant_reader=[%]',
+                v_take_sample_message,
+                v_status_message,
+                v_grant_message,
+                v_grant_after_usage_message;
+            end if;
+
+            assert v_refused,
+              format(
+                '#166: revoke_reader returned successfully; '
+                'take_sample=[%s], status=[%s], grant_reader=[%s], '
+                'USAGE + grant_reader=[%s]',
+                v_take_sample_message,
+                v_status_message,
+                v_grant_message,
+                v_grant_after_usage_message
+              );
+            assert v_refusal_message = v_expected_message,
+              format(
+                '#166: refusal expected [%s], got [%s]',
+                v_expected_message,
+                v_refusal_message
+              );
+            assert has_schema_privilege(current_user, 'ash', 'USAGE') = true,
+              '#166: refused call must preserve owner schema USAGE';
+            assert has_function_privilege(
+              current_user,
+              'ash._admin_funcs()',
+              'EXECUTE'
+            ) = true,
+              '#166: refused call must preserve owner _admin_funcs EXECUTE';
+            assert has_function_privilege(
+              current_user,
+              'ash.grant_reader(name)',
+              'EXECUTE'
+            ) = true,
+              '#166: refused call must preserve owner grant_reader EXECUTE';
+            assert '_admin_funcs' = any(ash._admin_funcs()),
+              '#166: _admin_funcs must be in its own admin exclusion set';
+            assert ash.take_sample() = 0,
+              '#166: take_sample should return exactly 0 in the isolated DB';
+            perform * from ash.status();
+            raise notice '#166 non-superuser owner refusal PASSED: %',
+              v_refusal_message;
+          end $$;
+
+          -- _admin_funcs is an administrative implementation detail. A normal
+          -- reader neither needs nor receives EXECUTE on it, and revoking that
+          -- reader remains an allowed operation.
+          select ash.grant_reader('ash_b6_reader');
+          do $$
+          begin
+            assert has_function_privilege(
+              'ash_b6_reader',
+              'ash._admin_funcs()',
+              'EXECUTE'
+            ) = false,
+              '#166: grant_reader must not grant _admin_funcs EXECUTE';
+          end $$;
+
+          /*
+           * Simulate a reader bundle created by the previous installer, when
+           * _admin_funcs still belonged to the reader set. CREATE OR REPLACE
+           * preserves function ACLs, so re-apply must explicitly scrub this
+           * legacy bundle grant rather than merely stop issuing new ones.
+           */
+          grant execute on function ash._admin_funcs()
+            to ash_b6_reader, pg_monitor;
+          do $$
+          begin
+            assert has_function_privilege(
+              'ash_b6_reader',
+              'ash._admin_funcs()',
+              'EXECUTE'
+            ) = true,
+              '#166: legacy reader precondition must hold _admin_funcs EXECUTE';
+            assert has_function_privilege(
+              'pg_monitor',
+              'ash._admin_funcs()',
+              'EXECUTE'
+            ) = true,
+              '#166: legacy pg_monitor precondition must hold _admin_funcs EXECUTE';
+          end $$;
+          \i :install_path
+          do $$
+          begin
+            assert has_function_privilege(
+              'ash_b6_reader',
+              'ash._admin_funcs()',
+              'EXECUTE'
+            ) = false,
+              '#166: installer re-apply must scrub legacy _admin_funcs EXECUTE';
+            assert has_function_privilege(
+              'pg_monitor',
+              'ash._admin_funcs()',
+              'EXECUTE'
+            ) = false,
+              '#166: re-apply must scrub legacy pg_monitor _admin_funcs EXECUTE';
+            raise notice '#166 legacy reader ACL scrub PASSED';
+          end $$;
+          select ash.revoke_reader('ash_b6_reader');
+
+          -- Exercise current_user independently: this target is neither the
+          -- schema owner nor a superuser. The temporary grants only make the
+          -- owner-only helper callable far enough to reach its early guard.
+          grant usage on schema ash to ash_b6_current;
+          grant execute on function ash._admin_funcs() to ash_b6_current;
+          grant execute on function ash.revoke_reader(name) to ash_b6_current;
+          set role ash_b6_current;
+          do $$
+          declare
+            v_expected_message constant text :=
+              'ash.revoke_reader: refusing protected role ash_b6_current '
+              '(schema owner, current user, or superuser)';
+            v_message text;
+          begin
+            assert current_user = 'ash_b6_current',
+              format('#166: current_user precondition got %s', current_user);
+            assert (
+              select rolsuper from pg_roles where rolname = current_user
+            ) = false,
+              '#166: current_user branch requires a non-superuser';
+            assert (
+              select nspowner::regrole::text
+              from pg_namespace
+              where nspname = 'ash'
+            ) <> current_user,
+              '#166: current_user branch must not be the schema-owner branch';
+
+            begin
+              perform ash.revoke_reader(current_user::name);
+            exception when others then
+              v_message := sqlerrm;
+            end;
+            assert v_message = v_expected_message,
+              format(
+                '#166: current_user refusal expected [%s], got [%s]',
+                v_expected_message,
+                v_message
+              );
+          end $$;
+          reset role;
+
+          -- Exercise the superuser target independently from current_user and
+          -- schema ownership.
+          do $$
+          declare
+            v_expected_message constant text :=
+              'ash.revoke_reader: refusing protected role postgres '
+              '(schema owner, current user, or superuser)';
+            v_message text;
+          begin
+            assert current_user = 'ash_b6_owner',
+              format('#166: owner session precondition got %s', current_user);
+            assert (
+              select rolsuper from pg_roles where rolname = 'postgres'
+            ) = true,
+              '#166: postgres must be a superuser for this branch';
+            assert (
+              select nspowner::regrole::text
+              from pg_namespace
+              where nspname = 'ash'
+            ) <> 'postgres',
+              '#166: superuser target must not be the schema-owner branch';
+
+            begin
+              perform ash.revoke_reader('postgres');
+            exception when others then
+              v_message := sqlerrm;
+            end;
+            assert v_message = v_expected_message,
+              format(
+                '#166: superuser refusal expected [%s], got [%s]',
+                v_expected_message,
+                v_message
+              );
+          end $$;
+          EOF
+
+          # Exercise schema ownership independently: postgres is the invoker,
+          # while the protected non-superuser target owns schema ash.
+          psql \
+            -h localhost \
+            -U postgres \
+            -d ash_b6_owner_test \
+            -v ON_ERROR_STOP=1 << 'EOF'
+          do $$
+          declare
+            v_expected_message constant text :=
+              'ash.revoke_reader: refusing protected role ash_b6_owner '
+              '(schema owner, current user, or superuser)';
+            v_message text;
+          begin
+            assert current_user = 'postgres',
+              format('#166: superuser invoker precondition got %s', current_user);
+            assert (
+              select rolsuper from pg_roles where rolname = 'ash_b6_owner'
+            ) = false,
+              '#166: schema-owner target must be a non-superuser';
+            assert (
+              select nspowner::regrole::text
+              from pg_namespace
+              where nspname = 'ash'
+            ) = 'ash_b6_owner',
+              '#166: ash_b6_owner must own schema ash';
+
+            begin
+              perform ash.revoke_reader('ash_b6_owner');
+            exception when others then
+              v_message := sqlerrm;
+            end;
+            assert v_message = v_expected_message,
+              format(
+                '#166: schema-owner refusal expected [%s], got [%s]',
+                v_expected_message,
+                v_message
+              );
+            raise notice '#166 protected-target guards PASSED';
+          end $$;
+          EOF
+
       - name: "Test 2.0: grant_reader NOTICEs missing pg_read_all_stats; query_text needs it (final re-test papercut)"
         env:
           PGPASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1711,6 +1711,279 @@ jobs:
           end $$;
           EOF
 
+      - name: "Issue #169: take_sample writes its captured query-map slot"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          n2_probe_pid=
+          cleanup_n2() {
+            psql \
+              -h localhost \
+              -U postgres \
+              -d postgres \
+              -AtX \
+              -c "
+                select pg_terminate_backend(pid)
+                from pg_stat_activity
+                where application_name = 'ash_n2_slot_probe'
+                  and pid <> pg_backend_pid();
+              " >/dev/null 2>&1 || true
+            if [ -n "$n2_probe_pid" ]; then
+              kill "$n2_probe_pid" 2>/dev/null || true
+              wait "$n2_probe_pid" 2>/dev/null || true
+            fi
+          }
+          trap cleanup_n2 EXIT
+          cleanup_n2
+
+          # One tagged active backend gives take_sample() an exact one-row,
+          # one-query fixture. compute_query_id=on makes the query-map
+          # attribution invariant independent of the cluster default.
+          PGAPPNAME=ash_n2_slot_probe \
+          PGOPTIONS="-c compute_query_id=on" \
+            psql \
+              -h localhost \
+              -U postgres \
+              -d postgres \
+              -v ON_ERROR_STOP=1 \
+              -c "select pg_sleep(60);" >/dev/null 2>&1 &
+          n2_probe_pid=$!
+
+          n2_probe_count=0
+          for _ in {1..50}; do
+            n2_probe_count=$(
+              psql \
+                -h localhost \
+                -U postgres \
+                -d postgres \
+                -AtX \
+                -v ON_ERROR_STOP=1 \
+                -c "
+                  select count(*)
+                  from pg_stat_activity
+                  where application_name = 'ash_n2_slot_probe'
+                    and datid = (
+                      select oid
+                      from pg_database
+                      where datname = current_database()
+                    )
+                    and state = 'active'
+                    and query_id is not null;
+                "
+            )
+            if [ "$n2_probe_count" = "1" ]; then
+              break
+            fi
+            sleep 0.2
+          done
+          echo "tagged_probe_ready=$([ "$n2_probe_count" = "1" ] && echo 1 || echo 0) count=$n2_probe_count"
+          test "$n2_probe_count" = "1"
+
+          psql \
+            -h localhost \
+            -U postgres \
+            -d postgres \
+            -v ON_ERROR_STOP=1 << 'EOF'
+          \pset pager off
+          begin;
+          truncate ash.sample, ash.query_map_0, ash.query_map_1, ash.query_map_2
+            restart identity;
+          update ash.config
+          set current_slot = 0,
+            sampling_enabled = true,
+            include_bg_workers = false,
+            insert_errors = 0
+          where singleton;
+
+          /*
+           * Deterministically emulate rotation between the sampler's early
+           * slot read and its INSERT: call 1 resolves dictionary slot 0; any
+           * later DEFAULT evaluation returns slot 1. All DDL/data rolls back.
+           */
+          create temp sequence n2_slot_calls start 1;
+          create or replace function ash.current_slot()
+          returns smallint
+          language sql
+          volatile
+          set search_path = pg_catalog
+          as $$
+            select case nextval('pg_temp.n2_slot_calls')
+              when 1 then 0::smallint
+              else 1::smallint
+            end
+          $$;
+
+          do $$
+          declare
+            v_active_count smallint;
+            v_current_slot_calls bigint;
+            v_data_len int;
+            v_expected_query_id bigint;
+            v_insert_errors bigint;
+            v_map_id int4;
+            v_resolved_query_id bigint;
+            v_sample_count int;
+            v_sample_slot smallint;
+            v_stamped_query_id bigint;
+            v_tagged_backends int;
+            v_take_result int;
+          begin
+            select count(*), min(query_id)
+              into v_tagged_backends, v_expected_query_id
+            from pg_stat_activity
+            where application_name = 'ash_n2_slot_probe'
+              and datid = (
+                select oid
+                from pg_database
+                where datname = current_database()
+              )
+              and state = 'active';
+            assert v_tagged_backends = 1,
+              format(
+                '#169: expected exactly 1 tagged backend, got %s',
+                v_tagged_backends
+              );
+            assert v_expected_query_id is not null,
+              '#169: tagged backend query_id must not be null';
+
+            select ash.take_sample() into v_take_result;
+            select
+              count(*),
+              min(slot),
+              min(active_count),
+              min(array_length(data, 1)),
+              min(data[3])
+            into
+              v_sample_count,
+              v_sample_slot,
+              v_active_count,
+              v_data_len,
+              v_map_id
+            from ash.sample
+            where datid = (
+              select oid
+              from pg_database
+              where datname = current_database()
+            );
+            select query_id into v_resolved_query_id
+            from ash.query_map_0
+            where id = v_map_id;
+            select query_id into v_stamped_query_id
+            from ash.query_map_all
+            where slot = v_sample_slot
+              and id = v_map_id;
+            select last_value into v_current_slot_calls
+            from pg_temp.n2_slot_calls;
+            select insert_errors into v_insert_errors
+            from ash.config
+            where singleton;
+
+            raise notice
+              '#169 probe: take_result=%, backends=%, samples=%, slot=%, '
+              'active_count=%, data_len=%, expected_query_id=%, '
+              'resolved_query_id=%, stamped_query_id=%, '
+              'current_slot_calls=%, insert_errors=%',
+              v_take_result,
+              v_tagged_backends,
+              v_sample_count,
+              v_sample_slot,
+              v_active_count,
+              v_data_len,
+              v_expected_query_id,
+              v_resolved_query_id,
+              v_stamped_query_id,
+              v_current_slot_calls,
+              v_insert_errors;
+
+            assert v_take_result = 1,
+              format('#169: take_sample expected 1, got %s', v_take_result);
+            assert v_sample_count = 1,
+              format('#169: sample count expected 1, got %s', v_sample_count);
+            assert v_active_count = 1,
+              format('#169: active_count expected 1, got %s', v_active_count);
+            assert v_data_len = 3,
+              format('#169: encoded data length expected 3, got %s', v_data_len);
+            assert v_sample_slot = 0,
+              format(
+                '#169: sample slot must equal resolved dictionary slot 0, got %s',
+                v_sample_slot
+              );
+            assert v_resolved_query_id = v_expected_query_id,
+              format(
+                '#169: slot-0 map expected query_id %s, got %s',
+                v_expected_query_id,
+                v_resolved_query_id
+              );
+            assert v_stamped_query_id = v_expected_query_id,
+              format(
+                '#169: stamped slot expected query_id %s, got %s',
+                v_expected_query_id,
+                v_stamped_query_id
+              );
+            assert v_current_slot_calls = 1,
+              format(
+                '#169: current_slot must be read exactly once, got %s calls',
+                v_current_slot_calls
+              );
+            assert v_insert_errors = 0,
+              format(
+                '#169: silent mismatch must leave insert_errors 0, got %s',
+                v_insert_errors
+              );
+          end $$;
+
+          -- Deterministically rule out a second ash.sample INSERT path with
+          -- the same shape. This complements the behavioral forced-rotation
+          -- probe rather than substituting a catalog-only smoke test for it.
+          do $$
+          declare
+            v_definition text;
+            v_explicit_slot boolean;
+            v_insert_paths int;
+            v_omitted_slot boolean;
+          begin
+            v_definition := regexp_replace(
+              lower(
+                pg_get_functiondef('ash.take_sample()'::regprocedure)
+              ),
+              '\s+',
+              ' ',
+              'g'
+            );
+            select count(*) into v_insert_paths
+            from regexp_matches(
+              v_definition,
+              'insert into ash[.]sample [(]',
+              'g'
+            );
+            v_explicit_slot := v_definition ~
+              'insert into ash[.]sample *[(] *sample_ts *, *datid *, *'
+              'active_count *, *data *, *slot *[)] *values *[(] *'
+              'v_sample_ts *, *v_datid_rec[.]datid *, *v_active_count *, *'
+              'v_data *, *v_current_slot *[)]';
+            v_omitted_slot := v_definition ~
+              'insert into ash[.]sample *[(] *sample_ts *, *datid *, *'
+              'active_count *, *data *[)] *values *[(] *v_sample_ts *, *'
+              'v_datid_rec[.]datid *, *v_active_count *, *v_data *[)]';
+
+            raise notice
+              '#169 structural: paths=%, explicit_slot=%, omitted_slot=%',
+              v_insert_paths,
+              v_explicit_slot,
+              v_omitted_slot;
+            assert v_insert_paths = 1,
+              format(
+                '#169: expected exactly 1 ash.sample INSERT path, got %s',
+                v_insert_paths
+              );
+            assert v_explicit_slot = true,
+              '#169: ash.sample INSERT must write v_current_slot explicitly';
+            assert v_omitted_slot = false,
+              '#169: ash.sample INSERT must not use the slot DEFAULT';
+          end $$;
+          rollback;
+          EOF
+
       - name: "Test 2.0: grant_reader NOTICEs missing pg_read_all_stats; query_text needs it (final re-test papercut)"
         env:
           PGPASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7385,9 +7385,10 @@ jobs:
           end $$;
 
           -- ACL equivalence sweep: every function name the reader could
-          -- execute before the upgrade and that still exists must remain
-          -- executable on every current overload. Nothing is enumerated, so
-          -- any future drop/recreate that loses reader grants fails here.
+          -- execute before the upgrade, that still exists, and that remains
+          -- in the current dynamic reader bundle must stay executable on
+          -- every current overload. Helpers promoted into _admin_funcs()
+          -- must instead lose their legacy reader grant.
           do $$
           declare
             v_lost text;
@@ -7399,6 +7400,7 @@ jobs:
             join pg_namespace n on n.oid = p.pronamespace
             where n.nspname = 'ash'
               and p.prokind = 'f'
+              and p.proname::text <> all (ash._admin_funcs())
               and not has_function_privilege('ash_b1_reader', p.oid, 'EXECUTE');
             assert v_lost is null,
               format('reader EXECUTE grants lost across upgrade on: %s', v_lost);
@@ -7436,6 +7438,8 @@ jobs:
               '#107: ash.grant_reader must remain admin-only after upgrade';
             assert not has_function_privilege('ash_b1_reader', 'ash.revoke_reader(name)', 'EXECUTE'),
               '#107: ash.revoke_reader must remain admin-only after upgrade';
+            assert not has_function_privilege('ash_b1_reader', 'ash._admin_funcs()', 'EXECUTE'),
+              '#166: legacy ash._admin_funcs reader EXECUTE must be scrubbed during upgrade';
             assert not has_function_privilege('public', 'ash.samples(timestamptz,timestamptz,int,text,text,bigint,name)', 'EXECUTE'),
               '#107: PUBLIC must not gain EXECUTE on ash.samples';
 
@@ -7506,12 +7510,15 @@ jobs:
             join pg_namespace n on n.oid = p.pronamespace
             where n.nspname = 'ash'
               and p.prokind = 'f'
+              and p.proname::text <> all (ash._admin_funcs())
               and not has_function_privilege('ash_b1_reader', p.oid, 'EXECUTE');
             assert v_lost is null,
               format('reader EXECUTE grants lost across installer re-apply on: %s', v_lost);
 
             assert not has_function_privilege('ash_b1_reader', 'ash.take_sample()', 'EXECUTE'),
               '#107: ash.take_sample must remain admin-only after re-apply';
+            assert not has_function_privilege('ash_b1_reader', 'ash._admin_funcs()', 'EXECUTE'),
+              '#166: legacy ash._admin_funcs reader EXECUTE survived re-apply';
 
             assert (select version from ash.config where singleton)
                      = current_setting('pg_ash.expected_version'),

--- a/README.md
+++ b/README.md
@@ -378,9 +378,10 @@ select ash.rebuild_partitions(9, 'yes');
 select ash.start();
 ```
 
-`rebuild_partitions()` drops all raw samples and query-map partitions. Rollups
-survive. Re-run `ash.grant_reader()` for monitoring roles afterward because
-new partitions need fresh grants.
+`rebuild_partitions()` drops all raw samples and recreates the query-map view
+and raw sample/query-map partitions. Rollups survive. Complete
+`ash.grant_reader()` bundles are preserved automatically across the rebuild,
+including the installer-default `pg_monitor` bundle.
 
 Historical 1.x sizing estimates at 1-second sampling are shown below. Treat
 them as rough planning inputs and measure the 2.0 payload on the target

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -157,7 +157,7 @@ select ash.revoke_reader('grafana');
 
 The admin function set is centralized in `ash._admin_funcs()` — a single source of truth for the REVOKE-from-PUBLIC hardening block and the grant/revoke helpers. (issue #67; [PR #71](https://github.com/NikolayS/pg_ash/pull/71))
 
-> **Note:** After `ash.rebuild_partitions(N, 'yes')`, previously-granted reader roles lose access to the new partition tables. Re-run `ash.grant_reader(...)` for each monitoring role.
+> **Note:** `ash.rebuild_partitions(N, 'yes')` preserves complete reader bundles automatically across the recreated query-map view and partition tables, including the installer-default `pg_monitor` bundle.
 
 ### Decoded-sample convenience overloads
 

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -1023,8 +1023,10 @@ begin
       cross join backend_count;
 
       if v_data is not null and array_length(v_data, 1) >= 3 then
-        insert into ash.sample (sample_ts, datid, active_count, data)
-        values (v_sample_ts, v_datid_rec.datid, v_active_count, v_data);
+        insert into ash.sample (sample_ts, datid, active_count, data, slot)
+        values (
+          v_sample_ts, v_datid_rec.datid, v_active_count, v_data, v_current_slot
+        );
         v_rows_inserted := v_rows_inserted + 1;
       end if;
 

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -1492,6 +1492,7 @@ as $$
 declare
   v_old_n int;
   v_new_n int;
+  v_rec record;
 begin
   /*
    * Destructive: drops all raw sample partitions. Require explicit
@@ -1580,6 +1581,47 @@ begin
     end if;
   end;
 
+  /*
+   * Reuse the installer's #107 reader-bundle snapshot/replay mechanism
+   * around this second drop/recreate path. Detect only complete, explicit
+   * per-overload EXECUTE bundles: inherited privileges (including members of
+   * pg_monitor) and superuser bypass must not be widened into direct grants.
+   * Replaying pg_monitor itself restores access for all of its members.
+   */
+  drop table if exists pg_temp._ash_install_reader_roles;
+  create temp table _ash_install_reader_roles (
+    rolname name primary key
+  );
+  insert into pg_temp._ash_install_reader_roles (rolname)
+  select grantee_role.rolname
+  from pg_catalog.pg_roles as grantee_role
+  where exists (
+    select
+    from pg_catalog.pg_proc as proc
+    join pg_catalog.pg_namespace as nsp on proc.pronamespace = nsp.oid
+    cross join lateral aclexplode(proc.proacl) as acl
+    where nsp.nspname = 'ash'
+      and proc.prokind = 'f'
+      and acl.privilege_type = 'EXECUTE'
+      and acl.grantee = grantee_role.oid
+      and acl.grantee <> proc.proowner
+  )
+    and not exists (
+      select
+      from pg_catalog.pg_proc as proc
+      join pg_catalog.pg_namespace as nsp on proc.pronamespace = nsp.oid
+      where nsp.nspname = 'ash'
+        and proc.prokind = 'f'
+        and proc.proname::text <> all (ash._admin_funcs())
+        and not exists (
+          select
+          from aclexplode(proc.proacl) as acl
+          where acl.privilege_type = 'EXECUTE'
+            and acl.grantee = grantee_role.oid
+            and acl.grantee <> proc.proowner
+        )
+    );
+
   -- Step 5: drop the query_map_all view first (depends on query_map tables).
   drop view if exists ash.query_map_all;
 
@@ -1620,6 +1662,21 @@ begin
 
   -- Step 8: rebuild the query_map_all view.
   perform ash._rebuild_query_map_view();
+
+  /*
+   * Restore each complete reader bundle only after the view and every child
+   * table exist, so grant_reader() covers the entire replacement object set.
+   */
+  for v_rec in
+    select reader_role.rolname
+    from pg_temp._ash_install_reader_roles as reader_role
+    join pg_catalog.pg_roles as role_row
+      on role_row.rolname = reader_role.rolname
+    order by reader_role.rolname
+  loop
+    perform ash.grant_reader(v_rec.rolname);
+  end loop;
+  drop table pg_temp._ash_install_reader_roles;
 
   /*
    * Step 9: leave sampling DISABLED. User must explicitly call ash.start() to
@@ -5855,7 +5912,7 @@ comment on function ash.rollup_cleanup() is
 $$Admin: delete rollup rows past retention (rollup_1m_retention_days / rollup_1h_retention_days in ash.config; the daily job scheduled by ash.start()). Returns a summary of rows deleted.$$;
 
 comment on function ash.rebuild_partitions(int, text) is
-$$Admin, DESTRUCTIVE: drop and recreate the sample/query-map partitions with num_partitions slots (3-32). Readable raw retention is approximately (num_partitions - 2) * rotation_period. Requires confirm => 'yes'. DELETES ALL RAW SAMPLES (rollups are kept). Re-run ash.grant_reader() for every monitoring role afterwards — the new partitions carry no grants.$$;
+$$Admin, DESTRUCTIVE: drop and recreate the sample/query-map partitions and query_map_all view with num_partitions slots (3-32). Readable raw retention is approximately (num_partitions - 2) * rotation_period. Requires confirm => 'yes'. DELETES ALL RAW SAMPLES (rollups are kept). Complete ash.grant_reader() bundles, including the default pg_monitor bundle, are preserved across the rebuild.$$;
 
 comment on function ash.set_debug_logging(bool) is
 $$Admin: toggle debug logging for the sampler and rollup jobs (null argument reports the current setting). Returns the resulting state.$$;
@@ -6234,7 +6291,7 @@ end;
 $$;
 
 comment on function ash.grant_reader(name) is
-  'Grants the minimum privileges (USAGE on schema ash, EXECUTE on all reader functions AND the internal helpers they depend on, SELECT on reader tables incl. partitions) to a monitoring role. This is the supported way to grant reader access: reader functions are SECURITY INVOKER and call shared internal helpers (also revoked from PUBLIC), so granting EXECUTE on an individual reader function alone is not sufficient. Idempotent. Inverse: ash.revoke_reader(name). Caveat: ash.rebuild_partitions(N, ''yes'') creates new partition tables that previously-granted readers cannot access; re-run ash.grant_reader() for each monitoring role after any rebuild_partitions() call.';
+  'Grants the minimum privileges (USAGE on schema ash, EXECUTE on all reader functions AND the internal helpers they depend on, SELECT on reader tables incl. partitions) to a monitoring role. This is the supported way to grant reader access: reader functions are SECURITY INVOKER and call shared internal helpers (also revoked from PUBLIC), so granting EXECUTE on an individual reader function alone is not sufficient. Idempotent. Inverse: ash.revoke_reader(name). Complete reader bundles are preserved automatically by ash.rebuild_partitions(N, ''yes'').';
 
 create or replace function ash.revoke_reader(role name)
 returns void
@@ -6307,7 +6364,7 @@ end;
 $$;
 
 comment on function ash.revoke_reader(name) is
-  'Revokes the privileges granted by ash.grant_reader(): USAGE on schema ash, EXECUTE on all reader functions, SELECT on reader tables. Idempotent. Inverse: ash.grant_reader(name). Caveat: ash.rebuild_partitions(N, ''yes'') creates new partition tables that previously-granted readers cannot access; re-run ash.grant_reader() for each monitoring role after any rebuild_partitions() call.';
+  'Revokes the privileges granted by ash.grant_reader(): USAGE on schema ash, EXECUTE on all reader functions, SELECT on reader tables. Idempotent. Inverse: ash.grant_reader(name).';
 
 -- Lock down the helpers themselves: only the schema owner may hand out
 -- (or take back) privileges. PUBLIC must not be able to call them.

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -1586,9 +1586,11 @@ begin
   /*
    * Reuse the installer's #107 reader-bundle snapshot/replay mechanism
    * around this second drop/recreate path. Detect only complete, explicit
-   * per-overload EXECUTE bundles: inherited privileges (including members of
-   * pg_monitor) and superuser bypass must not be widened into direct grants.
-   * Replaying pg_monitor itself restores access for all of its members.
+   * bundles: schema USAGE, per-overload EXECUTE, and SELECT on every reader
+   * relation. Inherited privileges (including members of pg_monitor),
+   * function-only manual grants, and superuser bypass must not be widened
+   * into direct grants. Replaying pg_monitor itself restores access for all
+   * of its members.
    */
   drop table if exists pg_temp._ash_install_reader_roles;
   create temp table _ash_install_reader_roles (
@@ -1608,6 +1610,15 @@ begin
       and acl.grantee = grantee_role.oid
       and acl.grantee <> proc.proowner
   )
+    and exists (
+      select
+      from pg_catalog.pg_namespace as nsp
+      cross join lateral aclexplode(nsp.nspacl) as acl
+      where nsp.nspname = 'ash'
+        and acl.privilege_type = 'USAGE'
+        and acl.grantee = grantee_role.oid
+        and acl.grantee <> nsp.nspowner
+    )
     and not exists (
       select
       from pg_catalog.pg_proc as proc
@@ -1621,6 +1632,27 @@ begin
           where acl.privilege_type = 'EXECUTE'
             and acl.grantee = grantee_role.oid
             and acl.grantee <> proc.proowner
+        )
+    )
+    and not exists (
+      select
+      from pg_catalog.pg_class as rel
+      join pg_catalog.pg_namespace as nsp on rel.relnamespace = nsp.oid
+      where nsp.nspname = 'ash'
+        and (
+          rel.relname in (
+            'sample', 'query_map_all', 'config', 'wait_event_map',
+            'rollup_1m', 'rollup_1h'
+          )
+          or rel.relname ~ '^query_map_[0-9]+$'
+          or rel.relname ~ '^sample_[0-9]+$'
+        )
+        and not exists (
+          select
+          from aclexplode(rel.relacl) as acl
+          where acl.privilege_type = 'SELECT'
+            and acl.grantee = grantee_role.oid
+            and acl.grantee <> rel.relowner
         )
     );
 
@@ -6490,7 +6522,7 @@ begin
       on role_row.rolname = reader_role.rolname
   loop
     execute format(
-      'revoke execute on function ash._admin_funcs() from %I',
+      'revoke execute on function ash._admin_funcs() from %I cascade',
       v_rec.rolname
     );
     perform ash.grant_reader(v_rec.rolname);

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -6043,10 +6043,13 @@ as $$
     '_truncate_pairs', '_int4_array_cat_agg', '_int8_array_cat_agg',
     '_register_wait',
     /*
-     * the helpers themselves: granting them to a reader role would let
-     * that role hand out privileges. keep them admin-only.
+     * The privilege helpers and their canonical exclusion-list helper are
+     * administrative. Granting grant_reader/revoke_reader to a monitoring
+     * role would let it hand out privileges; keeping _admin_funcs itself in
+     * this set also prevents revoke_reader from stripping the schema owner's
+     * EXECUTE privilege on the helper both functions initialize from.
      */
-    'grant_reader', 'revoke_reader',
+    '_admin_funcs', 'grant_reader', 'revoke_reader',
     /*
      * _apply_pgss_search_path runs ALTER FUNCTION on every reader, which
      * requires owner privilege so a non-owner call would fail anyway, but
@@ -6177,9 +6180,9 @@ end $$;
  *     rollup_minute, rollup_hour, rollup_cleanup, _drop_all_partitions,
  *     _rebuild_query_map_view, _merge_wait_counts, _merge_query_counts,
  *     _truncate_pairs, _int4_array_cat_agg, _int8_array_cat_agg,
- *     _register_wait). Defining "reader" by exclusion (rather than
- *     enumeration) keeps the helpers correct as new readers and
- *     reader-internal helpers are added.
+ *     _register_wait, _admin_funcs). Defining "reader" by exclusion
+ *     (rather than enumeration) keeps the helpers correct as new readers
+ *     and reader-internal helpers are added.
  *   - SELECT on ash.sample (+ every sample_N partition), ash.query_map_all
  *     (+ every query_map_N partition), ash.config, ash.wait_event_map,
  *     ash.rollup_1m, ash.rollup_1h.
@@ -6315,6 +6318,32 @@ begin
       quote_literal(role);
   end if;
 
+  /*
+   * A non-superuser schema owner does not bypass ACL checks. Revoking its
+   * schema/function privileges bricks sampling, readers, and grant_reader()
+   * itself. Refuse every protected target before changing any ACL.
+   */
+  if exists (
+    select
+    from pg_catalog.pg_roles as target_role
+    where target_role.rolname = role
+      and (
+        target_role.rolname = current_user
+        or target_role.rolsuper
+        or exists (
+          select
+          from pg_catalog.pg_namespace as nsp
+          where nsp.nspname = 'ash'
+            and nsp.nspowner = target_role.oid
+        )
+      )
+  ) then
+    raise exception
+      'ash.revoke_reader: refusing protected role % '
+      '(schema owner, current user, or superuser)',
+      role;
+  end if;
+
   v_role := quote_ident(role);
 
   for v_rec in
@@ -6364,7 +6393,7 @@ end;
 $$;
 
 comment on function ash.revoke_reader(name) is
-  'Revokes the privileges granted by ash.grant_reader(): USAGE on schema ash, EXECUTE on all reader functions, SELECT on reader tables. Idempotent. Inverse: ash.grant_reader(name).';
+  'Revokes the privileges granted by ash.grant_reader(): USAGE on schema ash, EXECUTE on all reader functions, SELECT on reader tables. Refuses schema-owner, current-user, and superuser targets so an installation cannot revoke its own operating privileges. Idempotent. Inverse: ash.grant_reader(name).';
 
 -- Lock down the helpers themselves: only the schema owner may hand out
 -- (or take back) privileges. PUBLIC must not be able to call them.
@@ -6446,6 +6475,11 @@ begin
    * exact-signature loop above only replays pre-upgrade grants, so helpers
    * new in this version would stay denied for these roles. grant_reader()
    * excludes the admin set, so this never widens beyond reader access.
+   *
+   * _admin_funcs() moved from the reader set into the admin set in #166.
+   * CREATE OR REPLACE preserves its old ACL, so explicitly remove that one
+   * legacy bundle grant before replaying the current bundle. Partial/manual
+   * roles are untouched because they are not present in the reader snapshot.
    */
   for v_rec in
     select reader_role.rolname
@@ -6453,6 +6487,10 @@ begin
     join pg_catalog.pg_roles as role_row
       on role_row.rolname = reader_role.rolname
   loop
+    execute format(
+      'revoke execute on function ash._admin_funcs() from %I',
+      v_rec.rolname
+    );
     perform ash.grant_reader(v_rec.rolname);
   end loop;
 


### PR DESCRIPTION
Closes #164.
Closes #166.
Closes #169.

## What changed

- Preserve complete direct reader bundles, including the installer-default `pg_monitor` bundle, across `ash.rebuild_partitions()` by reusing the installer's `_ash_install_reader_roles` snapshot/replay mechanism.
- Refuse `ash.revoke_reader()` when its target owns schema `ash`, is `current_user`, or is a superuser. Keep `_admin_funcs()` out of reader grants and scrub its legacy EXECUTE grant during installer re-apply.
- Stamp each `ash.sample` row with the already captured `v_current_slot`, so packed query-map IDs and their slot cannot diverge during rotation.
- Correct README/RELEASE_NOTES guidance around partition rebuilds and reader ACL preservation.

## Regression coverage

- #164: exact direct ACL checks before/after `rebuild_partitions(6, 'yes')`; immediate empty-reader smoke test; delayed sample insertion; custom reader plus a plain `pg_monitor` member.
- #166: isolated database owned by a LOGIN/NOSUPERUSER role; exact refusal message and no privilege loss; independent owner/current-user/superuser branches; fresh reader and legacy `_admin_funcs()` ACL re-apply coverage.
- #169: forced two-value `ash.current_slot()` transition proves the sample uses the captured slot and reads it once; exact query attribution and `insert_errors = 0`; normalized function-definition assertion proves there is exactly one `ash.sample` INSERT path and that it names `slot` explicitly.

## Local validation

- PostgreSQL 17.9 fresh install, installer re-apply, and full upgrade chain
- Verbatim RED reproduction and GREEN regression runs for #164, #166, and #169
- Workflow YAML parse, targeted embedded-shell syntax, and `git diff --check`

The N2 behavioral probe deterministically forces the slot transition. Its tagged one-active-backend fixture is controlled in CI, but—as with any `pg_stat_activity` fixture—could be perturbed by an unexpected concurrent client in a shared local database; the structural assertion remains fully deterministic.

This draft was rebased onto current `origin/main` immediately before push. It still needs a fresh rebase onto `origin/main` before merge.