### PR TITLE
release: fix rollup_1h grain honesty

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6260,10 +6260,10 @@ jobs:
           -- p99_aas as a short (rollup_1m-backed) window containing the same spike.
           -- Invariants: (a) monotonic peak — widening the window never shrinks the
           -- peak; (b) seam consistency — identical peak/p99 from either source;
-          -- (c) p99_aas non-null over rollup_1h-backed windows. Also: rollup_hour()
-          -- computes minute_counts exactly, legacy NULL rows flat-fill to the hour
-          -- average (lower bound, never an invented spike), and wait-filtered reads
-          -- honestly stay hour-grain.
+          -- (c) p99_aas non-null over rollup_1h-backed windows with genuine
+          -- minute_counts. Also: rollup_hour() preserves the exact stored-total
+          -- invariant, legacy NULL rows are disclosed at hour grain, and
+          -- wait-filtered reads NULL extrema requested below that grain.
           -- ============================================================================
           do $$
           declare
@@ -6361,35 +6361,80 @@ jobs:
             where data_points > 0;
             assert n = 6, 'timeline 10-min buckets with data over rollup_1h = 6, got ' || n;
 
-            -- wait-filtered long window has no per-minute detail and honestly stays
-            -- hour-grain: peak = IO hour average (59*20+60)/3600 = 0.34, timeline p99 null
+            -- wait-filtered long window has no per-minute detail. The default
+            -- requested minute extremes are unsupported and therefore NULL.
             select * into a from ash.aas(v_h - interval '2 hours', v_h + interval '1 hour',
                                          wait_event_type => 'IO');
-            assert a.source = 'rollup_1h' and a.peak_aas = 0.34,
-              format('filtered long window stays hour-grain: peak=%s (want 0.34)', a.peak_aas);
-            select p99_aas into v_p99
+            assert a.source = 'rollup_1h'
+               and a.avg_aas = 0.11
+               and a.backend_seconds = 1240.00
+               and a.peak_aas is null
+               and a.p99_aas is null,
+              format(
+                'filtered long window source=%s avg=%s seconds=%s peak=%s p99=%s',
+                a.source, a.avg_aas, a.backend_seconds, a.peak_aas, a.p99_aas
+              );
+
+            -- An explicit hour bucket matches the retained grain, so the
+            -- hour-level peak/p99 are honest and remain available.
+            select * into a from ash.aas(
+              v_h - interval '2 hours',
+              v_h + interval '1 hour',
+              wait_event_type => 'IO',
+              bucket => interval '1 hour'
+            );
+            assert a.peak_aas = 0.34 and a.p99_aas = 0.34,
+              format(
+                'filtered hour bucket peak=%s p99=%s (want 0.34/0.34)',
+                a.peak_aas, a.p99_aas
+              );
+            select peak_aas, p99_aas into v_peak, v_p99
             from ash.timeline(v_h - interval '2 hours', v_h + interval '1 hour', '1 hour',
                               wait_event_type => 'IO')
             where data_points > 0;
-            assert v_p99 is null, 'filtered rollup_1h timeline p99 stays null, got ' || coalesce(v_p99::text, 'null');
+            assert v_peak = 0.34 and v_p99 = 0.34,
+              format(
+                'filtered hourly timeline peak=%s p99=%s (want 0.34/0.34)',
+                v_peak, v_p99
+              );
 
-            -- legacy pre-2.0 row (minute_counts null): flat-fills to its hour average
-            -- (AAS 1.00/min) — peak keeps the real spike, p99 non-null, no fake spike
+            -- A legacy pre-2.0 row makes the mixed window conservatively
+            -- hour-grain. It is marked and never becomes 60 fake observations.
             insert into ash.rollup_1h (ts, datid, samples, peak_backends, wait_counts, query_counts, minute_counts)
             values (ash.ts_from_timestamptz(v_h - interval '1 hour'), 0::oid, 3600, 9,
                     array[v_cpu, 3600]::int4[], '{}'::int8[], null);
             select * into a from ash.aas(v_h - interval '2 hours', v_h + interval '1 hour');
-            assert a.peak_aas = 11.30 and a.p99_aas = 1.00 and a.buckets_with_data = 120,
-              format('legacy mix: peak=%s p99=%s bwd=%s (want 11.30 1.00 120)',
-                     a.peak_aas, a.p99_aas, a.buckets_with_data);
+            assert a.source = 'rollup_1h_flat'
+               and a.effective_bucket = interval '1 hour'
+               and a.buckets_expected = 3
+               and a.buckets_with_data = 2
+               and a.avg_aas = 0.72
+               and a.backend_seconds = 7818.00
+               and a.peak_aas is null
+               and a.p99_aas is null,
+              format(
+                'legacy mix source=%s bucket=%s expected=%s data=%s avg=%s seconds=%s peak=%s p99=%s',
+                a.source,
+                a.effective_bucket,
+                a.buckets_expected,
+                a.buckets_with_data,
+                a.avg_aas,
+                a.backend_seconds,
+                a.peak_aas,
+                a.p99_aas
+              );
 
-            -- periods(): the long windows (1w, 1mo) carry the true minute peak and a
-            -- non-null p99 (US-6 capacity planning works past rollup_1m retention)
+            -- periods() carries the same flat provenance and effective bucket.
             for r in select * from ash.periods(v_h + interval '1 hour') loop
               if r.period in ('1w', '1mo') then
-                assert r.peak_aas = 11.30 and r.p99_aas is not null,
-                  format('periods %s: peak=%s p99=%s (want 11.30, non-null)',
-                         r.period, r.peak_aas, r.p99_aas);
+                assert r.source = 'rollup_1h_flat'
+                   and r.bucket = interval '1 hour'
+                   and r.peak_aas is null
+                   and r.p99_aas is null,
+                  format(
+                    'periods %s source=%s bucket=%s peak=%s p99=%s',
+                    r.period, r.source, r.bucket, r.peak_aas, r.p99_aas
+                  );
               end if;
             end loop;
 
@@ -6414,8 +6459,11 @@ jobs:
             v_io smallint;
             v_h timestamptz := date_trunc('hour', now()) - interval '45 days';
             v_aas record;
+            v_aas_90 record;
             v_wait record;
             v_database record;
+            v_timeline_90_rows bigint;
+            v_timeline_90_points bigint;
           begin
             truncate ash.sample;
             truncate ash.rollup_1m, ash.rollup_1h;
@@ -6460,6 +6508,19 @@ jobs:
               n => 10,
               bucket => interval '1 minute'
             );
+            select * into v_aas_90
+            from ash.aas(
+              v_h,
+              v_h + interval '1 hour',
+              bucket => interval '90 seconds'
+            );
+            select count(*), sum(data_points)
+              into v_timeline_90_rows, v_timeline_90_points
+            from ash.timeline(
+              v_h,
+              v_h + interval '1 hour',
+              bucket => interval '90 seconds'
+            );
 
             assert v_aas.avg_aas = 1.15
                and v_aas.peak_aas = 10.00
@@ -6482,6 +6543,32 @@ jobs:
                 v_database.peak_aas,
                 v_database.p99_aas
               );
+
+            assert v_aas_90.effective_bucket = interval '2 minutes'
+               and v_aas_90.buckets_expected = 30
+               and v_timeline_90_rows = 30
+               and v_timeline_90_points = 60,
+              format(
+                'bucket widening effective=%s expected=%s timeline_rows=%s points=%s',
+                v_aas_90.effective_bucket,
+                v_aas_90.buckets_expected,
+                v_timeline_90_rows,
+                v_timeline_90_points
+              );
+
+            begin
+              perform *
+              from ash.aas(
+                v_h,
+                v_h + interval '1 hour',
+                bucket => interval '59.9 seconds'
+              );
+              raise exception 'sub-minute fractional bucket was accepted';
+            exception when others then
+              if sqlerrm not like 'bucket must be at least 1 minute%' then
+                raise;
+              end if;
+            end;
           end $$;
 
           -- B1b: adding a filter must disclose the surviving hour grain by
@@ -6493,6 +6580,7 @@ jobs:
             v_h timestamptz := date_trunc('hour', now()) - interval '45 days';
             v_all record;
             v_io_minute record;
+            v_io_fractional_hour record;
             v_io_hour record;
           begin
             truncate ash.sample;
@@ -6535,6 +6623,13 @@ jobs:
               wait_event_type => 'IO',
               bucket => interval '1 hour'
             );
+            select * into v_io_fractional_hour
+            from ash.aas(
+              v_h,
+              v_h + interval '1 hour',
+              wait_event_type => 'IO',
+              bucket => interval '3599.9 seconds'
+            );
 
             assert v_all.avg_aas = 2.32
                and v_all.peak_aas = 21.00
@@ -6543,10 +6638,13 @@ jobs:
                and v_io_minute.backend_seconds = 8280.00
                and v_io_minute.peak_aas is null
                and v_io_minute.p99_aas is null
+               and v_io_fractional_hour.effective_bucket = interval '1 hour'
+               and v_io_fractional_hour.peak_aas is null
+               and v_io_fractional_hour.p99_aas is null
                and v_io_hour.peak_aas = 2.30
                and v_io_hour.p99_aas = 2.30,
               format(
-                'B1b unfiltered avg=%s peak=%s p99=%s; IO minute avg=%s seconds=%s peak=%s p99=%s; IO hour peak=%s p99=%s',
+                'B1b unfiltered avg=%s peak=%s p99=%s; IO minute avg=%s seconds=%s peak=%s p99=%s; IO fractional-hour bucket=%s peak=%s p99=%s; IO hour peak=%s p99=%s',
                 v_all.avg_aas,
                 v_all.peak_aas,
                 v_all.p99_aas,
@@ -6554,6 +6652,9 @@ jobs:
                 v_io_minute.backend_seconds,
                 v_io_minute.peak_aas,
                 v_io_minute.p99_aas,
+                v_io_fractional_hour.effective_bucket,
+                v_io_fractional_hour.peak_aas,
+                v_io_fractional_hour.p99_aas,
                 v_io_hour.peak_aas,
                 v_io_hour.p99_aas
               );
@@ -6569,6 +6670,7 @@ jobs:
             v_new_h timestamptz := date_trunc('hour', now()) - interval '2 hours';
             v_overall record;
             v_dimension record;
+            v_dimension_hour record;
           begin
             truncate ash.sample;
             truncate ash.rollup_1m, ash.rollup_1h;
@@ -6625,9 +6727,22 @@ jobs:
               v_new_h + interval '1 hour',
               dimension => 'wait_event'
             );
+            select * into v_dimension_hour
+            from ash.compare(
+              v_old_h,
+              v_old_h + interval '1 hour',
+              v_new_h,
+              v_new_h + interval '1 hour',
+              dimension => 'wait_event',
+              bucket => interval '1 hour'
+            );
 
             assert to_jsonb(v_overall) ->> 'source_1' = 'rollup_1h'
                and to_jsonb(v_overall) ->> 'source_2' = 'rollup_1m'
+               and (to_jsonb(v_overall) ->> 'effective_bucket_1')::interval
+                     = interval '1 minute'
+               and (to_jsonb(v_overall) ->> 'effective_bucket_2')::interval
+                     = interval '1 minute'
                and v_overall.avg_aas_1 = 10.98
                and v_overall.avg_aas_2 = 10.98
                and v_overall.avg_delta = 0.00
@@ -6637,6 +6752,10 @@ jobs:
                and v_overall.p99_aas_2 = 246.59
                and to_jsonb(v_dimension) ->> 'source_1' = 'rollup_1h'
                and to_jsonb(v_dimension) ->> 'source_2' = 'rollup_1m'
+               and (to_jsonb(v_dimension) ->> 'effective_bucket_1')::interval
+                     = interval '1 hour'
+               and (to_jsonb(v_dimension) ->> 'effective_bucket_2')::interval
+                     = interval '1 minute'
                and v_dimension.avg_aas_1 = 10.98
                and v_dimension.avg_aas_2 = 10.98
                and v_dimension.avg_delta = 0.00
@@ -6665,6 +6784,39 @@ jobs:
                 v_dimension.p99_aas_1,
                 v_dimension.p99_aas_2
               );
+
+            -- Matching displayed buckets do not make different retained
+            -- grains comparable: the old wait dimension has one hourly
+            -- datum while the recent side has 60 minute observations.
+            assert to_jsonb(v_dimension_hour) ->> 'source_1' = 'rollup_1h'
+               and to_jsonb(v_dimension_hour) ->> 'source_2' = 'rollup_1m'
+               and (
+                 to_jsonb(v_dimension_hour) ->> 'effective_bucket_1'
+               )::interval = interval '1 hour'
+               and (
+                 to_jsonb(v_dimension_hour) ->> 'effective_bucket_2'
+               )::interval = interval '1 hour'
+               and v_dimension_hour.avg_aas_1 = 10.98
+               and v_dimension_hour.avg_aas_2 = 10.98
+               and v_dimension_hour.avg_delta = 0.00
+               and v_dimension_hour.peak_aas_1 is null
+               and v_dimension_hour.peak_aas_2 is null
+               and v_dimension_hour.p99_aas_1 is null
+               and v_dimension_hour.p99_aas_2 is null,
+              format(
+                'B1c equal bucket/different grain source=%s/%s bucket=%s/%s avg=%s/%s delta=%s peak=%s/%s p99=%s/%s',
+                to_jsonb(v_dimension_hour) ->> 'source_1',
+                to_jsonb(v_dimension_hour) ->> 'source_2',
+                to_jsonb(v_dimension_hour) ->> 'effective_bucket_1',
+                to_jsonb(v_dimension_hour) ->> 'effective_bucket_2',
+                v_dimension_hour.avg_aas_1,
+                v_dimension_hour.avg_aas_2,
+                v_dimension_hour.avg_delta,
+                v_dimension_hour.peak_aas_1,
+                v_dimension_hour.peak_aas_2,
+                v_dimension_hour.p99_aas_1,
+                v_dimension_hour.p99_aas_2
+              );
           end $$;
 
           -- #130: hour-only dimensions snap partial bounds outward and expose
@@ -6680,6 +6832,11 @@ jobs:
             v_rows bigint;
             v_min_aas numeric;
             v_max_aas numeric;
+            v_min_source text;
+            v_max_source text;
+            v_points bigint;
+            v_nonnull_peaks bigint;
+            v_nonnull_p99s bigint;
           begin
             truncate ash.sample;
             truncate ash.rollup_1m, ash.rollup_1h;
@@ -6780,6 +6937,50 @@ jobs:
               );
 
             select
+              count(*),
+              min(source),
+              max(source),
+              sum(data_points),
+              min(avg_aas),
+              max(avg_aas),
+              count(peak_aas),
+              count(p99_aas)
+              into
+                v_rows,
+                v_min_source,
+                v_max_source,
+                v_points,
+                v_min_aas,
+                v_max_aas,
+                v_nonnull_peaks,
+                v_nonnull_p99s
+            from ash.timeline(
+              v_h + interval '30 minutes',
+              v_h + interval '90 minutes',
+              interval '30 minutes',
+              wait_event_type => 'IO'
+            );
+            assert v_rows = 2
+               and v_min_source = 'rollup_1h'
+               and v_max_source = 'rollup_1h'
+               and v_points = 2
+               and v_min_aas = 0.00
+               and v_max_aas = 1.00
+               and v_nonnull_peaks = 0
+               and v_nonnull_p99s = 0,
+              format(
+                '#130 timeline rows=%s source=%s..%s points=%s avg=%s..%s nonnull_peak=%s nonnull_p99=%s',
+                v_rows,
+                v_min_source,
+                v_max_source,
+                v_points,
+                v_min_aas,
+                v_max_aas,
+                v_nonnull_peaks,
+                v_nonnull_p99s
+              );
+
+            select
               count(*) filter (where bucket_start is not null),
               min(aas) filter (where bucket_start is not null),
               max(aas) filter (where bucket_start is not null)
@@ -6813,6 +7014,12 @@ jobs:
             v_chart_rows bigint;
             v_chart_min numeric;
             v_chart_max numeric;
+            v_timeline_rows bigint;
+            v_timeline_points bigint;
+            v_timeline_min numeric;
+            v_timeline_max numeric;
+            v_timeline_peaks bigint;
+            v_timeline_p99s bigint;
             v_top record;
             v_aas record;
           begin
@@ -6862,6 +7069,21 @@ jobs:
               max(aas) filter (where bucket_start is not null)
               into v_chart_rows, v_chart_min, v_chart_max
             from ash.chart();
+            select
+              count(*),
+              sum(data_points),
+              min(avg_aas),
+              max(avg_aas),
+              count(peak_aas),
+              count(p99_aas)
+              into
+                v_timeline_rows,
+                v_timeline_points,
+                v_timeline_min,
+                v_timeline_max,
+                v_timeline_peaks,
+                v_timeline_p99s
+            from ash.timeline();
             select * into v_top from ash.top('wait_event_type')
             where key = 'IO';
             select * into v_aas from ash.aas(wait_event_type => 'IO');
@@ -6871,6 +7093,12 @@ jobs:
                and v_chart_rows = v_expected_hours
                and v_chart_min = 1.00
                and v_chart_max = 1.00
+               and v_timeline_rows = 60
+               and v_timeline_points = 60
+               and v_timeline_min = 1.00
+               and v_timeline_max = 1.00
+               and v_timeline_peaks = 60
+               and v_timeline_p99s = 60
                and v_top.avg_aas = 1.00
                and v_top.peak_aas is null
                and v_top.p99_aas is null
@@ -6880,13 +7108,19 @@ jobs:
                and v_aas.peak_aas is null
                and v_aas.p99_aas is null,
               format(
-                '#131 defaults summary rows=%s avg=%s; chart rows=%s expected=%s aas=%s..%s; top avg=%s peak=%s p99=%s; filtered aas avg=%s seconds=%s peak=%s p99=%s',
+                '#131 defaults summary rows=%s avg=%s; chart rows=%s expected=%s aas=%s..%s; timeline rows=%s points=%s avg=%s..%s nonnull_peak=%s nonnull_p99=%s; top avg=%s peak=%s p99=%s; filtered aas avg=%s seconds=%s peak=%s p99=%s',
                 v_summary_rows,
                 v_summary_avg,
                 v_chart_rows,
                 v_expected_hours,
                 v_chart_min,
                 v_chart_max,
+                v_timeline_rows,
+                v_timeline_points,
+                v_timeline_min,
+                v_timeline_max,
+                v_timeline_peaks,
+                v_timeline_p99s,
                 v_top.avg_aas,
                 v_top.peak_aas,
                 v_top.p99_aas,
@@ -8386,12 +8620,36 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
-          released_version="$(python3 devel/scripts/ash_sql_chain.py latest-released-version)"
-          git show "v${released_version}:sql/ash-install.sql" \
+          # Discover the final-release source immediately before the current
+          # development version. latest-released-version also sees migration
+          # destinations, which need not have a matching final tag yet.
+          fresh_version="$(
+            python3 devel/scripts/ash_sql_chain.py fresh-install-version
+          )"
+          target_version="${fresh_version%%-*}"
+          mapfile -t upgrade_candidates < <(
+            find sql/migrations -maxdepth 1 -type f \
+              -name "ash-*-to-${target_version}.sql" -print |
+              sort
+          )
+          test "${#upgrade_candidates[@]}" -eq 1
+          upgrade_path="${upgrade_candidates[0]}"
+          released_version="${upgrade_path##*/ash-}"
+          released_version="${released_version%-to-${target_version}.sql}"
+          released_tag="v${released_version}"
+          git cat-file -e "${released_tag}:sql/ash-install.sql"
+          git show "${released_tag}:sql/ash-install.sql" \
             > /tmp/ash-released-install.sql
 
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
+            -v released_version="$released_version" \
+            -v upgrade_path="$upgrade_path" << 'EOF'
           \i /tmp/ash-released-install.sql
+
+          create temporary table upgrade_release_probe (
+            version text not null
+          );
+          insert into upgrade_release_probe values (:'released_version');
 
           create temporary table upgrade_rollup_probe (
             label text primary key,
@@ -8419,8 +8677,13 @@ jobs:
           begin
             assert (
               select version from ash.config where singleton
-            ) = '1.5',
-              'precondition: real v1.5 installer required';
+            ) = (
+              select version from upgrade_release_probe
+            ),
+              format(
+                'precondition: real v%s installer required',
+                (select version from upgrade_release_probe)
+              );
             assert not exists (
               select
               from information_schema.columns
@@ -8496,7 +8759,7 @@ jobs:
             from generate_series(0, 59) as minute_idx;
           end $$;
 
-          \i sql/migrations/ash-1.5-to-2.0.sql
+          \i :upgrade_path
 
           -- B1d: a genuine legacy hour is one disclosed hour-grain datum, not
           -- 60 synthesized observations that claim minute precision.
@@ -8581,6 +8844,46 @@ jobs:
                 v_aas.p99_aas,
                 v_aas.backend_seconds
               );
+
+            assert (
+              select value
+              from ash.summary(
+                ash.ts_to_timestamptz(v_h),
+                ash.ts_to_timestamptz(v_h + 3600)
+              )
+              where metric = 'source'
+            ) = 'rollup_1h_flat'
+              and (
+                select value
+                from ash.summary(
+                  ash.ts_to_timestamptz(v_h),
+                  ash.ts_to_timestamptz(v_h + 3600)
+                )
+                where metric = 'buckets_with_data'
+              ) = '1'
+              and not exists (
+                select
+                from ash.summary(
+                  ash.ts_to_timestamptz(v_h),
+                  ash.ts_to_timestamptz(v_h + 3600)
+                )
+                where metric = 'minutes_with_data'
+              ),
+              'B1d summary must label its effective-grain count as buckets';
+
+            raise notice
+              'B1d GREEN timeline rows=% source=% points=% avg=% nonnull_peak=% nonnull_p99=%; aas source=% buckets=%/% avg=% peak=NULL p99=NULL seconds=%',
+              v_rows,
+              v_min_source,
+              v_points,
+              v_min_avg,
+              v_peaks,
+              v_p99s,
+              v_aas.source,
+              v_aas.buckets_with_data,
+              v_aas.buckets_expected,
+              v_aas.avg_aas,
+              v_aas.backend_seconds;
           end $$;
 
           -- N1: a partial candidate is worse than the exact hourly fallback,
@@ -8620,6 +8923,10 @@ jobs:
                 v_minute_sum,
                 v_hour_sum
               );
+
+            raise notice
+              'N1 GREEN partial minute_counts=NULL hour_sum=%',
+              v_hour_sum;
           end $$;
 
           -- Complete coverage is retained and satisfies the stored invariant.
@@ -8667,6 +8974,15 @@ jobs:
                 v_minute_sum,
                 v_hour_sum
               );
+
+            raise notice
+              'N1 GREEN complete cardinality=% null_slots=% first=% quiet_slots=% minute_sum=% hour_sum=%',
+              cardinality(v_mc),
+              v_null_slots,
+              v_mc[1],
+              v_quiet_slots,
+              v_minute_sum,
+              v_hour_sum;
           end $$;
 
           -- Re-apply repairs a partial array already written by an earlier
@@ -8679,7 +8995,7 @@ jobs:
             and hourly.ts = probe.hour_ts
             and hourly.datid = 0::oid;
 
-          \i sql/migrations/ash-1.5-to-2.0.sql
+          \i :upgrade_path
 
           do $$
           begin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6271,6 +6271,10 @@ jobs:
             v_cpu smallint; v_io smallint;
             v_h timestamptz;
             v_mc int4[];
+            v_wait_counts int4[];
+            v_minute_sum bigint;
+            v_hour_sum bigint;
+            v_null_slots bigint;
             n int; v_peak numeric; v_p99 numeric;
           begin
             truncate ash.sample_0, ash.sample_1, ash.sample_2;
@@ -6300,10 +6304,29 @@ jobs:
             perform ash.rollup_hour();
 
             -- rollup_hour() computes minute_counts exactly: 60 slots, storm at 31
-            select minute_counts into v_mc from ash.rollup_1h;
+            select minute_counts, wait_counts into v_mc, v_wait_counts
+            from ash.rollup_1h;
             assert cardinality(v_mc) = 60, 'minute_counts 60 slots, got ' || cardinality(v_mc);
             assert v_mc[31] = 678, 'storm slot 678, got ' || v_mc[31];
             assert (select count(*) from unnest(v_mc) m where m = 60) = 59, '59 quiet slots of 60';
+            select
+              coalesce(sum(minute_count), 0),
+              count(*) filter (where minute_count is null)
+              into v_minute_sum, v_null_slots
+            from unnest(v_mc) as minute_count;
+            select coalesce(sum(v_wait_counts[pos + 1]), 0)
+              into v_hour_sum
+            from generate_subscripts(v_wait_counts, 1) as pos
+            where pos % 2 = 1;
+            assert v_minute_sum = 4218
+               and v_hour_sum = 4218
+               and v_null_slots = 0,
+              format(
+                'rollup_hour invariant minute_sum=%s hour_sum=%s null_slots=%s',
+                v_minute_sum,
+                v_hour_sum,
+                v_null_slots
+              );
 
             -- seam consistency: short window (rollup_1m) vs long window (rollup_1h)
             -- containing the same spike report IDENTICAL minute-grain peak and p99
@@ -6376,6 +6399,511 @@ jobs:
               where singleton;
 
             raise notice 'rollup_1h seam minute-grain peak/p99 PASSED';
+          end $$;
+          EOF
+
+      - name: "Test 2.0: rollup_1h grain honesty and partial-hour degradation (#161, #130)"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          -- B1a: top() must not present an hour average as a minute peak.
+          do $$
+          declare
+            v_cpu smallint;
+            v_io smallint;
+            v_h timestamptz := date_trunc('hour', now()) - interval '45 days';
+            v_aas record;
+            v_wait record;
+            v_database record;
+          begin
+            truncate ash.sample;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set sample_interval = interval '1 second',
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+            select ash._register_wait('active', 'IO', 'DataFileRead') into v_io;
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            ) values (
+              ash.ts_from_timestamptz(v_h),
+              0::oid,
+              3600,
+              10,
+              array[v_io, 2760, v_cpu, 1380]::int4[],
+              '{}'::int8[],
+              array[600]::int4[] || array_fill(60, array[59])
+            );
+
+            select * into v_aas
+            from ash.aas(v_h, v_h + interval '1 hour');
+            select * into v_wait
+            from ash.top(
+              'wait_event',
+              v_h,
+              v_h + interval '1 hour',
+              n => 10,
+              bucket => interval '1 minute'
+            )
+            where key = 'IO:DataFileRead';
+            select * into v_database
+            from ash.top(
+              'database',
+              v_h,
+              v_h + interval '1 hour',
+              n => 10,
+              bucket => interval '1 minute'
+            );
+
+            assert v_aas.avg_aas = 1.15
+               and v_aas.peak_aas = 10.00
+               and v_aas.p99_aas = 4.69
+               and v_wait.avg_aas = 0.77
+               and v_wait.peak_aas is null
+               and v_wait.p99_aas is null
+               and v_database.avg_aas = 1.15
+               and v_database.peak_aas = 10.00
+               and v_database.p99_aas = 4.69,
+              format(
+                'B1a aas avg=%s peak=%s p99=%s; top wait avg=%s peak=%s p99=%s; database avg=%s peak=%s p99=%s',
+                v_aas.avg_aas,
+                v_aas.peak_aas,
+                v_aas.p99_aas,
+                v_wait.avg_aas,
+                v_wait.peak_aas,
+                v_wait.p99_aas,
+                v_database.avg_aas,
+                v_database.peak_aas,
+                v_database.p99_aas
+              );
+          end $$;
+
+          -- B1b: adding a filter must disclose the surviving hour grain by
+          -- keeping exact totals while NULLing unsupported minute extremes.
+          do $$
+          declare
+            v_cpu smallint;
+            v_io smallint;
+            v_h timestamptz := date_trunc('hour', now()) - interval '45 days';
+            v_all record;
+            v_io_minute record;
+            v_io_hour record;
+          begin
+            truncate ash.sample;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set sample_interval = interval '1 second',
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+            select ash._register_wait('active', 'IO', 'DataFileRead') into v_io;
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            ) values (
+              ash.ts_from_timestamptz(v_h),
+              0::oid,
+              3600,
+              21,
+              array[v_io, 8280, v_cpu, 60]::int4[],
+              '{}'::int8[],
+              array[1260]::int4[] || array_fill(120, array[59])
+            );
+
+            select * into v_all
+            from ash.aas(v_h, v_h + interval '1 hour');
+            select * into v_io_minute
+            from ash.aas(
+              v_h,
+              v_h + interval '1 hour',
+              wait_event_type => 'IO',
+              bucket => interval '1 minute'
+            );
+            select * into v_io_hour
+            from ash.aas(
+              v_h,
+              v_h + interval '1 hour',
+              wait_event_type => 'IO',
+              bucket => interval '1 hour'
+            );
+
+            assert v_all.avg_aas = 2.32
+               and v_all.peak_aas = 21.00
+               and v_all.p99_aas = 9.79
+               and v_io_minute.avg_aas = 2.30
+               and v_io_minute.backend_seconds = 8280.00
+               and v_io_minute.peak_aas is null
+               and v_io_minute.p99_aas is null
+               and v_io_hour.peak_aas = 2.30
+               and v_io_hour.p99_aas = 2.30,
+              format(
+                'B1b unfiltered avg=%s peak=%s p99=%s; IO minute avg=%s seconds=%s peak=%s p99=%s; IO hour peak=%s p99=%s',
+                v_all.avg_aas,
+                v_all.peak_aas,
+                v_all.p99_aas,
+                v_io_minute.avg_aas,
+                v_io_minute.backend_seconds,
+                v_io_minute.peak_aas,
+                v_io_minute.p99_aas,
+                v_io_hour.peak_aas,
+                v_io_hour.p99_aas
+              );
+          end $$;
+
+          -- B1c: byte-identical windows across retention tiers keep their
+          -- honest averages. Overall minute-detail extremes remain comparable;
+          -- dimensional hour-vs-minute extremes are suppressed as a pair.
+          do $$
+          declare
+            v_io smallint;
+            v_old_h timestamptz := date_trunc('hour', now()) - interval '45 days';
+            v_new_h timestamptz := date_trunc('hour', now()) - interval '2 hours';
+            v_overall record;
+            v_dimension record;
+          begin
+            truncate ash.sample;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set sample_interval = interval '1 second',
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+
+            select ash._register_wait('active', 'IO', 'DataFileRead') into v_io;
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            ) values (
+              ash.ts_from_timestamptz(v_old_h),
+              0::oid,
+              3600,
+              600,
+              array[v_io, 39540]::int4[],
+              '{}'::int8[],
+              array[36000]::int4[] || array_fill(60, array[59])
+            );
+
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            )
+            select
+              ash.ts_from_timestamptz(
+                v_new_h + minute_idx * interval '1 minute'
+              ),
+              0::oid,
+              60,
+              case when minute_idx = 0 then 600 else 1 end,
+              array[
+                v_io,
+                case when minute_idx = 0 then 36000 else 60 end
+              ]::int4[],
+              '{}'::int8[]
+            from generate_series(0, 59) as minute_idx;
+
+            select * into v_overall
+            from ash.compare(
+              v_old_h,
+              v_old_h + interval '1 hour',
+              v_new_h,
+              v_new_h + interval '1 hour'
+            );
+            select * into v_dimension
+            from ash.compare(
+              v_old_h,
+              v_old_h + interval '1 hour',
+              v_new_h,
+              v_new_h + interval '1 hour',
+              dimension => 'wait_event'
+            );
+
+            assert to_jsonb(v_overall) ->> 'source_1' = 'rollup_1h'
+               and to_jsonb(v_overall) ->> 'source_2' = 'rollup_1m'
+               and v_overall.avg_aas_1 = 10.98
+               and v_overall.avg_aas_2 = 10.98
+               and v_overall.avg_delta = 0.00
+               and v_overall.peak_aas_1 = 600.00
+               and v_overall.peak_aas_2 = 600.00
+               and v_overall.p99_aas_1 = 246.59
+               and v_overall.p99_aas_2 = 246.59
+               and to_jsonb(v_dimension) ->> 'source_1' = 'rollup_1h'
+               and to_jsonb(v_dimension) ->> 'source_2' = 'rollup_1m'
+               and v_dimension.avg_aas_1 = 10.98
+               and v_dimension.avg_aas_2 = 10.98
+               and v_dimension.avg_delta = 0.00
+               and v_dimension.peak_aas_1 is null
+               and v_dimension.peak_aas_2 is null
+               and v_dimension.p99_aas_1 is null
+               and v_dimension.p99_aas_2 is null,
+              format(
+                'B1c overall source=%s/%s avg=%s/%s delta=%s peak=%s/%s p99=%s/%s; dimension source=%s/%s avg=%s/%s delta=%s peak=%s/%s p99=%s/%s',
+                coalesce(to_jsonb(v_overall) ->> 'source_1', '<missing>'),
+                coalesce(to_jsonb(v_overall) ->> 'source_2', '<missing>'),
+                v_overall.avg_aas_1,
+                v_overall.avg_aas_2,
+                v_overall.avg_delta,
+                v_overall.peak_aas_1,
+                v_overall.peak_aas_2,
+                v_overall.p99_aas_1,
+                v_overall.p99_aas_2,
+                coalesce(to_jsonb(v_dimension) ->> 'source_1', '<missing>'),
+                coalesce(to_jsonb(v_dimension) ->> 'source_2', '<missing>'),
+                v_dimension.avg_aas_1,
+                v_dimension.avg_aas_2,
+                v_dimension.avg_delta,
+                v_dimension.peak_aas_1,
+                v_dimension.peak_aas_2,
+                v_dimension.p99_aas_1,
+                v_dimension.p99_aas_2
+              );
+          end $$;
+
+          -- #130: hour-only dimensions snap partial bounds outward and expose
+          -- the effective window; the database dimension keeps minute precision.
+          do $$
+          declare
+            v_cpu smallint;
+            v_io smallint;
+            v_h timestamptz := date_trunc('hour', now()) - interval '45 days';
+            v_aas record;
+            v_wait record;
+            v_database record;
+            v_rows bigint;
+            v_min_aas numeric;
+            v_max_aas numeric;
+          begin
+            truncate ash.sample;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set sample_interval = interval '1 second',
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+            select ash._register_wait('active', 'IO', 'DataFileRead') into v_io;
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            ) values
+              (
+                ash.ts_from_timestamptz(v_h),
+                0::oid,
+                3600,
+                1,
+                array[v_io, 3600]::int4[],
+                '{}'::int8[],
+                array_fill(60, array[60])
+              ),
+              (
+                ash.ts_from_timestamptz(v_h + interval '1 hour'),
+                0::oid,
+                3600,
+                1,
+                array[v_cpu, 3600]::int4[],
+                '{}'::int8[],
+                array_fill(60, array[60])
+              );
+
+            select * into v_aas
+            from ash.aas(
+              v_h,
+              v_h + interval '30 minutes',
+              wait_event_type => 'IO'
+            );
+            select * into v_wait
+            from ash.top(
+              'wait_event_type',
+              v_h + interval '30 minutes',
+              v_h + interval '90 minutes',
+              n => 10
+            )
+            where key = 'IO';
+            select * into v_database
+            from ash.top(
+              'database',
+              v_h,
+              v_h + interval '30 minutes',
+              n => 10
+            );
+
+            assert v_aas.period_start = v_h
+               and v_aas.period_end = v_h + interval '1 hour'
+               and v_aas.avg_aas = 1.00
+               and v_aas.backend_seconds = 3600.00
+               and v_aas.peak_aas is null
+               and v_aas.p99_aas is null
+               and (to_jsonb(v_wait) ->> 'period_start')::timestamptz = v_h
+               and (to_jsonb(v_wait) ->> 'period_end')::timestamptz
+                     = v_h + interval '2 hours'
+               and v_wait.avg_aas = 0.50
+               and v_wait.backend_seconds = 3600.00
+               and v_wait.peak_aas is null
+               and v_wait.p99_aas is null
+               and (to_jsonb(v_database) ->> 'period_start')::timestamptz = v_h
+               and (to_jsonb(v_database) ->> 'period_end')::timestamptz
+                     = v_h + interval '30 minutes'
+               and v_database.avg_aas = 1.00
+               and v_database.backend_seconds = 1800.00
+               and v_database.peak_aas = 1.00
+               and v_database.p99_aas = 1.00,
+              format(
+                '#130 aas period=%s..%s avg=%s seconds=%s peak=%s p99=%s; wait period=%s..%s avg=%s seconds=%s peak=%s p99=%s; database period=%s..%s avg=%s seconds=%s peak=%s p99=%s',
+                v_aas.period_start,
+                v_aas.period_end,
+                v_aas.avg_aas,
+                v_aas.backend_seconds,
+                v_aas.peak_aas,
+                v_aas.p99_aas,
+                coalesce(to_jsonb(v_wait) ->> 'period_start', '<missing>'),
+                coalesce(to_jsonb(v_wait) ->> 'period_end', '<missing>'),
+                v_wait.avg_aas,
+                v_wait.backend_seconds,
+                v_wait.peak_aas,
+                v_wait.p99_aas,
+                coalesce(to_jsonb(v_database) ->> 'period_start', '<missing>'),
+                coalesce(to_jsonb(v_database) ->> 'period_end', '<missing>'),
+                v_database.avg_aas,
+                v_database.backend_seconds,
+                v_database.peak_aas,
+                v_database.p99_aas
+              );
+
+            select
+              count(*) filter (where bucket_start is not null),
+              min(aas) filter (where bucket_start is not null),
+              max(aas) filter (where bucket_start is not null)
+              into v_rows, v_min_aas, v_max_aas
+            from ash.chart(
+              v_h + interval '30 minutes',
+              v_h + interval '90 minutes',
+              interval '30 minutes'
+            );
+            assert v_rows = 2 and v_min_aas = 1.00 and v_max_aas = 1.00,
+              format(
+                '#130 chart snapped rows=%s aas=%s..%s',
+                v_rows,
+                v_min_aas,
+                v_max_aas
+              );
+          end $$;
+
+          -- #131 regression controls: defaults and now()-relative calls remain
+          -- usable when rollup_1h is the only retained source.
+          do $$
+          declare
+            v_io smallint;
+            v_requested_start int4;
+            v_requested_end int4;
+            v_effective_start int4;
+            v_effective_end int4;
+            v_expected_hours int;
+            v_summary_rows bigint;
+            v_summary_avg text;
+            v_chart_rows bigint;
+            v_chart_min numeric;
+            v_chart_max numeric;
+            v_top record;
+            v_aas record;
+          begin
+            truncate ash.sample;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set sample_interval = interval '1 second',
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+
+            select ash._register_wait('active', 'IO', 'DataFileRead') into v_io;
+
+            v_requested_start :=
+              (ash.ts_from_timestamptz(now() - interval '1 hour') / 60) * 60;
+            v_requested_end :=
+              (ash.ts_from_timestamptz(now()) / 60) * 60;
+            v_effective_start := (v_requested_start / 3600) * 3600;
+            v_effective_end :=
+              ((v_requested_end::bigint + 3599) / 3600 * 3600)::int4;
+            v_expected_hours := (v_effective_end - v_effective_start) / 3600;
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            )
+            select
+              hour_ts::int4,
+              0::oid,
+              3600,
+              1,
+              array[v_io, 3600]::int4[],
+              array[111::bigint, 3600]::int8[],
+              array_fill(60, array[60])
+            from generate_series(
+              v_effective_start::bigint,
+              (v_effective_end - 3600)::bigint,
+              3600
+            ) as hour_ts;
+
+            select count(*), max(value) filter (where metric = 'avg_aas')
+              into v_summary_rows, v_summary_avg
+            from ash.summary();
+            select
+              count(*) filter (where bucket_start is not null),
+              min(aas) filter (where bucket_start is not null),
+              max(aas) filter (where bucket_start is not null)
+              into v_chart_rows, v_chart_min, v_chart_max
+            from ash.chart();
+            select * into v_top from ash.top('wait_event_type')
+            where key = 'IO';
+            select * into v_aas from ash.aas(wait_event_type => 'IO');
+
+            assert v_summary_rows = 11
+               and v_summary_avg = '1.00'
+               and v_chart_rows = v_expected_hours
+               and v_chart_min = 1.00
+               and v_chart_max = 1.00
+               and v_top.avg_aas = 1.00
+               and v_top.peak_aas is null
+               and v_top.p99_aas is null
+               and v_aas.avg_aas = 1.00
+               and v_aas.backend_seconds
+                     = (v_effective_end - v_effective_start)::numeric
+               and v_aas.peak_aas is null
+               and v_aas.p99_aas is null,
+              format(
+                '#131 defaults summary rows=%s avg=%s; chart rows=%s expected=%s aas=%s..%s; top avg=%s peak=%s p99=%s; filtered aas avg=%s seconds=%s peak=%s p99=%s',
+                v_summary_rows,
+                v_summary_avg,
+                v_chart_rows,
+                v_expected_hours,
+                v_chart_min,
+                v_chart_max,
+                v_top.avg_aas,
+                v_top.peak_aas,
+                v_top.p99_aas,
+                v_aas.avg_aas,
+                v_aas.backend_seconds,
+                v_aas.peak_aas,
+                v_aas.p99_aas
+              );
+
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+
+            raise notice
+              'rollup_1h grain honesty, partial-hour, and default-call tests PASSED';
           end $$;
           EOF
 
@@ -7848,6 +8376,324 @@ jobs:
             ), 'direct v1.4 -> v1.5 upgrade did not honor rebuilt retained raw slots';
 
             raise notice 'direct v1.4 -> v1.5 release upgrade regression PASSED';
+          end $$;
+
+          select ash.uninstall('yes');
+          EOF
+
+      - name: "Release upgrade path: v1.5 rollup_1h backfill honesty (#161, #168)"
+        if: matrix.postgres == 17 && matrix.cron == 'on'
+        env:
+          PGPASSWORD: postgres
+        run: |
+          released_version="$(python3 devel/scripts/ash_sql_chain.py latest-released-version)"
+          git show "v${released_version}:sql/ash-install.sql" \
+            > /tmp/ash-released-install.sql
+
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          \i /tmp/ash-released-install.sql
+
+          create temporary table upgrade_rollup_probe (
+            label text primary key,
+            hour_ts int4 not null
+          );
+
+          do $$
+          declare
+            v_wait_id smallint;
+            v_flat_h int4 := (
+              ash.ts_from_timestamptz(
+                date_trunc('hour', now()) - interval '60 days'
+              ) / 3600
+            ) * 3600;
+            v_partial_h int4 := (
+              ash.ts_from_timestamptz(
+                date_trunc('hour', now()) - interval '29 days'
+              ) / 3600
+            ) * 3600;
+            v_complete_h int4 := (
+              ash.ts_from_timestamptz(
+                date_trunc('hour', now()) - interval '28 days'
+              ) / 3600
+            ) * 3600;
+          begin
+            assert (
+              select version from ash.config where singleton
+            ) = '1.5',
+              'precondition: real v1.5 installer required';
+            assert not exists (
+              select
+              from information_schema.columns
+              where table_schema = 'ash'
+                and table_name = 'rollup_1h'
+                and column_name = 'minute_counts'
+            ), 'precondition: v1.5 unexpectedly has minute_counts';
+
+            select ash._register_wait('active', 'IO', 'DataFileRead')
+              into v_wait_id;
+
+            insert into upgrade_rollup_probe values
+              ('legacy_flat', v_flat_h),
+              ('partial_backfill', v_partial_h),
+              ('complete_backfill', v_complete_h);
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values
+              (
+                v_flat_h,
+                0::oid,
+                60,
+                10,
+                array[v_wait_id, 600]::int4[],
+                '{}'::int8[]
+              ),
+              (
+                v_partial_h,
+                0::oid,
+                3600,
+                1,
+                array[v_wait_id, 3600]::int4[],
+                '{}'::int8[]
+              ),
+              (
+                v_complete_h,
+                0::oid,
+                3600,
+                10,
+                array[v_wait_id, 4140]::int4[],
+                '{}'::int8[]
+              );
+
+            -- N1: only half of this hour's minute detail survives.
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            )
+            select
+              v_partial_h + minute_idx * 60,
+              0::oid,
+              60,
+              1,
+              array[v_wait_id, 60]::int4[],
+              '{}'::int8[]
+            from generate_series(0, 29) as minute_idx;
+
+            -- Positive control: complete detail with one 600-count spike and
+            -- 59 quiet minutes of 60 counts.
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            )
+            select
+              v_complete_h + minute_idx * 60,
+              0::oid,
+              60,
+              case when minute_idx = 0 then 10 else 1 end,
+              array[
+                v_wait_id,
+                case when minute_idx = 0 then 600 else 60 end
+              ]::int4[],
+              '{}'::int8[]
+            from generate_series(0, 59) as minute_idx;
+          end $$;
+
+          \i sql/migrations/ash-1.5-to-2.0.sql
+
+          -- B1d: a genuine legacy hour is one disclosed hour-grain datum, not
+          -- 60 synthesized observations that claim minute precision.
+          do $$
+          declare
+            v_h int4;
+            v_rows bigint;
+            v_min_source text;
+            v_max_source text;
+            v_points numeric;
+            v_min_avg numeric;
+            v_max_avg numeric;
+            v_peaks bigint;
+            v_p99s bigint;
+            v_aas record;
+          begin
+            select hour_ts into v_h
+            from upgrade_rollup_probe
+            where label = 'legacy_flat';
+
+            select
+              count(*),
+              min(source),
+              max(source),
+              sum(data_points),
+              min(avg_aas),
+              max(avg_aas),
+              count(peak_aas),
+              count(p99_aas)
+              into
+                v_rows,
+                v_min_source,
+                v_max_source,
+                v_points,
+                v_min_avg,
+                v_max_avg,
+                v_peaks,
+                v_p99s
+            from ash.timeline(
+              ash.ts_to_timestamptz(v_h),
+              ash.ts_to_timestamptz(v_h + 3600),
+              interval '1 minute'
+            );
+
+            select * into v_aas
+            from ash.aas(
+              ash.ts_to_timestamptz(v_h),
+              ash.ts_to_timestamptz(v_h + 3600),
+              bucket => interval '1 minute'
+            );
+
+            assert v_rows = 1
+               and v_min_source = 'rollup_1h_flat'
+               and v_max_source = 'rollup_1h_flat'
+               and v_points = 1
+               and v_min_avg = 0.17
+               and v_max_avg = 0.17
+               and v_peaks = 0
+               and v_p99s = 0
+               and v_aas.source = 'rollup_1h_flat'
+               and v_aas.buckets_expected = 1
+               and v_aas.buckets_with_data = 1
+               and v_aas.avg_aas = 0.17
+               and v_aas.peak_aas is null
+               and v_aas.p99_aas is null
+               and v_aas.backend_seconds = 600.00,
+              format(
+                'B1d legacy timeline rows=%s source=%s..%s points=%s avg=%s..%s nonnull_peak=%s nonnull_p99=%s; aas source=%s buckets=%s/%s avg=%s peak=%s p99=%s seconds=%s',
+                v_rows,
+                v_min_source,
+                v_max_source,
+                v_points,
+                v_min_avg,
+                v_max_avg,
+                v_peaks,
+                v_p99s,
+                v_aas.source,
+                v_aas.buckets_with_data,
+                v_aas.buckets_expected,
+                v_aas.avg_aas,
+                v_aas.peak_aas,
+                v_aas.p99_aas,
+                v_aas.backend_seconds
+              );
+          end $$;
+
+          -- N1: a partial candidate is worse than the exact hourly fallback,
+          -- so the migration must leave minute_counts NULL.
+          do $$
+          declare
+            v_mc int4[];
+            v_wait_counts int4[];
+            v_minute_sum bigint;
+            v_hour_sum bigint;
+            v_null_slots bigint;
+          begin
+            select hourly.minute_counts, hourly.wait_counts
+              into v_mc, v_wait_counts
+            from ash.rollup_1h as hourly
+            join upgrade_rollup_probe as probe
+              on probe.hour_ts = hourly.ts
+            where probe.label = 'partial_backfill'
+              and hourly.datid = 0::oid;
+
+            select
+              sum(minute_count),
+              count(*) filter (where minute_count is null)
+              into v_minute_sum, v_null_slots
+            from unnest(v_mc) as minute_count;
+
+            select sum(v_wait_counts[pos + 1])
+              into v_hour_sum
+            from generate_subscripts(v_wait_counts, 1) as pos
+            where pos % 2 = 1;
+
+            assert v_mc is null,
+              format(
+                'N1 partial backfill minute_counts cardinality=%s null_slots=%s minute_sum=%s hour_sum=%s',
+                cardinality(v_mc),
+                v_null_slots,
+                v_minute_sum,
+                v_hour_sum
+              );
+          end $$;
+
+          -- Complete coverage is retained and satisfies the stored invariant.
+          do $$
+          declare
+            v_mc int4[];
+            v_wait_counts int4[];
+            v_minute_sum bigint;
+            v_hour_sum bigint;
+            v_null_slots bigint;
+            v_quiet_slots bigint;
+          begin
+            select hourly.minute_counts, hourly.wait_counts
+              into v_mc, v_wait_counts
+            from ash.rollup_1h as hourly
+            join upgrade_rollup_probe as probe
+              on probe.hour_ts = hourly.ts
+            where probe.label = 'complete_backfill'
+              and hourly.datid = 0::oid;
+
+            select
+              coalesce(sum(minute_count), 0),
+              count(*) filter (where minute_count is null),
+              count(*) filter (where minute_count = 60)
+              into v_minute_sum, v_null_slots, v_quiet_slots
+            from unnest(v_mc) as minute_count;
+
+            select coalesce(sum(v_wait_counts[pos + 1]), 0)
+              into v_hour_sum
+            from generate_subscripts(v_wait_counts, 1) as pos
+            where pos % 2 = 1;
+
+            assert cardinality(v_mc) = 60
+               and v_null_slots = 0
+               and v_mc[1] = 600
+               and v_quiet_slots = 59
+               and v_minute_sum = 4140
+               and v_hour_sum = 4140,
+              format(
+                'complete backfill invariant cardinality=%s null_slots=%s first=%s quiet_slots=%s minute_sum=%s hour_sum=%s',
+                cardinality(v_mc),
+                v_null_slots,
+                v_mc[1],
+                v_quiet_slots,
+                v_minute_sum,
+                v_hour_sum
+              );
+          end $$;
+
+          -- Re-apply repairs a partial array already written by an earlier
+          -- 2.0 beta installer instead of preserving permanent undercounting.
+          update ash.rollup_1h as hourly
+          set minute_counts =
+            array_fill(60, array[30]) || array_fill(null::int4, array[30])
+          from upgrade_rollup_probe as probe
+          where probe.label = 'partial_backfill'
+            and hourly.ts = probe.hour_ts
+            and hourly.datid = 0::oid;
+
+          \i sql/migrations/ash-1.5-to-2.0.sql
+
+          do $$
+          begin
+            assert (
+              select hourly.minute_counts is null
+              from ash.rollup_1h as hourly
+              join upgrade_rollup_probe as probe
+                on probe.hour_ts = hourly.ts
+              where probe.label = 'partial_backfill'
+                and hourly.datid = 0::oid
+            ), 'N1 installer re-apply must NULL a pre-existing partial array';
+
+            raise notice
+              'real v1.5 rollup_1h legacy and backfill honesty PASSED';
           end $$;
 
           select ash.uninstall('yes');

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6999,6 +6999,111 @@ jobs:
               );
           end $$;
 
+          -- summary(): the minute-precise headline and widened hour-only
+          -- wait/query drills must disclose their distinct effective plans.
+          do $$
+          declare
+            v_cpu smallint;
+            v_io smallint;
+            v_h timestamptz := date_trunc('hour', now()) - interval '45 days';
+            v_period_start text;
+            v_period_end text;
+            v_avg text;
+            v_drill_source text;
+            v_drill_start text;
+            v_drill_end text;
+            v_drill_bucket text;
+            v_top_wait text;
+          begin
+            truncate ash.sample;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set sample_interval = interval '1 second',
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+            select ash._register_wait('active', 'IO', 'DataFileRead') into v_io;
+
+            /*
+             * Both hours contain load only in the halves outside the requested
+             * [h+30m, h+90m) window. The headline can prove measured zero from
+             * minute_counts; the dimensional drills can only report the two
+             * complete hours (IO 36000 / 7200 = 5.00 AAS).
+             */
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            ) values
+              (
+                ash.ts_from_timestamptz(v_h),
+                0::oid,
+                3600,
+                20,
+                array[v_io, 36000]::int4[],
+                '{}'::int8[],
+                array_fill(1200, array[30])
+                  || array_fill(0, array[30])
+              ),
+              (
+                ash.ts_from_timestamptz(v_h + interval '1 hour'),
+                0::oid,
+                3600,
+                10,
+                array[v_cpu, 18000]::int4[],
+                '{}'::int8[],
+                array_fill(0, array[30])
+                  || array_fill(600, array[30])
+              );
+
+            select
+              max(value) filter (where metric = 'period_start'),
+              max(value) filter (where metric = 'period_end'),
+              max(value) filter (where metric = 'avg_aas'),
+              max(value) filter (where metric = 'drill_source'),
+              max(value) filter (where metric = 'drill_period_start'),
+              max(value) filter (where metric = 'drill_period_end'),
+              max(value) filter (where metric = 'drill_effective_bucket'),
+              max(value) filter (where metric = 'top_wait_1')
+              into
+                v_period_start,
+                v_period_end,
+                v_avg,
+                v_drill_source,
+                v_drill_start,
+                v_drill_end,
+                v_drill_bucket,
+                v_top_wait
+            from ash.summary(
+              v_h + interval '30 minutes',
+              v_h + interval '90 minutes'
+            );
+
+            assert v_period_start::timestamptz
+                     = v_h + interval '30 minutes'
+               and v_period_end::timestamptz
+                     = v_h + interval '90 minutes'
+               and v_avg = '0.00'
+               and v_drill_source = 'rollup_1h'
+               and v_drill_start::timestamptz = v_h
+               and v_drill_end::timestamptz = v_h + interval '2 hours'
+               and v_drill_bucket::interval = interval '1 hour'
+               and v_top_wait
+                     = 'IO:DataFileRead (avg_aas 5.00, 66.67%)',
+              format(
+                'summary headline=%s..%s avg=%s; drill=%s %s..%s bucket=%s top=%s',
+                v_period_start,
+                v_period_end,
+                v_avg,
+                v_drill_source,
+                v_drill_start,
+                v_drill_end,
+                v_drill_bucket,
+                v_top_wait
+              );
+          end $$;
+
           -- #131 regression controls: defaults and now()-relative calls remain
           -- usable when rollup_1h is the only retained source.
           do $$
@@ -7011,6 +7116,10 @@ jobs:
             v_expected_hours int;
             v_summary_rows bigint;
             v_summary_avg text;
+            v_summary_drill_source text;
+            v_summary_drill_start text;
+            v_summary_drill_end text;
+            v_summary_drill_bucket text;
             v_chart_rows bigint;
             v_chart_min numeric;
             v_chart_max numeric;
@@ -7060,8 +7169,20 @@ jobs:
               3600
             ) as hour_ts;
 
-            select count(*), max(value) filter (where metric = 'avg_aas')
-              into v_summary_rows, v_summary_avg
+            select
+              count(*),
+              max(value) filter (where metric = 'avg_aas'),
+              max(value) filter (where metric = 'drill_source'),
+              max(value) filter (where metric = 'drill_period_start'),
+              max(value) filter (where metric = 'drill_period_end'),
+              max(value) filter (where metric = 'drill_effective_bucket')
+              into
+                v_summary_rows,
+                v_summary_avg,
+                v_summary_drill_source,
+                v_summary_drill_start,
+                v_summary_drill_end,
+                v_summary_drill_bucket
             from ash.summary();
             select
               count(*) filter (where bucket_start is not null),
@@ -7088,8 +7209,14 @@ jobs:
             where key = 'IO';
             select * into v_aas from ash.aas(wait_event_type => 'IO');
 
-            assert v_summary_rows = 11
+            assert v_summary_rows = 15
                and v_summary_avg = '1.00'
+               and v_summary_drill_source = 'rollup_1h'
+               and v_summary_drill_start::timestamptz
+                     = ash.ts_to_timestamptz(v_effective_start)
+               and v_summary_drill_end::timestamptz
+                     = ash.ts_to_timestamptz(v_effective_end)
+               and v_summary_drill_bucket::interval = interval '1 hour'
                and v_chart_rows = v_expected_hours
                and v_chart_min = 1.00
                and v_chart_max = 1.00
@@ -7108,9 +7235,13 @@ jobs:
                and v_aas.peak_aas is null
                and v_aas.p99_aas is null,
               format(
-                '#131 defaults summary rows=%s avg=%s; chart rows=%s expected=%s aas=%s..%s; timeline rows=%s points=%s avg=%s..%s nonnull_peak=%s nonnull_p99=%s; top avg=%s peak=%s p99=%s; filtered aas avg=%s seconds=%s peak=%s p99=%s',
+                '#131 defaults summary rows=%s avg=%s drill=%s %s..%s bucket=%s; chart rows=%s expected=%s aas=%s..%s; timeline rows=%s points=%s avg=%s..%s nonnull_peak=%s nonnull_p99=%s; top avg=%s peak=%s p99=%s; filtered aas avg=%s seconds=%s peak=%s p99=%s',
                 v_summary_rows,
                 v_summary_avg,
+                v_summary_drill_source,
+                v_summary_drill_start,
+                v_summary_drill_end,
+                v_summary_drill_bucket,
                 v_chart_rows,
                 v_expected_hours,
                 v_chart_min,

--- a/README.md
+++ b/README.md
@@ -105,9 +105,10 @@ Full mapping: [`blueprints/AAS_EXAMPLES.md`](blueprints/AAS_EXAMPLES.md).
 Start with `ash.periods()`, then drill down with `ash.timeline()` and `ash.top()`.
 Typed aggregate readers report `raw`, `rollup_1m`, `rollup_1h`,
 `rollup_1h_flat`, or `none`; `ash.compare()` reports `source_1` / `source_2`,
-`ash.report()` embeds provenance in JSON coverage, `ash.summary()` includes a
-source metric, `ash.samples()` is raw-only, and `ash.chart()` emits a planning
-`NOTICE` when hour grain widens the request. `rollup_1h_flat` means a
+`ash.report()` embeds provenance in JSON coverage, and `ash.summary()` includes
+separate headline and wait/query drill source/bounds metrics. `ash.samples()`
+is raw-only, and `ash.chart()` emits a planning `NOTICE` when hour grain widens
+the request. `rollup_1h_flat` means a
 minute-capable plan encountered legacy/incomplete detail and degraded honestly
 to hour grain.
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,13 @@ Full mapping: [`blueprints/AAS_EXAMPLES.md`](blueprints/AAS_EXAMPLES.md).
 ## Reader API
 
 Start with `ash.periods()`, then drill down with `ash.timeline()` and `ash.top()`.
-Every reader reports its data source: `raw`, `rollup_1m`, `rollup_1h`, or
-`none`.
+Typed aggregate readers report `raw`, `rollup_1m`, `rollup_1h`,
+`rollup_1h_flat`, or `none`; `ash.compare()` reports `source_1` / `source_2`,
+`ash.report()` embeds provenance in JSON coverage, `ash.summary()` includes a
+source metric, `ash.samples()` is raw-only, and `ash.chart()` emits a planning
+`NOTICE` when hour grain widens the request. `rollup_1h_flat` means a
+minute-capable plan encountered legacy/incomplete detail and degraded honestly
+to hour grain.
 
 | Function | Use it for |
 |---|---|
@@ -134,14 +139,19 @@ Filters are consistent where they apply:
 
 `order_by` is `avg`, `peak`, or `p99`. During incidents, `order_by => 'peak'`
 is usually the right first cut because it surfaces short spikes that averages
-hide.
+hide. When retained grain is coarser than the requested bucket, peak/p99 are
+NULL instead of being filled with an hour average. Hour-only partial-window
+drills snap outward and disclose effective bounds/bucket; plain
+`top('database')` keeps minute precision through per-database `minute_counts`.
 
 ## Investigation flow
 
 ### 1. Is it bad now, or was it a spike?
 
 ```sql
-select * from ash.periods();
+select period, source, bucket, buckets_with_data,
+       avg_aas, peak_aas, p99_aas
+from ash.periods();
 ```
 
 Typical output:
@@ -160,7 +170,8 @@ load.
 ### 2. What kind of wait dominated?
 
 ```sql
-select *
+select key, query_text, source, avg_aas, peak_aas, p99_aas,
+       backend_seconds, pct
 from ash.top(
   'wait_event_type',
   since => now() - interval '5 minutes',

--- a/blueprints/AAS_API.md
+++ b/blueprints/AAS_API.md
@@ -27,18 +27,17 @@ removed (see §8). Sampling, storage, rollups, and admin/lifecycle functions
    `database`) are uniform named parameters across all readers.
 4. **Data ≠ presentation.** Data functions return typed columns only. ASCII
    bars/charts/colors live in exactly two human helpers (§5).
-5. **Source honesty (the trust property).** Every reader auto-selects its data
-   source by window (raw → `rollup_1m` → `rollup_1h`). Every over-time /
-   breakdown reader (`periods`, `aas`, `timeline`, `top`, `chart`) reports the
-   chosen source in a `source` column (`samples` reads raw only, by definition).
-   `compare()` and `report()`
-   surface provenance differently: `compare()` has no `source` column — a window
-   with no coverage yields NULL columns plus a NOTICE (never a fake zero
-   baseline, see §2.5); `report()` returns `jsonb`, so its source and coverage
-   live inside a `coverage` object (`coverage.source`, always `rollup_1m` — see
-   §4). When a request *cannot* be answered (the event↔query tie needs raw
-   samples but the window exceeds raw retention), the reader raises a clear
-   exception naming the boundary — never a silent empty result.
+5. **Source honesty (the trust property).** Aggregate readers auto-select their
+   data source by window (raw → `rollup_1m` → `rollup_1h`). `periods`, `aas`,
+   `timeline`, and `top` report it in `source`; `compare` reports
+   `source_1` / `source_2`; `report` embeds it in `coverage.source`; and the
+   presentation-only `chart` emits a `NOTICE` when hour grain widens its plan.
+   `samples` is raw-only by definition, while `summary` includes a `source`
+   metric. `rollup_1h_flat` marks legacy/incomplete detail only when a
+   minute-capable plan must degrade to hour grain. When a request *cannot* be
+   answered (the event↔query tie needs raw samples but the window exceeds raw
+   retention), the reader raises a clear exception naming the boundary—never a
+   silent empty result.
 6. **Self-describing.** Every function carries a catalog `comment` stating the
    unit, the column contract, and the recommended next call, so an AI agent
    can navigate via `\df+` / `obj_description()` alone.
@@ -77,50 +76,74 @@ bucket          interval    default '1 minute'  -- sub-bucket grain for peak/p99
 
 `peak_aas` = max per-`bucket` AAS over the window; `p99_aas` =
 `percentile_cont(0.99)` over the same per-bucket AAS values, **zero-filled**
-for buckets with no activity within data coverage. Buckets with *no data*
-(sampler off) are excluded from percentiles and reported via coverage columns.
+for stored buckets with no matching activity. When retained grain is coarser
+than the requested `bucket`, both extrema are **NULL** rather than presenting
+an hour average as a minute peak/percentile. A missing stored row does not say
+why it is missing: `take_sample()` writes no row when no backend qualifies, so
+a sampled-idle minute and an uncovered minute are indistinguishable until
+sampling cadence/coverage is persisted by issue #137.
 
 ### 2.1 `ash.periods(until timestamptz default null)`
 
-One row per standard trailing window (1m, 5m, 1h, 1d, 1w, 1mo) ending at
-`until` (default `now()`). The zero-argument "start here" call.
+One row per standard trailing window (1m, 5m, 1h, 1d, 1w, 1mo) requested to
+end at `until` (default `now()`). The zero-argument "start here" call.
 
 Returns:
 `(period text, period_start timestamptz, period_end timestamptz, source text,
 bucket interval, buckets_with_data bigint, avg_aas numeric, peak_aas numeric,
 p99_aas numeric)`
 
-`buckets_with_data` (renamed from `minutes_with_data`, to match `aas()`) counts
-the covered buckets at the grain named by the new `bucket` column. Every
-unfiltered read is minute-grain after the `rollup_1h` seam fix, so `bucket` is
-always `'1 minute'` here — `43200 @ 1 minute` reads without cross-referencing.
+`period_start` / `period_end` are the effective returned bounds. They normally
+match the requested trailing window, but an hour-only plan snaps them outward,
+so `period_end` can be later than `until`. `buckets_with_data` (renamed from
+`minutes_with_data`, to match `aas()`) counts covered buckets at the effective
+grain named by `bucket`. Genuine `rollup_1h.minute_counts` keeps unfiltered
+reads at one minute. If a minute-capable plan encounters legacy/incomplete
+detail, the row reports `source = 'rollup_1h_flat'`, `bucket = '1 hour'`, and
+NULL sub-hour extrema instead of synthesizing 60 measured minutes.
 
 ### 2.2 `ash.aas(since, until, wait_event_type, wait_event, query_id, database, bucket)`
 
-Scalar load summary for one window, optionally filtered. This is also the
-US-4 "leaf summary": `ash.aas(wait_event => 'DataFileRead')` returns that
-event's avg/peak/p99.
+Scalar load summary for one effective window, optionally filtered. This is
+also the US-4 "leaf summary":
+`ash.aas(wait_event => 'DataFileRead')` returns that event's avg/peak/p99.
 
 Returns one row:
 `(period_start timestamptz, period_end timestamptz, source text,
+effective_bucket interval,
 buckets_expected bigint, buckets_with_data bigint,
 avg_aas numeric, peak_aas numeric, p99_aas numeric, backend_seconds numeric)`
 
 The per-`bucket` peak/p99 buckets are **calendar-aligned** (§2.3): floored to
-`bucket` on UTC/epoch boundaries, not anchored to `since`, so the same
-absolute window always yields the same buckets regardless of when the call runs.
+`bucket` on UTC/epoch boundaries, not anchored to `since`. `effective_bucket`
+reports the bucket actually used after retained-grain widening. A bucket that
+is not a whole multiple of retained grain is rounded **up** to the next
+multiple, so the effective bucket is never finer than the request. On
+`rollup_1h`, wait/query-filtered reads have only hour arrays; partial bounds
+snap outward to complete hours and are disclosed by `period_start` /
+`period_end`. Their average/backend seconds are exact for that disclosed
+effective window, while
+peak/p99 requested below one hour are NULL. Unfiltered/database-only reads use
+per-`(ts, datid)` `minute_counts` when valid. Legacy/incomplete detail reports
+`rollup_1h_flat` and follows the honest hour-grain behavior.
 
 ### 2.3 `ash.timeline(since, until, bucket interval default null, filters…)`
 
 Time series. `bucket => null` auto-selects grain by span (≤ 6 h → 1 minute,
 ≤ 7 d → 1 hour, else 1 day) and is always safely bounded. Emits a row for
-**every** bucket in the window: `data_points = 0` with null AAS marks
-"no data", distinguishing it from measured-zero load. When ranking buckets to
-find a spike, use `order by peak_aas desc nulls last` — no-data buckets carry
-null `peak_aas`, which sorts first under a bare `desc` and would hide the spike. An **explicit**
+**every** effective bucket in the window. `data_points = 0` with NULL AAS
+means there is no stored observation. It cannot distinguish sampled-idle from
+uncovered time because both states store no row; issue #137 tracks the
+coverage/cadence architecture needed to do that. When ranking buckets to find
+a spike, use `order by peak_aas desc nulls last` — no-observation buckets carry
+NULL `peak_aas`, which sorts first under a bare `desc` and would hide the spike. An **explicit**
 `bucket` that would emit more than 100 000 buckets (e.g. `'1 minute'` over a
 year) raises rather than materialize an unbounded result — pass `null` for
 auto-grain or a coarser bucket.
+
+An explicit bucket that is not a whole multiple of retained grain widens to
+the next multiple (for example, 90 seconds over minute data becomes 2
+minutes); it never rounds down to a finer bucket.
 
 **Calendar-aligned buckets.** `bucket_start` is floored to `bucket` on
 UTC/epoch boundaries — a 1-minute bucket starts on the minute, a 1-hour bucket
@@ -135,11 +158,14 @@ Returns:
 `(bucket_start timestamptz, source text, data_points bigint,
 avg_aas numeric, peak_aas numeric, p99_aas numeric)`
 
-`peak_aas` and `p99_aas` are **per-minute even on `rollup_1h`-backed windows**:
-`rollup_hour()` preserves per-minute totals in `rollup_1h.minute_counts`, so a
-long-window read keeps minute-grain extremes across the hourly seam (US-6). The
-only case that returns null `p99_aas` is a **wait/query-filtered**
-`rollup_1h`-backed bucket, where the surviving grain is the hour.
+`peak_aas` and `p99_aas` stay per-minute on a `rollup_1h`-backed window only
+when valid `minute_counts` preserves that detail. Wait/query-filtered reads and
+legacy/incomplete `rollup_1h_flat` reads have hour grain. Their partial bounds
+and sub-hour buckets widen outward to complete hours instead of falling
+through to unavailable `rollup_1m`; both extrema are NULL when the requested
+bucket is finer than that retained grain. `data_points` counts retained-grain
+rows contributing to the effective bucket (for example, about 60 minute rows
+in a covered one-hour bucket), not one-second samples.
 
 ### 2.4 `ash.top(dimension text, since, until, filters…, n int default 10, bucket, order_by text default 'avg')`
 
@@ -157,17 +183,21 @@ select * from ash.top('query_id', wait_event => 'DataFileRead');          -- US-
 
 Returns:
 `(key text, query_text text, source text,
+period_start timestamptz, period_end timestamptz, effective_bucket interval,
 avg_aas numeric, peak_aas numeric, p99_aas numeric,
 backend_seconds numeric, pct numeric)`
 
-- **Every row carries avg + peak + p99** (US-3). `pct` is the row's share of
-  the window's total AAS.
+- Every row carries exact avg/backend seconds and `pct`, plus effective bounds
+  and bucket. `peak_aas` / `p99_aas` are NULL when retained grain exceeds the
+  requested bucket.
 - **`order_by` ∈ `'avg' | 'peak' | 'p99'` (default `'avg'`)** picks the
   ranking metric applied **before** the `n` cut. This is how you surface a
   spiky-but-low-average row: `order_by => 'peak'` ranks by the per-bucket
   spike, so a query that spiked for one minute outranks steady background rows
-  that a mean would keep on top (the spike-first triage recipe). An unknown
-  value raises `ash.top: unknown order_by <v>; use avg|peak|p99`.
+  that a mean would keep on top (the spike-first triage recipe). If the
+  requested extreme is unavailable, ordering falls back to average/total
+  rather than ranking on an undisclosed hourly surrogate. An unknown value
+  raises `ash.top: unknown order_by <v>; use avg|peak|p99`.
 - `query_text` is non-null only for `dimension = 'query_id'` with
   pg_stat_statements present **and** a caller that can read other roles'
   pgss text — i.e. holding `pg_read_all_stats` (e.g. via `pg_monitor`
@@ -195,11 +225,12 @@ backend_seconds numeric, pct numeric)`
     the exact boundary to move to: *"…raw retention starts at `<ts>` but the
     requested window starts at `<ts>`. Narrow the window to start at or after
     `<ts>` … or drill without the query/event tie."*
-- On a `rollup_1h`-backed window (`source = rollup_1h`), each row's `peak_aas`
-  and `p99_aas` collapse to **hour** grain — the per-dimension arrays are stored
-  per hour, so a one-minute spike is averaged into its hour. For a minute-grain
-  peak over a long window use `ash.timeline()`, whose unfiltered `peak_aas` stays
-  per-minute across the `rollup_1h` seam (§2.3).
+- On a `rollup_1h`-backed window, wait/query dimensions and any database
+  breakdown carrying a wait/query filter have hour grain. Partial bounds snap
+  outward, and minute-requested extrema are NULL. Plain
+  `dimension = 'database'` is the exception: `minute_counts` is stored per
+  `(ts, datid)`, so it retains minute precision. Legacy/incomplete database
+  detail reports `rollup_1h_flat`.
 
 ### 2.5 `ash.compare(since_1, until_1, since_2, until_2, dimension text default null, n int default 10, filters…, bucket)`
 
@@ -208,7 +239,10 @@ dimension: top rows by `abs(avg_delta)` (full outer across the two windows —
 a wait/query present in only one window still appears).
 
 Returns:
-`(key text, query_text text,
+`(key text, query_text text, source_1 text, source_2 text,
+period_start_1 timestamptz, period_end_1 timestamptz,
+period_start_2 timestamptz, period_end_2 timestamptz,
+effective_bucket_1 interval, effective_bucket_2 interval,
 avg_aas_1 numeric, avg_aas_2 numeric, avg_delta numeric,
 peak_aas_1 numeric, peak_aas_2 numeric,
 p99_aas_1 numeric, p99_aas_2 numeric,
@@ -222,6 +256,13 @@ pct_1 numeric, pct_2 numeric)`
   the empty window and pointing at `ash.status()`. This is consistent across
   **both** modes: the overall row and every per-dimension row. Within a
   *covered* window, an absent key is a true zero.
+- **Grain visibility.** `source_1` / `source_2`, effective bounds, and
+  `effective_bucket_1` / `_2` are constant per window. If the two retained
+  read grains differ, both peak values and both p99 values are NULL as
+  incomparable—even when an explicit coarse request makes the two effective
+  bucket labels equal. Exact averages and `avg_delta` remain available.
+  Different physical sources can still be comparable—for example valid
+  `rollup_1h.minute_counts` and `rollup_1m` are both minute grain.
 - **Validation from `compare`'s own frame.** An unknown `dimension` raises
   `ash.compare: unknown dimension <v>; use wait_event_type|wait_event|query_id|database (or null for one overall row)` —
   named `ash.compare`, not `ash.top`.
@@ -377,7 +418,10 @@ pg_ash never uses it in computation.
   wait events **UNION any event that is top-1 in at least one bucket**, plus
   `Other` — so a single-bucket spike culprit always appears in the legend even
   if it never makes the window-wide top-N. Buckets are calendar-aligned exactly
-  like `ash.timeline()` (§2.3).
+  like `ash.timeline()` (§2.3). When only hour arrays can answer a partial
+  window, the chart snaps the bounds outward and the bucket up to hour grain,
+  then emits a `NOTICE` with the effective source, bounds, and bucket instead
+  of silently falling through to missing minute data.
 - `ash.summary(since, until)` — key/value overview (v1.x `activity_summary`,
   AAS units, plus top waits/queries), the human companion to `periods`.
 
@@ -398,12 +442,16 @@ function does any of that.
   `top('wait_event', query_id => …)`) and `samples` — force `raw`, because
   rollups don't preserve that association; past raw retention they raise (§1
   rule 5) rather than return empty.
-- Each reader reports the source it used in the `source` column
-  (`raw` | `rollup_1m` | `rollup_1h` | `none`). Scalar readers and `top` pick a
-  single source per result (never mixing — no double-counting); `timeline`
-  reports its source per bucket, so a long series may show different sources
-  across rows. A window with no data at all reports `source = 'none'`
-  uniformly across readers.
+- Typed aggregate readers report `source`
+  (`raw` | `rollup_1m` | `rollup_1h` | `rollup_1h_flat` | `none`);
+  `compare` reports `source_1` / `source_2`, `report` uses JSON coverage,
+  `summary` uses a key/value metric, `samples` is raw-only, and `chart`
+  discloses hour-grain widening by `NOTICE`. `rollup_1h_flat` is a
+  conservative window-level marker for a minute-capable plan: at least one
+  contributing legacy or incomplete hour lacks trustworthy minute detail.
+  Scalar readers and `top` pick a single source/effective grain per result
+  (never mixing grains under one undisclosed label). A typed aggregate window
+  with no data reports `source = 'none'`.
 - `ash.status()` gains rows for `raw_retention_start`,
   `rollup_1m_retention_start`, `rollup_1h_retention_start` so callers can
   plan windows before querying.
@@ -422,9 +470,9 @@ Unchanged from [AAS_USER_STORIES.md §6](AAS_USER_STORIES.md) except:
   → `query_id`, …). Positional calls are unaffected; only callers passing
   named arguments need to update. This is a breaking change for v1.x named-arg
   callers.
-- **Performance budgets:** rollup-backed reads < 100 ms for a 1-day window;
-  raw-backed reads (incl. `report` over 1 day and US-4 leaf drills
-  over 1 hour) < 1 s on a default-config instance.
+- **Performance budgets:** rollup-backed reads (including `report`) < 100 ms
+  for a 1-day window; raw-backed US-4 leaf drills over 1 hour < 1 s on a
+  default-config instance.
 
 ## 8. Removed in 2.0
 

--- a/blueprints/AAS_API.md
+++ b/blueprints/AAS_API.md
@@ -32,12 +32,12 @@ removed (see §8). Sampling, storage, rollups, and admin/lifecycle functions
    `timeline`, and `top` report it in `source`; `compare` reports
    `source_1` / `source_2`; `report` embeds it in `coverage.source`; and the
    presentation-only `chart` emits a `NOTICE` when hour grain widens its plan.
-   `samples` is raw-only by definition, while `summary` includes a `source`
-   metric. `rollup_1h_flat` marks legacy/incomplete detail only when a
-   minute-capable plan must degrade to hour grain. When a request *cannot* be
-   answered (the event↔query tie needs raw samples but the window exceeds raw
-   retention), the reader raises a clear exception naming the boundary—never a
-   silent empty result.
+   `samples` is raw-only by definition, while `summary` includes separate
+   headline and wait/query drill provenance metrics. `rollup_1h_flat` marks
+   legacy/incomplete detail only when a minute-capable plan must degrade to
+   hour grain. When a request *cannot* be answered (the event↔query tie needs
+   raw samples but the window exceeds raw retention), the reader raises a
+   clear exception naming the boundary — never a silent empty result.
 6. **Self-describing.** Every function carries a catalog `comment` stating the
    unit, the column contract, and the recommended next call, so an AI agent
    can navigate via `\df+` / `obj_description()` alone.
@@ -259,9 +259,9 @@ pct_1 numeric, pct_2 numeric)`
 - **Grain visibility.** `source_1` / `source_2`, effective bounds, and
   `effective_bucket_1` / `_2` are constant per window. If the two retained
   read grains differ, both peak values and both p99 values are NULL as
-  incomparable—even when an explicit coarse request makes the two effective
+  incomparable — even when an explicit coarse request makes the two effective
   bucket labels equal. Exact averages and `avg_delta` remain available.
-  Different physical sources can still be comparable—for example valid
+  Different physical sources can still be comparable — for example valid
   `rollup_1h.minute_counts` and `rollup_1m` are both minute grain.
 - **Validation from `compare`'s own frame.** An unknown `dimension` raises
   `ash.compare: unknown dimension <v>; use wait_event_type|wait_event|query_id|database (or null for one overall row)` —
@@ -424,6 +424,12 @@ pg_ash never uses it in computation.
   of silently falling through to missing minute data.
 - `ash.summary(since, until)` — key/value overview (v1.x `activity_summary`,
   AAS units, plus top waits/queries), the human companion to `periods`.
+  `period_start` / `period_end` / `source` describe the headline `aas()` plan;
+  `drill_period_start` / `drill_period_end` / `drill_source` /
+  `drill_effective_bucket` separately describe the shared wait/query `top()`
+  plan. On `rollup_1h`, the headline can retain an exact partial-hour window
+  through `minute_counts` while the dimensional drills honestly widen to
+  complete hours.
 
 Both are presentation-only: they may format, color, truncate. No data
 function does any of that.
@@ -445,13 +451,16 @@ function does any of that.
 - Typed aggregate readers report `source`
   (`raw` | `rollup_1m` | `rollup_1h` | `rollup_1h_flat` | `none`);
   `compare` reports `source_1` / `source_2`, `report` uses JSON coverage,
-  `summary` uses a key/value metric, `samples` is raw-only, and `chart`
-  discloses hour-grain widening by `NOTICE`. `rollup_1h_flat` is a
+  `summary` uses separate headline and drill key/value provenance,
+  `samples` is raw-only, and `chart` discloses hour-grain widening by
+  `NOTICE`. `rollup_1h_flat` is a
   conservative window-level marker for a minute-capable plan: at least one
   contributing legacy or incomplete hour lacks trustworthy minute detail.
   Scalar readers and `top` pick a single source/effective grain per result
   (never mixing grains under one undisclosed label). A typed aggregate window
-  with no data reports `source = 'none'`.
+  with no covered rows keeps its planned source and reports
+  `buckets_with_data = 0`; `source = 'none'` means all aggregate source tables
+  are globally empty, not merely that this particular window is uncovered.
 - `ash.status()` gains rows for `raw_retention_start`,
   `rollup_1m_retention_start`, `rollup_1h_retention_start` so callers can
   plan windows before querying.

--- a/blueprints/AAS_EXAMPLES.md
+++ b/blueprints/AAS_EXAMPLES.md
@@ -16,7 +16,9 @@ Conventions that repeat below, stated once:
 - v1.5 units vary by function — `samples` (raw readers), `backend_seconds`
   (rollup readers), active sessions (chart only). 2.0 always answers in AAS
   (`avg_aas` / `peak_aas` / `p99_aas`), with `backend_seconds` as a secondary
-  column and a `source` column showing where the data came from.
+  column. Typed aggregate readers expose source columns; `report`, `summary`,
+  `samples`, and `chart` disclose provenance in the forms documented in
+  [AAS_API.md](AAS_API.md).
 
 ---
 
@@ -47,21 +49,24 @@ columns, p99 so a spike is legible without a second call:
 select * from ash.periods();
 ```
 ```
- period | period_start        | source    | bucket   | buckets_with_data | avg_aas | peak_aas | p99_aas
---------+---------------------+-----------+----------+-------------------+---------+----------+---------
- 1m     | 2026-07-04 14:44:00 | raw       | 00:01:00 |                 1 |    2.9  |     3.4  |    3.4
- 5m     | 2026-07-04 14:40:00 | raw       | 00:01:00 |                 5 |    3.1  |     4.0  |    3.9
- 1h     | 2026-07-04 13:45:00 | rollup_1m | 00:01:00 |                60 |    3.2  |    41.0  |   12.7
- 1d     | 2026-07-03 14:45:00 | rollup_1m | 00:01:00 |              1440 |    2.8  |    41.0  |    6.3
- 1w     | 2026-06-27 14:45:00 | rollup_1h | 00:01:00 |             10080 |    2.6  |    41.0  |    5.9
- 1mo    | 2026-06-04 14:45:00 | rollup_1h | 00:01:00 |             43200 |    2.5  |    41.0  |    5.7
+ period | period_start        | period_end          | source    | bucket   | buckets_with_data | avg_aas | peak_aas | p99_aas
+--------+---------------------+---------------------+-----------+----------+-------------------+---------+----------+---------
+ 1m     | 2026-07-04 14:44:00 | 2026-07-04 14:45:00 | raw       | 00:01:00 |                 1 |    2.9  |     3.4  |    3.4
+ 5m     | 2026-07-04 14:40:00 | 2026-07-04 14:45:00 | raw       | 00:01:00 |                 5 |    3.1  |     4.0  |    3.9
+ 1h     | 2026-07-04 13:45:00 | 2026-07-04 14:45:00 | rollup_1m | 00:01:00 |                60 |    3.2  |    41.0  |   12.7
+ 1d     | 2026-07-03 14:45:00 | 2026-07-04 14:45:00 | rollup_1m | 00:01:00 |              1440 |    2.8  |    41.0  |    6.3
+ 1w     | 2026-06-27 14:45:00 | 2026-07-04 14:45:00 | rollup_1h | 00:01:00 |             10080 |    2.6  |    41.0  |    5.9
+ 1mo    | 2026-06-04 14:45:00 | 2026-07-04 14:45:00 | rollup_1h | 00:01:00 |             43200 |    2.5  |    41.0  |    5.7
 ```
 
 Reading: the last hour peaked at 41 while the average is 3.2 — a spike, not a
 sustained shift. (`ash.summary()` renders the same picture for humans.) The
 `buckets_with_data` column (renamed from `minutes_with_data`) counts covered
-buckets at the grain named by `bucket` — always `1 minute` post-`rollup_1h`
-seam fix, so `43200` reads as `43200 @ 1 minute`.
+buckets at the effective grain named by `bucket`. Valid `minute_counts` keeps
+one-minute grain; a legacy/incomplete hour reports `rollup_1h_flat` and an
+hour bucket instead of synthetic minute observations. `period_start` /
+`period_end` are effective bounds, so an hour-only row can snap outward and
+end after the requested `until`.
 
 ## 2. Locate
 
@@ -86,17 +91,21 @@ select * from ash.wait_timeline('30 minutes', '5 minutes');
 no-data rows:
 
 ```sql
-select * from ash.timeline(since => '2026-07-04 14:15', until => '2026-07-04 14:45');
+select * from ash.timeline(
+  since => '2026-07-04 14:15',
+  until => '2026-07-04 14:45',
+  bucket => interval '5 minutes'
+);
 ```
 ```
     bucket_start     | source | data_points | avg_aas | peak_aas | p99_aas
 ---------------------+--------+-------------+---------+----------+---------
- 2026-07-04 14:15:00 | raw    |         300 |    2.7  |     3.6  |    3.5
- 2026-07-04 14:20:00 | raw    |         300 |    2.9  |     4.1  |    4.0
- 2026-07-04 14:25:00 | raw    |           0 |         |          |          -- sampler was off: no data ≠ zero
- 2026-07-04 14:30:00 | raw    |         300 |   24.8  |    41.0  |   39.2   -- ← the spike
- 2026-07-04 14:35:00 | raw    |         300 |    6.1  |    11.4  |   10.9
- 2026-07-04 14:40:00 | raw    |         300 |    3.0  |     3.8  |    3.7
+ 2026-07-04 14:15:00 | raw    |           5 |    2.7  |     3.6  |    3.5
+ 2026-07-04 14:20:00 | raw    |           5 |    2.9  |     4.1  |    4.0
+ 2026-07-04 14:25:00 | raw    |           0 |         |          |          -- no stored observation; idle vs uncovered needs #137
+ 2026-07-04 14:30:00 | raw    |           5 |   24.8  |    41.0  |   39.2   -- ← the spike
+ 2026-07-04 14:35:00 | raw    |           5 |    6.1  |    11.4  |   10.9
+ 2026-07-04 14:40:00 | raw    |           5 |    3.0  |     3.8  |    3.7
 ```
 
 `bucket_start` labels are **calendar-aligned** (floored to `bucket` on
@@ -128,8 +137,17 @@ select * from ash.top_by_type('15 minutes');
 **After** — same drill, AAS + peak + p99 per row (a spiky class is
 distinguishable from a steadily-busy one), no presentation columns:
 
+The projection keeps the tables readable; `select *` additionally returns
+`period_start`, `period_end`, and `effective_bucket`.
+
 ```sql
-select * from ash.top('wait_event_type', since => '2026-07-04 14:30', until => '2026-07-04 14:45');
+select key, query_text, source, avg_aas, peak_aas, p99_aas,
+       backend_seconds, pct
+from ash.top(
+  'wait_event_type',
+  since => '2026-07-04 14:30',
+  until => '2026-07-04 14:45'
+);
 ```
 ```
  key    | query_text | source | avg_aas | peak_aas | p99_aas | backend_seconds |  pct
@@ -159,8 +177,14 @@ select * from ash.top_waits('15 minutes', 5);
 separate function:
 
 ```sql
-select * from ash.top('wait_event', wait_event_type => 'IO',
-                      since => '2026-07-04 14:30', until => '2026-07-04 14:45');
+select key, query_text, source, avg_aas, peak_aas, p99_aas,
+       backend_seconds, pct
+from ash.top(
+  'wait_event',
+  wait_event_type => 'IO',
+  since => '2026-07-04 14:30',
+  until => '2026-07-04 14:45'
+);
 ```
 ```
  key              | query_text | source | avg_aas | peak_aas | p99_aas | backend_seconds |  pct
@@ -189,7 +213,14 @@ select * from ash.top_queries('15 minutes', 3);
 **After:**
 
 ```sql
-select * from ash.top('query_id', since => '2026-07-04 14:30', until => '2026-07-04 14:45', n => 3);
+select key, query_text, source, avg_aas, peak_aas, p99_aas,
+       backend_seconds, pct
+from ash.top(
+  'query_id',
+  since => '2026-07-04 14:30',
+  until => '2026-07-04 14:45',
+  n => 3
+);
 ```
 ```
        key         |            query_text             | source | avg_aas | peak_aas | p99_aas | backend_seconds |  pct
@@ -221,8 +252,14 @@ select * from ash.query_waits(8231004856741017, '15 minutes');
 **After:**
 
 ```sql
-select * from ash.top('wait_event', query_id => 8231004856741017,
-                      since => '2026-07-04 14:30', until => '2026-07-04 14:45');
+select key, query_text, source, avg_aas, peak_aas, p99_aas,
+       backend_seconds, pct
+from ash.top(
+  'wait_event',
+  query_id => 8231004856741017,
+  since => '2026-07-04 14:30',
+  until => '2026-07-04 14:45'
+);
 ```
 
 Same shape as every other `top()` call — `avg_aas 11.2, peak_aas 26.0, p99_aas 24.9` for `IO:DataFileRead`, etc.
@@ -313,8 +350,8 @@ select * from ash.timeline(since => now() - interval '7 days');  -- auto: 1-hour
 ```
     bucket_start     |  source   | data_points | avg_aas | peak_aas | p99_aas
 ---------------------+-----------+-------------+---------+----------+---------
- 2026-06-28 00:00:00 | rollup_1h |        3600 |    2.1  |     4.0  |
- 2026-06-28 01:00:00 | rollup_1h |        3600 |    2.3  |     5.0  |
+ 2026-06-28 00:00:00 | rollup_1h |          60 |    2.1  |     4.0  |    3.8
+ 2026-06-28 01:00:00 | rollup_1h |          60 |    2.3  |     5.0  |    4.6
  …
 ```
 
@@ -324,7 +361,9 @@ same query ranking, over rollups, in AAS.
 ### `samples_by_database(...)` → `ash.top('database', …)`
 
 ```sql
-select * from ash.top('database', since => now() - interval '1 hour');
+select key, query_text, source, avg_aas, peak_aas, p99_aas,
+       backend_seconds, pct
+from ash.top('database', since => now() - interval '1 hour');
 ```
 ```
    key    | query_text | source    | avg_aas | peak_aas | p99_aas | backend_seconds |  pct
@@ -351,24 +390,31 @@ select * from ash.samples(n => 3, wait_event => 'DataFileRead');
 select * from ash.aas();   -- the last hour, one row
 ```
 ```
-    period_start     |      period_end      | source    | buckets_expected | buckets_with_data | avg_aas | peak_aas | p99_aas | backend_seconds
----------------------+----------------------+-----------+------------------+-------------------+---------+----------+---------+-----------------
- 2026-07-04 13:45:00 | 2026-07-04 14:45:00  | rollup_1m |               60 |                59 |    3.2  |    41.0  |   12.7  |           11520
+    period_start     |      period_end      | source    | effective_bucket | buckets_expected | buckets_with_data | avg_aas | peak_aas | p99_aas | backend_seconds
+---------------------+----------------------+-----------+------------------+------------------+-------------------+---------+----------+---------+-----------------
+ 2026-07-04 13:45:00 | 2026-07-04 14:45:00  | rollup_1m | 00:01:00         |               60 |                59 |    3.2  |    41.0  |   12.7  |           11520
 ```
 
 ### `ash.compare()` — before/after a deploy
 
 ```sql
-select * from ash.compare(since_1 => '2026-07-04 14:00', until_1 => '2026-07-04 14:30',    -- baseline
-                          since_2 => '2026-07-04 14:30', until_2 => '2026-07-04 15:00',    -- after deploy
-                          dimension => 'wait_event');
+select key, source_1, source_2, effective_bucket_1, effective_bucket_2,
+       avg_aas_1, avg_aas_2, avg_delta,
+       peak_aas_1, peak_aas_2, p99_aas_1, p99_aas_2, pct_1, pct_2
+from ash.compare(
+  since_1 => '2026-07-04 14:00',
+  until_1 => '2026-07-04 14:30',    -- baseline
+  since_2 => '2026-07-04 14:30',
+  until_2 => '2026-07-04 15:00',    -- after deploy
+  dimension => 'wait_event'
+);
 ```
 ```
-        key         | avg_aas_1 | avg_aas_2 | avg_delta | peak_aas_1 | peak_aas_2 | p99_aas_1 | p99_aas_2 | pct_1 | pct_2
---------------------+-----------+-----------+-----------+------------+------------+-----------+-----------+-------+-------
- IO:DataFileRead    |      1.1  |     14.0  |    +12.9  |       2.0  |      31.0  |      1.9  |     29.8  |  34.4 |  55.4
- Lock:transactionid |      0.2  |      4.6  |     +4.4  |       1.0  |      12.0  |      0.9  |     11.2  |   6.3 |  18.4
- CPU*               |      1.7  |      3.8  |     +2.1  |       3.0  |       6.0  |      2.8  |      5.7  |  53.1 |  14.9
+        key         | source_1   | source_2   | effective_bucket_1 | effective_bucket_2 | avg_aas_1 | avg_aas_2 | avg_delta | peak_aas_1 | peak_aas_2 | p99_aas_1 | p99_aas_2 | pct_1 | pct_2
+--------------------+------------+------------+--------------------+--------------------+-----------+-----------+-----------+------------+------------+-----------+-----------+-------+-------
+ IO:DataFileRead    | rollup_1m  | rollup_1m  | 00:01:00           | 00:01:00           |      1.1  |     14.0  |    +12.9  |       2.0  |      31.0  |      1.9  |     29.8  |  34.4 |  55.4
+ Lock:transactionid | rollup_1m  | rollup_1m  | 00:01:00           | 00:01:00           |      0.2  |      4.6  |     +4.4  |       1.0  |      12.0  |      0.9  |     11.2  |   6.3 |  18.4
+ CPU*               | rollup_1m  | rollup_1m  | 00:01:00           | 00:01:00           |      1.7  |      3.8  |     +2.1  |       3.0  |       6.0  |      2.8  |      5.7  |  53.1 |  14.9
 ```
 
 ### `ash.report()` — one JSON load report per period (machine ingest)
@@ -461,9 +507,12 @@ select * from ash.timeline(since => now() - interval '6 hours') order by peak_aa
 
 ### (c) Recurring peak hours (capacity / US-6)
 
-`rollup_1h.minute_counts` preserves per-minute extremes across the hourly seam,
-so `peak_aas` stays honest over weeks. Group hourly buckets by hour-of-day to
-find the recurring hot hours:
+Valid `rollup_1h.minute_counts` preserves per-minute extremes across the
+hourly seam, so `peak_aas` stays honest over weeks. Legacy/incomplete flat
+hours return NULL extremes only when the requested bucket is below their
+retained one-hour grain; an explicit one-hour bucket can report honest
+hour-level extrema. Group supported hourly buckets by hour-of-day to find the
+recurring hot hours:
 
 ```sql
 select extract(hour from bucket_start) as hod, max(peak_aas) as peak

--- a/blueprints/AAS_EXAMPLES.md
+++ b/blueprints/AAS_EXAMPLES.md
@@ -18,7 +18,9 @@ Conventions that repeat below, stated once:
   (`avg_aas` / `peak_aas` / `p99_aas`), with `backend_seconds` as a secondary
   column. Typed aggregate readers expose source columns; `report`, `summary`,
   `samples`, and `chart` disclose provenance in the forms documented in
-  [AAS_API.md](AAS_API.md).
+  [AAS_API.md](AAS_API.md). `summary` uses separate headline and wait/query
+  drill source/bounds metrics because the two plans can have different
+  effective windows.
 
 ---
 
@@ -60,7 +62,9 @@ select * from ash.periods();
 ```
 
 Reading: the last hour peaked at 41 while the average is 3.2 — a spike, not a
-sustained shift. (`ash.summary()` renders the same picture for humans.) The
+sustained shift. (`ash.summary()` renders the same picture for humans and
+labels a widened wait/query plan with `drill_source`, `drill_period_start`,
+`drill_period_end`, and `drill_effective_bucket`.) The
 `buckets_with_data` column (renamed from `minutes_with_data`) counts covered
 buckets at the effective grain named by `bucket`. Valid `minute_counts` keeps
 one-minute grain; a legacy/incomplete hour reports `rollup_1h_flat` and an

--- a/blueprints/AAS_USER_STORIES.md
+++ b/blueprints/AAS_USER_STORIES.md
@@ -133,8 +133,9 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   5. Callable by the least-privilege reader role, and degrades gracefully when pg_stat_statements is absent.
 - **Primary API:** cross-cutting across the whole family.
 - **Coverage:** ✅ Covered by design — typed aggregate readers expose `source`
-  fields, while `report` uses JSON coverage, `summary` a metric, `chart` a
-  planning `NOTICE`, and `samples` is raw-only; retention rows live in
+  fields, while `report` uses JSON coverage, `summary` has separate headline
+  and wait/query drill provenance metrics, `chart` a planning `NOTICE`, and
+  `samples` is raw-only; retention rows live in
   `ash.status()`, with a raise-don't-return-empty rule for unanswerable drills
   ([AAS_API.md §5–§6](AAS_API.md)).
 - **Drivable from the catalog alone.** pg_ash self-documents in-DB, which is what

--- a/blueprints/AAS_USER_STORIES.md
+++ b/blueprints/AAS_USER_STORIES.md
@@ -78,7 +78,8 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   1. Returns one row per time bucket (bucket size configurable).
   2. Includes `peak_aas` per bucket (not just `avg_aas`), so short spikes are not averaged away; orderable by peak to surface the worst buckets.
   3. Auto-selects rollup granularity by span — per-minute for short spans, per-hour for long spans — and reaches back across the relevant rollup retention.
-  4. Distinguishes "no data" buckets from "zero load" buckets.
+  4. Marks buckets with no stored observation; sampled-idle and uncovered
+     time remain indistinguishable until issue #137 persists cadence/coverage.
 - **Primary API:** `ash.timeline(since, until, bucket)`.
 - **Coverage:** ✅ Covered by design ([AAS_API.md §2.3](AAS_API.md)); adds per-bucket `p99_aas` and explicit no-data rows.
 
@@ -131,7 +132,11 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   4. Self-describing catalog comments (`obj_description`) covering the term, the columns, and the recommended next call.
   5. Callable by the least-privilege reader role, and degrades gracefully when pg_stat_statements is absent.
 - **Primary API:** cross-cutting across the whole family.
-- **Coverage:** ✅ Covered by design — `source` column on every reader, retention rows in `ash.status()`, and the raise-don't-return-empty rule for unanswerable drills ([AAS_API.md §5–§6](AAS_API.md)).
+- **Coverage:** ✅ Covered by design — typed aggregate readers expose `source`
+  fields, while `report` uses JSON coverage, `summary` a metric, `chart` a
+  planning `NOTICE`, and `samples` is raw-only; retention rows live in
+  `ash.status()`, with a raise-don't-return-empty rule for unanswerable drills
+  ([AAS_API.md §5–§6](AAS_API.md)).
 - **Drivable from the catalog alone.** pg_ash self-documents in-DB, which is what
   lets an agent navigate it without external docs: `COMMENT ON SCHEMA ash` names
   the reader entry points and the reader-vs-ops split, and **every** function —
@@ -154,7 +159,10 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   2. Per-bucket `peak_aas` (and ideally `p99_aas`) preserved at hour/day grain.
   3. Works to the limit of `rollup_1h` retention and signals that horizon.
 - **Primary API:** `ash.timeline` over long spans.
-- **Coverage:** ✅ Covered — auto `rollup_1h` selection; `rollup_1h.minute_counts` preserves per-minute totals, so unfiltered/database-filtered long windows report exact minute-grain `peak_aas` and non-null `p99_aas` (seam-consistent with `rollup_1m`); `p99_aas` is null only for wait/query-filtered `rollup_1h`-backed buckets (hour grain).
+- **Coverage:** ✅ Covered — auto `rollup_1h` selection; valid
+  `rollup_1h.minute_counts` preserves unfiltered/database-only minute totals.
+  Wait/query dimensions and legacy/incomplete `rollup_1h_flat` data retain
+  hour grain and NULL extrema requested below that grain.
 
 ### US-7 — Before/after comparison
 
@@ -196,7 +204,7 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
 | US-2 Locate | `timeline` | ✅ | — |
 | US-3 Drill | `top(dimension, filters…)` | ✅ | — |
 | US-4 Leaf | `aas(event…)` + `top('query_id', event…)` | ✅ | — |
-| US-5 Programmatic | whole family (`source` column, retention in `status()`) | ✅ | — |
+| US-5 Programmatic | whole family (explicit provenance, retention in `status()`) | ✅ | — |
 | US-6 Capacity | `timeline` (long span) | ✅ | — |
 | US-7 Before/after | `compare` | ✅ | — |
 | US-8 Load report | `report` | ✅ | — |
@@ -210,7 +218,10 @@ These apply to every story above.
 
 - **Unit consistency.** AAS is the primary unit (`avg_aas` / `peak_aas` / `p99_aas`); `backend_seconds` may appear as a secondary column. No third unit.
 - **Percentile definition.** `p99_aas` = the 99th percentile of per-sub-bucket AAS. The sub-bucket grain is a parameter (default `'1 minute'`). `peak_aas` is the max over the same sub-buckets.
-- **Raw-vs-rollup honesty (trust property).** Any reader auto-selects its source by window; when a requested drill or window cannot be answered (rollup can't tie event→query; window exceeds retention), it signals this explicitly rather than returning a silent empty/partial result.
+- **Raw-vs-rollup honesty (trust property).** Aggregate readers select or
+  declare their source by window; when a requested drill or window cannot be
+  answered (rollup can't tie event→query; window exceeds retention), it signals
+  this explicitly rather than returning a silent empty/partial result.
 - **Time addressing convention (2.0).** Every reader takes `since timestamptz default null` (→ `now() - '1 hour'`) and `until timestamptz default null` (→ `now()`). The v1.x `f(p_interval)` / `f_at(p_start, p_end)` twin convention is dropped — 2.0 breaks compat, and the single convention halves the surface. ([AAS_API.md §1](AAS_API.md))
 - **Naming.** Function and column names use full domain terms — no abbreviations in user-facing names. Drill dimensions and filters spell out `wait_event_type` / `wait_event` / `query_id` / `database`, as the `dimension` values and parameter names of `top`. The on-CPU class is spelled `CPU*` — the asterisk marks "on CPU *or* uninstrumented wait" and must not be dropped.
 - **Dual audience.** Data functions are typed and presentation-free; ASCII bars/charts live only in dedicated rendering helpers.

--- a/blueprints/SPEC.md
+++ b/blueprints/SPEC.md
@@ -466,8 +466,9 @@ Row count depends only on sampling frequency, not backend count. Size scales wit
 - Respect config flag: `include_bg_workers`
 - Store `active_count` per row — total sampled backends for this datid+tick
 - **No row for zero activity:** If a database has zero matching backends in a
-  tick, no row is emitted. Gaps in the time series for a specific `datid` mean
-  "no active or idle-in-transaction sessions during those ticks" — not data loss.
+  tick, no row is emitted. The stored state therefore cannot distinguish an
+  observed idle tick from missing sampler coverage; issue #137 tracks
+  persistent cadence/coverage.
 - Performance: select only needed columns, filter early on `state` and
   `backend_type` to minimize shared memory reads
 - **Error handling:** Per-row `BEGIN ... EXCEPTION WHEN OTHERS` around

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -198,6 +198,7 @@ begin
         'rollup_minute',
         '_color_on', '_wait_color', '_reset', '_bar',
         '_pick_source', '_pick_source_agg', '_raise_tie_retention',
+        '_minute_counts_valid', '_rollup_1h_has_flat',
         '_grain_counts', '_grain_by',
         'timeline', 'compare', '_pgss_query_text',
         '_hr_top_events', '_hr_top_queryids',
@@ -3037,12 +3038,11 @@ create table if not exists ash.rollup_1h (
   minute_counts   int4[],            -- 60-slot per-minute total activity counts:
                                      -- element i = sum of wait_counts counts of the
                                      -- rollup_1m row at ts + (i-1)*60; NULL element =
-                                     -- no rollup_1m row for that minute. Preserves the
-                                     -- true minute-grain AAS distribution so long
-                                     -- (rollup_1h-backed) windows report the exact
-                                     -- per-minute peak_aas / p99_aas. NULL column =
-                                     -- legacy pre-2.0 row (readers fall back to the
-                                     -- flat hour average for such hours).
+                                     -- no stored rollup_1m row for that minute.
+                                     -- A valid array preserves minute-grain totals.
+                                     -- NULL/invalid column = legacy or incomplete
+                                     -- detail; readers use one disclosed hour-grain
+                                     -- datum instead of synthesizing 60 observations.
   primary key (ts, datid)
 );
 
@@ -3051,31 +3051,88 @@ alter table ash.rollup_1h
   add column if not exists minute_counts int4[];
 
 /*
+ * A minute_counts array is usable only when all 60 slots are represented and
+ * its non-NULL elements preserve the exact hourly activity total. NULL slots
+ * can be legitimate because the storage model writes no row for both an idle
+ * minute and an uncovered minute (#137); equality, not physical row count, is
+ * the strongest invariant the stored data can prove.
+ */
+create or replace function ash._minute_counts_valid(
+  minute_counts int4[],
+  wait_counts int4[]
+)
+returns boolean
+language sql
+immutable
+set search_path = pg_catalog, ash
+as $$
+  select coalesce(
+    cardinality(minute_counts) = 60
+    and (
+      select coalesce(sum(minute_count), 0)
+      from unnest(minute_counts) as minute_count
+    ) = (
+      select coalesce(sum(wait_counts[pos + 1]), 0)
+      from generate_subscripts(wait_counts, 1) as pos
+      where pos % 2 = 1
+    ),
+    false
+  )
+$$;
+
+/*
  * Upgrade backfill: reconstruct minute_counts for legacy rollup_1h rows whose
  * hour is still covered by rollup_1m (per-minute detail survives there for
- * rollup_1m_retention_days). Older hours keep minute_counts NULL and readers
- * fall back to the flat hour average — a lower bound, never a wrong spike.
- * Idempotent: only touches rows where minute_counts is still NULL.
+ * rollup_1m_retention_days). A candidate is accepted only when it preserves
+ * the hourly total. Older hours and partial candidates that fail that
+ * invariant keep minute_counts NULL and readers disclose hour grain. Re-apply
+ * also repairs partial arrays written by earlier 2.0 beta installers.
  */
 update ash.rollup_1h as rollup_hour
-set minute_counts = (
-  select array_agg(minute_total.total order by minute_series.idx)
-  from generate_series(0, 59) as minute_series(idx)
-  left join lateral (
-    select (select coalesce(sum(rollup_min.wait_counts[sub + 1]), 0)::int4
-            from generate_subscripts(rollup_min.wait_counts, 1) as sub
-            where sub % 2 = 1) as total
-    from ash.rollup_1m as rollup_min
-    where rollup_min.datid = rollup_hour.datid
-      and rollup_min.ts = rollup_hour.ts + minute_series.idx * 60
-  ) as minute_total on true
+set minute_counts = null
+where rollup_hour.minute_counts is not null
+  and not ash._minute_counts_valid(
+    rollup_hour.minute_counts,
+    rollup_hour.wait_counts
+  );
+
+with candidates as (
+  select
+    rollup_hour.ts,
+    rollup_hour.datid,
+    rollup_hour.wait_counts,
+    (
+      select array_agg(minute_total.total order by minute_series.idx)
+      from generate_series(0, 59) as minute_series(idx)
+      left join lateral (
+        select (
+          select coalesce(sum(rollup_min.wait_counts[sub + 1]), 0)::int4
+          from generate_subscripts(rollup_min.wait_counts, 1) as sub
+          where sub % 2 = 1
+        ) as total
+        from ash.rollup_1m as rollup_min
+        where rollup_min.datid = rollup_hour.datid
+          and rollup_min.ts = rollup_hour.ts + minute_series.idx * 60
+      ) as minute_total on true
+    ) as minute_counts
+  from ash.rollup_1h as rollup_hour
+  where rollup_hour.minute_counts is null
+    and exists (
+      select
+      from ash.rollup_1m as rollup_min
+      where rollup_min.datid = rollup_hour.datid
+        and rollup_min.ts >= rollup_hour.ts
+        and rollup_min.ts < rollup_hour.ts + 3600
+    )
 )
-where rollup_hour.minute_counts is null
-  and exists (
-    select from ash.rollup_1m as rollup_min
-    where rollup_min.datid = rollup_hour.datid
-      and rollup_min.ts >= rollup_hour.ts
-      and rollup_min.ts < rollup_hour.ts + 3600
+update ash.rollup_1h as rollup_hour
+set minute_counts = candidates.minute_counts
+from candidates
+where rollup_hour.ts = candidates.ts
+  and rollup_hour.datid = candidates.datid
+  and ash._minute_counts_valid(
+    candidates.minute_counts,
+    candidates.wait_counts
   );
 
 /*
@@ -3805,12 +3862,12 @@ $$;
 /*
  * The minimal AAS surface (issue #113, blueprints/AAS_API.md): seven data
  * functions (periods, aas, timeline, top, compare, samples, report) and two
- * render helpers (chart, summary). AAS = Average Active Sessions. Every reader
- * auto-selects its data source by window (raw -> rollup_1m -> rollup_1h),
- * reports it in a `source` column, and raises rather than returning a silent
- * empty result when a wait<->query drill exceeds raw retention. Internal
- * workhorses (_grain_counts / _grain_by) and the retention helpers back the
- * whole family.
+ * render helpers (chart, summary). AAS = Average Active Sessions. Aggregate
+ * readers auto-select raw -> rollup_1m -> rollup_1h; typed readers expose a
+ * source column, compare exposes both sources, report embeds provenance in
+ * JSON, and chart emits a planning NOTICE when hour grain widens its request.
+ * Unanswerable wait<->query drills raise past raw retention. Internal
+ * workhorses (_grain_counts / _grain_by) and retention helpers back the family.
  */
 
 /*
@@ -3877,6 +3934,39 @@ stable
 set search_path = pg_catalog, ash
 as $$
   select ash.ts_to_timestamptz(min(ts)) from ash.rollup_1h
+$$;
+
+/*
+ * True when a rollup_1h window overlaps legacy or incomplete minute detail.
+ * Minute-capable readers then conservatively use hour grain for the whole
+ * window and publish source = rollup_1h_flat.
+ */
+create or replace function ash._rollup_1h_has_flat(
+  start_ts int4,
+  end_ts int4,
+  database name default null
+)
+returns boolean
+language sql
+stable
+set search_path = pg_catalog, ash
+as $$
+  select exists (
+    select
+    from ash.rollup_1h as rollup_hour
+    left join pg_database as db
+      on db.oid = rollup_hour.datid
+    where rollup_hour.ts::bigint < end_ts::bigint
+      and rollup_hour.ts::bigint + 3600 > start_ts::bigint
+      and (
+        _rollup_1h_has_flat.database is null
+        or db.datname = _rollup_1h_has_flat.database
+      )
+      and not ash._minute_counts_valid(
+        rollup_hour.minute_counts,
+        rollup_hour.wait_counts
+      )
+  )
 $$;
 
 /*
@@ -4019,8 +4109,9 @@ $$;
  * 'raw' supports the wait<->query tie (both a wait filter and query_id);
  * the rollup sources cannot and must not be asked for it (caller routes such
  * requests to 'raw'). grain_secs is 60 (raw / rollup_1m / rollup_1h_minutes)
- * or 3600 (rollup_1h). 'rollup_1h_minutes' is the internal minute-grain view
- * of rollup_1h (unfiltered / database-filtered only) via minute_counts.
+ * or 3600 (rollup_1h and legacy/incomplete rollup_1h detail).
+ * 'rollup_1h_minutes' is the internal minute-capable view used for
+ * unfiltered/database-only totals; invalid detail emits one hourly row.
  */
 create or replace function ash._grain_counts(
   start_ts int4,
@@ -4115,10 +4206,9 @@ begin
      * arrays, so peak_aas / p99_aas survive the rollup_1m -> rollup_1h seam
      * (same values a rollup_1m read of the window would produce). Totals only:
      * wait/query filters need the hour-grain arrays, so callers route filtered
-     * reads to 'rollup_1h'. Legacy pre-2.0 rows (minute_counts is null)
-     * flatten to their hour average per covered minute — a lower bound for the
-     * peak and an "hour was flat" assumption for percentiles, never an
-     * invented spike.
+     * reads to 'rollup_1h'. Legacy/incomplete arrays emit one exact hourly
+     * datum: callers detect that case up front, normalize the whole window to
+     * hour grain, and publish source = rollup_1h_flat.
      */
     if wait_event_type is not null or wait_event is not null
        or query_id is not null then
@@ -4128,31 +4218,36 @@ begin
     return query
     with hours as (
       select rollup_hour.ts, rollup_hour.datid,
-             rollup_hour.minute_counts, rollup_hour.wait_counts
+             rollup_hour.minute_counts, rollup_hour.wait_counts,
+             ash._minute_counts_valid(
+               rollup_hour.minute_counts,
+               rollup_hour.wait_counts
+             ) as has_minutes
       from ash.rollup_1h as rollup_hour
       where rollup_hour.ts >= start_ts - 3540 and rollup_hour.ts < end_ts
         and (v_datid is null or rollup_hour.datid = v_datid)
     ),
     mins as (
       select (hours.ts + (minute_elem.idx - 1) * 60)::int4 as mts,
-             minute_elem.mc::numeric as cnt
+             minute_elem.mc::numeric as cnt,
+             60::int4 as grain_secs
       from hours
       cross join lateral unnest(hours.minute_counts)
         with ordinality as minute_elem(mc, idx)
-      where hours.minute_counts is not null and minute_elem.mc is not null
+      where hours.has_minutes and minute_elem.mc is not null
       union all
-      select (hours.ts + minute_series.idx * 60)::int4,
+      select hours.ts,
              (select coalesce(sum(hours.wait_counts[pos + 1]), 0)
               from generate_subscripts(hours.wait_counts, 1) as pos
-              where pos % 2 = 1)::numeric / 60.0
+              where pos % 2 = 1)::numeric,
+             3600::int4
       from hours
-      cross join generate_series(0, 59) as minute_series(idx)
-      where hours.minute_counts is null
+      where not hours.has_minutes
     )
-    select mins.mts, sum(mins.cnt)::numeric, 60
+    select mins.mts, sum(mins.cnt)::numeric, mins.grain_secs
     from mins
     where mins.mts >= start_ts and mins.mts < end_ts
-    group by mins.mts;
+    group by mins.mts, mins.grain_secs;
 
   elsif source = 'rollup_1h' then
     if query_id is not null then
@@ -4254,6 +4349,7 @@ returns table (
   period_start timestamptz,
   period_end timestamptz,
   source text,
+  effective_bucket interval,
   buckets_expected bigint,
   buckets_with_data bigint,
   avg_aas numeric,
@@ -4272,17 +4368,20 @@ declare
   v_start_ts int4;
   v_end_ts int4;
   v_bucket_secs int4;
+  v_requested_bucket_secs numeric;
   v_grain_secs int4;
   v_si numeric;
   v_source text;
   v_read_source text;
   v_tie boolean;
+  v_extrema_supported boolean;
   v_raw_start timestamptz;
 begin
-  v_bucket_secs := extract(epoch from bucket)::int4;
-  if v_bucket_secs is null or v_bucket_secs < 60 then
+  v_requested_bucket_secs := extract(epoch from bucket);
+  if v_requested_bucket_secs is null or v_requested_bucket_secs < 60 then
     raise exception 'bucket must be at least 1 minute, got %', bucket;
   end if;
+  v_bucket_secs := ceil(v_requested_bucket_secs)::int4;
 
   v_start_ts := (ash.ts_from_timestamptz(v_from) / 60) * 60;
   v_end_ts := (ash.ts_from_timestamptz(v_to) / 60) * 60;
@@ -4311,17 +4410,34 @@ begin
   v_read_source := v_source;
 
   /*
-   * rollup_1h preserves the per-minute totals (minute_counts), so the
-   * unfiltered / database-only read keeps minute grain across the
-   * rollup_1m -> rollup_1h seam: peak_aas / p99_aas stay per-minute and match
-   * what a rollup_1m-backed window of the same span reports (wider window
-   * never shrinks the peak). Wait/query filters still need the hour-grain
-   * arrays. The reported source stays 'rollup_1h' — that is what was read.
+   * Genuine minute_counts keep unfiltered/database-only reads at minute
+   * grain. If any contributing hour has legacy/incomplete detail, disclose
+   * rollup_1h_flat and conservatively plan the whole window at hour grain.
+   * Wait/query filters always need the hour-grain arrays.
    */
   if v_source = 'rollup_1h' and wait_event_type is null
      and wait_event is null and query_id is null then
     v_read_source := 'rollup_1h_minutes';
-    v_grain_secs := 60;
+    if ash._rollup_1h_has_flat(v_start_ts, v_end_ts, database) then
+      v_source := 'rollup_1h_flat';
+      v_grain_secs := 3600;
+    else
+      v_grain_secs := 60;
+    end if;
+  end if;
+
+  /*
+   * Hour arrays describe whole [ts, ts + 1 hour) intervals. Expand partial
+   * requested bounds to complete hours so totals are never divided by a
+   * clipped duration (#130). period_start/period_end disclose these effective
+   * bounds.
+   */
+  if v_grain_secs = 3600 then
+    v_start_ts := ((v_start_ts::bigint / 3600) * 3600)::int4;
+    v_end_ts := least(
+      ((v_end_ts::bigint + 3599) / 3600) * 3600,
+      2147483647
+    )::int4;
   end if;
 
   /*
@@ -4330,10 +4446,14 @@ begin
    * minute grain) misaligns with the grain rows — a bucket then holds up to
    * ceil(bucket/grain) whole grains of activity but divides by its own
    * (shorter) coverage, fabricating AAS peaks that no grain ever reached.
-   * Integer division snaps down to the nearest grain multiple.
+   * Round UP to the nearest grain multiple so the effective bucket is never
+   * finer than the caller requested.
    */
-  v_bucket_secs := (greatest(v_bucket_secs, v_grain_secs) / v_grain_secs)
-                   * v_grain_secs;
+  v_bucket_secs := (
+    (greatest(v_bucket_secs, v_grain_secs)::bigint + v_grain_secs - 1)
+    / v_grain_secs * v_grain_secs
+  )::int4;
+  v_extrema_supported := v_grain_secs <= v_requested_bucket_secs;
 
   return query
   /*
@@ -4370,14 +4490,21 @@ begin
     ash.ts_to_timestamptz(v_start_ts),
     ash.ts_to_timestamptz(v_end_ts),
     v_source,
+    v_bucket_secs * interval '1 second',
     (((v_end_ts - 1) / v_bucket_secs)
       - (v_start_ts / v_bucket_secs) + 1)::bigint,
     (select count(*) from per_bucket)::bigint,
     round((select coalesce(sum(cnt), 0) from per_bucket) * v_si
           / (v_end_ts - v_start_ts)::numeric, 2),
-    coalesce(round((select max(aas) from bucket_aas), 2), 0),
-    coalesce(round((select percentile_cont(0.99) within group (order by aas)
-                    from bucket_aas)::numeric, 2), 0),
+    case when v_extrema_supported then
+      coalesce(round((select max(aas) from bucket_aas), 2), 0)
+    end,
+    case when v_extrema_supported then
+      coalesce(round((
+        select percentile_cont(0.99) within group (order by aas)
+        from bucket_aas
+      )::numeric, 2), 0)
+    end,
     round((select coalesce(sum(cnt), 0) from per_bucket) * v_si, 2);
 end;
 $$;
@@ -4386,10 +4513,10 @@ $$;
  * AAS time series: one row per bucket across the whole window (no-data buckets
  * included with data_points = 0 and null AAS). bucket => null auto-selects
  * grain by span. peak_aas is the worst underlying grain within the bucket;
- * p99_aas is the 99th percentile of the per-grain AAS. Unfiltered /
- * database-filtered reads are minute-grain on every source (rollup_1h keeps
- * per-minute totals in minute_counts); p99_aas is null only for wait/query-
- * filtered rollup_1h-backed buckets, which remain hour-grain.
+ * p99_aas is the 99th percentile of the per-grain AAS. Genuine rollup_1h
+ * minute_counts preserve minute grain for unfiltered/database-only reads.
+ * Hour-grain reads widen partial bounds and buckets; peak/p99 are NULL when
+ * that retained grain exceeds the bucket the caller requested.
  */
 create or replace function ash.timeline(
   since timestamptz default null,
@@ -4420,11 +4547,13 @@ declare
   v_end_ts int4;
   v_span int4;
   v_bucket_secs int4;
+  v_requested_bucket_secs numeric;
   v_grain_secs int4;
   v_si numeric;
   v_source text;
   v_read_source text;
   v_tie boolean;
+  v_extrema_supported boolean;
   v_raw_start timestamptz;
 begin
   v_start_ts := (ash.ts_from_timestamptz(v_from) / 60) * 60;
@@ -4440,23 +4569,13 @@ begin
       when v_span <= 6 * 3600 then 60
       when v_span <= 7 * 86400 then 3600
       else 86400 end;
+    v_requested_bucket_secs := v_bucket_secs;
   else
-    v_bucket_secs := extract(epoch from bucket)::int4;
-    if v_bucket_secs is null or v_bucket_secs < 60 then
+    v_requested_bucket_secs := extract(epoch from bucket);
+    if v_requested_bucket_secs < 60 then
       raise exception 'bucket must be at least 1 minute, got %', bucket;
     end if;
-  end if;
-
-  /*
-   * Bound the emitted-row count: one row per bucket, so an explicit fine
-   * bucket over a very wide window can blow up (1 minute over 10 years ~ 5M
-   * rows). Cap at 100000 and tell the caller to widen bucket.
-   */
-  if (v_span::bigint / v_bucket_secs) > 100000 then
-    raise exception
-      'ash.timeline: % buckets exceeds the 100000-row cap; use a coarser '
-      'bucket (or bucket => null for auto grain)',
-      (v_span::bigint / v_bucket_secs);
+    v_bucket_secs := ceil(v_requested_bucket_secs)::int4;
   end if;
 
   v_si := ash._sample_interval_secs();
@@ -4474,29 +4593,50 @@ begin
     if v_source = 'rollup_1h' and wait_event_type is null
        and wait_event is null and query_id is null then
       /*
-       * rollup_1h preserves per-minute totals (minute_counts), so the
-       * unfiltered / database-only read keeps minute grain: peak_aas /
-       * p99_aas stay per-minute across the rollup_1m -> rollup_1h seam, and
-       * sub-hour buckets work. The reported source stays 'rollup_1h'.
+       * Genuine minute_counts keep the unfiltered/database-only read at
+       * minute grain. Any legacy/incomplete contributing hour makes the
+       * whole effective read hour-grain and is disclosed in the source.
        */
       v_read_source := 'rollup_1h_minutes';
-    elsif v_source = 'rollup_1h' and v_bucket_secs < 3600 then
-      /*
-       * filtered sub-hour buckets need minute grain; the hour-grain arrays
-       * cannot supply it, so fall back to rollup_1m (older buckets simply
-       * show no data). 'none' (a truly empty window) is left as-is and
-       * reported honestly.
-       */
-      v_source := 'rollup_1m';
+      if ash._rollup_1h_has_flat(v_start_ts, v_end_ts, database) then
+        v_source := 'rollup_1h_flat';
+        v_grain_secs := 3600;
+      else
+        v_grain_secs := 60;
+      end if;
+    else
+      v_grain_secs := case when v_source = 'rollup_1h' then 3600 else 60 end;
     end if;
     v_read_source := coalesce(v_read_source, v_source);
-    v_grain_secs := case when v_read_source = 'rollup_1h' then 3600 else 60 end;
   end if;
   v_read_source := coalesce(v_read_source, v_source);
+
+  if v_grain_secs = 3600 then
+    v_start_ts := ((v_start_ts::bigint / 3600) * 3600)::int4;
+    v_end_ts := least(
+      ((v_end_ts::bigint + 3599) / 3600) * 3600,
+      2147483647
+    )::int4;
+  end if;
+
   -- snap to a whole grain multiple (see ash.aas): a non-multiple bucket
   -- misaligns with the grain rows and fabricates per-bucket AAS.
-  v_bucket_secs := (greatest(v_bucket_secs, v_grain_secs) / v_grain_secs)
-                   * v_grain_secs;
+  v_bucket_secs := (
+    (greatest(v_bucket_secs, v_grain_secs)::bigint + v_grain_secs - 1)
+    / v_grain_secs * v_grain_secs
+  )::int4;
+  v_extrema_supported := v_grain_secs <= v_requested_bucket_secs;
+  v_span := v_end_ts - v_start_ts;
+
+  /*
+   * Bound the emitted-row count after widening to the effective grain.
+   */
+  if (v_span::bigint / v_bucket_secs) > 100000 then
+    raise exception
+      'ash.timeline: % buckets exceeds the 100000-row cap; use a coarser '
+      'bucket (or bucket => null for auto grain)',
+      (v_span::bigint / v_bucket_secs);
+  end if;
 
   return query
   /*
@@ -4509,11 +4649,24 @@ begin
    * calendar hour/UTC-day label. The first bucket_start may therefore precede
    * since; edge buckets divide by their in-window coverage only.
    */
-  with grains as (
-    select (grain_row.ts / v_bucket_secs) * v_bucket_secs as bstart,
-           (grain_row.cnt * v_si / v_grain_secs) as gaas, grain_row.cnt
+  with source_grains as (
+    select grain_row.ts, grain_row.cnt
     from ash._grain_counts(v_start_ts, v_end_ts, v_read_source,
            wait_event_type, wait_event, query_id, database) as grain_row
+  ),
+  normalized_grains as (
+    select
+      (source_grains.ts / v_grain_secs) * v_grain_secs as gstart,
+      sum(source_grains.cnt) as cnt
+    from source_grains
+    group by 1
+  ),
+  grains as (
+    select
+      (normalized_grains.gstart / v_bucket_secs) * v_bucket_secs as bstart,
+      normalized_grains.cnt * v_si / v_grain_secs as gaas,
+      normalized_grains.cnt
+    from normalized_grains
   ),
   agg as (
     select bstart, count(*) as n, sum(cnt) as cnt, max(gaas) as peak,
@@ -4536,14 +4689,10 @@ begin
       round(agg.cnt * v_si / (least(buckets.bstart + v_bucket_secs, v_end_ts)
                             - greatest(buckets.bstart, v_start_ts)), 2)
     end,
-    case when agg.n > 0 then round(agg.peak, 2) end,
-    /*
-     * p99 stays null only for the genuinely hour-grain read (filtered
-     * rollup_1h): a percentile over hour averages would masquerade as a
-     * minute percentile. The unfiltered rollup_1h read is minute-grain via
-     * minute_counts and reports a real per-minute p99.
-     */
-    case when agg.n > 0 and v_read_source <> 'rollup_1h' then
+    case when agg.n > 0 and v_extrema_supported then
+      round(agg.peak, 2)
+    end,
+    case when agg.n > 0 and v_extrema_supported then
       round(agg.p99::numeric, 2)
     end
   from buckets
@@ -4553,17 +4702,15 @@ end;
 $$;
 
 /*
- * Standard trailing windows for triage: one summary row per window ending at
- * until. Each window delegates to ash.aas(), which auto-selects its source
- * (short windows may read raw for the freshest partial minute; the wide
- * windows read rollups). peak_aas/p99_aas are per-minute (worst /
- * 99th-percentile minute), which is what capacity triage wants, and
- * buckets_with_data is a true count of covered buckets at the grain named by
- * the bucket column — always '1 minute' here (unfiltered reads are
- * minute-grain on every source, incl. rollup_1h via minute_counts), exposed
- * per row so "43200 buckets" reads as "43200 @ 1 minute" without
- * cross-referencing. After the arithmetic-bucketing fix this is cheap even
- * for the 1-month window (~90ms for the whole call on a month of rollups).
+ * Standard trailing windows for triage: one summary row per window requested
+ * to end at until. Each delegates to ash.aas(), whose effective bounds may
+ * snap outward at hour grain. Short windows may read raw for the freshest
+ * partial minute; wide windows read rollups. Genuine minute_counts keep
+ * minute-grain peak/p99;
+ * legacy flat hours disclose an effective hour bucket and NULL unsupported
+ * extremes. buckets_with_data is a true count at the grain named by bucket.
+ * After the arithmetic-bucketing fix this is cheap even for the 1-month
+ * window (~90ms for the whole call on a month of rollups).
  */
 create or replace function ash.periods(
   until timestamptz default null
@@ -4601,7 +4748,7 @@ as $$
     aas_result.period_start,
     aas_result.period_end,
     aas_result.source,
-    interval '1 minute',
+    aas_result.effective_bucket,
     aas_result.buckets_with_data,
     aas_result.avg_aas,
     aas_result.peak_aas,
@@ -4730,6 +4877,77 @@ begin
     return;
   end if;
 
+  if source = 'rollup_1h_minutes' then
+    /*
+     * minute_counts is stored per (hour, datid), so a plain database
+     * breakdown retains the same minute precision as an unfiltered scalar
+     * read. Wait/query filters cannot be reconstructed from this total.
+     */
+    if dimension <> 'database'
+       or wait_event_type is not null
+       or wait_event is not null
+       or query_id is not null then
+      raise exception
+        'ash._grain_by: rollup_1h_minutes supports only an unfiltered '
+        'database dimension';
+    end if;
+
+    return query
+    with hours as (
+      select
+        rollup_hour.ts,
+        rollup_hour.datid,
+        coalesce(
+          db.datname::text,
+          '<oid:' || rollup_hour.datid || '>'
+        ) as database_key,
+        rollup_hour.minute_counts,
+        rollup_hour.wait_counts,
+        ash._minute_counts_valid(
+          rollup_hour.minute_counts,
+          rollup_hour.wait_counts
+        ) as has_minutes
+      from ash.rollup_1h as rollup_hour
+      left join pg_database as db
+        on db.oid = rollup_hour.datid
+      where rollup_hour.ts >= start_ts - 3540
+        and rollup_hour.ts < end_ts
+        and (v_datid is null or rollup_hour.datid = v_datid)
+    ),
+    grains as (
+      select
+        (hours.ts + (minute_elem.idx - 1) * 60)::int4 as mts,
+        hours.database_key,
+        minute_elem.mc::numeric as cnt
+      from hours
+      cross join lateral unnest(hours.minute_counts)
+        with ordinality as minute_elem(mc, idx)
+      where hours.has_minutes
+        and minute_elem.mc is not null
+      union all
+      select
+        hours.ts,
+        hours.database_key,
+        (
+          select coalesce(sum(hours.wait_counts[pos + 1]), 0)
+          from generate_subscripts(hours.wait_counts, 1) as pos
+          where pos % 2 = 1
+        )::numeric
+      from hours
+      where not hours.has_minutes
+    )
+    select
+      grains.mts,
+      grains.database_key,
+      null::bigint,
+      sum(grains.cnt)::numeric
+    from grains
+    where grains.mts >= start_ts
+      and grains.mts < end_ts
+    group by grains.mts, grains.database_key;
+    return;
+  end if;
+
   v_tbl := case
     when source = 'rollup_1h' then 'ash.rollup_1h'
     else 'ash.rollup_1m'
@@ -4838,6 +5056,9 @@ returns table (
   key text,
   query_text text,
   source text,
+  period_start timestamptz,
+  period_end timestamptz,
+  effective_bucket interval,
   avg_aas numeric,
   peak_aas numeric,
   p99_aas numeric,
@@ -4858,10 +5079,13 @@ declare
   v_start_ts int4;
   v_end_ts int4;
   v_bucket_secs int4;
+  v_requested_bucket_secs numeric;
   v_grain_secs int4;
   v_si numeric;
   v_source text;
+  v_read_source text;
   v_tie boolean;
+  v_extrema_supported boolean;
   v_raw_start timestamptz;
   v_has_pgss boolean := false;
   v_pgss_schema text;
@@ -4877,10 +5101,11 @@ begin
   if order_by not in ('avg', 'peak', 'p99') then
     raise exception 'ash.top: unknown order_by %; use avg|peak|p99', order_by;
   end if;
-  v_bucket_secs := extract(epoch from bucket)::int4;
-  if v_bucket_secs is null or v_bucket_secs < 60 then
+  v_requested_bucket_secs := extract(epoch from bucket);
+  if v_requested_bucket_secs is null or v_requested_bucket_secs < 60 then
     raise exception 'bucket must be at least 1 minute, got %', bucket;
   end if;
+  v_bucket_secs := ceil(v_requested_bucket_secs)::int4;
 
   v_start_ts := (ash.ts_from_timestamptz(v_from) / 60) * 60;
   v_end_ts := (ash.ts_from_timestamptz(v_to) / 60) * 60;
@@ -4908,10 +5133,42 @@ begin
                                      ash.ts_to_timestamptz(v_end_ts));
     v_grain_secs := case when v_source = 'rollup_1h' then 3600 else 60 end;
   end if;
+  v_read_source := v_source;
+
+  /*
+   * minute_counts is per (hour, datid), so a plain database breakdown keeps
+   * minute precision. Database reads with wait/query filters and every other
+   * rollup_1h dimension use the hourly arrays.
+   */
+  if v_source = 'rollup_1h'
+     and dimension = 'database'
+     and wait_event_type is null
+     and wait_event is null
+     and query_id is null then
+    v_read_source := 'rollup_1h_minutes';
+    if ash._rollup_1h_has_flat(v_start_ts, v_end_ts, database) then
+      v_source := 'rollup_1h_flat';
+      v_grain_secs := 3600;
+    else
+      v_grain_secs := 60;
+    end if;
+  end if;
+
+  if v_grain_secs = 3600 then
+    v_start_ts := ((v_start_ts::bigint / 3600) * 3600)::int4;
+    v_end_ts := least(
+      ((v_end_ts::bigint + 3599) / 3600) * 3600,
+      2147483647
+    )::int4;
+  end if;
+
   -- snap to a whole grain multiple (see ash.aas): a non-multiple bucket
   -- misaligns with the grain rows and fabricates per-bucket AAS.
-  v_bucket_secs := (greatest(v_bucket_secs, v_grain_secs) / v_grain_secs)
-                   * v_grain_secs;
+  v_bucket_secs := (
+    (greatest(v_bucket_secs, v_grain_secs)::bigint + v_grain_secs - 1)
+    / v_grain_secs * v_grain_secs
+  )::int4;
+  v_extrema_supported := v_grain_secs <= v_requested_bucket_secs;
 
   /*
    * pgss presence/readability probe, schema-qualified from the catalog (#115):
@@ -4931,18 +5188,50 @@ begin
     end;
   end if;
 
-  for key, v_key_num, source, avg_aas, peak_aas, p99_aas, backend_seconds, pct in
+  for
+    key,
+    v_key_num,
+    source,
+    period_start,
+    period_end,
+    effective_bucket,
+    avg_aas,
+    peak_aas,
+    p99_aas,
+    backend_seconds,
+    pct
+  in
   /*
    * Buckets are calendar-aligned (floored to bucket relative to ash.epoch(),
    * midnight UTC), matching ash.aas()/ash.timeline(): the same absolute
    * window always yields the same bucket boundaries. Edge buckets clipped by
    * the window divide by their in-window coverage only.
    */
-  with keyed as (
-    select (grain_by_row.ts / v_bucket_secs) * v_bucket_secs as bstart,
-           grain_by_row.key, grain_by_row.key_num, grain_by_row.cnt
-    from ash._grain_by(v_start_ts, v_end_ts, v_source, dimension,
+  with source_keyed as (
+    select
+      grain_by_row.ts,
+      grain_by_row.key,
+      grain_by_row.key_num,
+      grain_by_row.cnt
+    from ash._grain_by(v_start_ts, v_end_ts, v_read_source, dimension,
            wait_event_type, wait_event, query_id, database) as grain_by_row
+  ),
+  keyed_grains as (
+    select
+      (source_keyed.ts / v_grain_secs) * v_grain_secs as gstart,
+      source_keyed.key,
+      max(source_keyed.key_num) as key_num,
+      sum(source_keyed.cnt) as cnt
+    from source_keyed
+    group by 1, source_keyed.key
+  ),
+  keyed as (
+    select
+      (keyed_grains.gstart / v_bucket_secs) * v_bucket_secs as bstart,
+      keyed_grains.key,
+      keyed_grains.key_num,
+      keyed_grains.cnt
+    from keyed_grains
   ),
   /*
    * Zero-fill frame = the sampler-covered buckets, derived from the source's
@@ -4951,10 +5240,17 @@ begin
    * with ash.aas() for the same drill. database is the only filter that
    * legitimately restricts coverage, so it is the only one passed here.
    */
-  covered as (
-    select distinct (grain_row.ts / v_bucket_secs) * v_bucket_secs as bstart
-    from ash._grain_counts(v_start_ts, v_end_ts, v_source,
+  coverage_grains as (
+    select
+      (grain_row.ts / v_grain_secs) * v_grain_secs as gstart
+    from ash._grain_counts(v_start_ts, v_end_ts, v_read_source,
            null, null, null, database) as grain_row
+    group by 1
+  ),
+  covered as (
+    select distinct
+      (coverage_grains.gstart / v_bucket_secs) * v_bucket_secs as bstart
+    from coverage_grains
   ),
   keys as (
     select keyed.key, max(keyed.key_num) as key_num, sum(keyed.cnt) as total
@@ -4973,7 +5269,8 @@ begin
    */
   top_keys as (
     select * from keys order by total desc
-    limit case when order_by = 'avg' then greatest(n, 0)
+    limit case when order_by = 'avg' or not v_extrema_supported
+          then greatest(n, 0)
           else 2147483647 end
   ),
   key_bucket_data as (
@@ -4993,15 +5290,18 @@ begin
     select key_bucket.key, key_bucket.key_num, key_bucket.total,
            round(key_bucket.total * v_si
                  / (v_end_ts - v_start_ts)::numeric, 2) as avg_aas,
-           round(max(key_bucket.bcnt * v_si
-                     / (least(key_bucket.bstart + v_bucket_secs, v_end_ts)
-                        - greatest(key_bucket.bstart, v_start_ts))), 2)
-             as peak_aas,
-           round(percentile_cont(0.99) within group (
-                   order by key_bucket.bcnt * v_si
-                     / (least(key_bucket.bstart + v_bucket_secs, v_end_ts)
-                        - greatest(key_bucket.bstart, v_start_ts)))::numeric, 2)
-             as p99_aas
+           case when v_extrema_supported then
+             round(max(key_bucket.bcnt * v_si
+                       / (least(key_bucket.bstart + v_bucket_secs, v_end_ts)
+                          - greatest(key_bucket.bstart, v_start_ts))), 2)
+           end as peak_aas,
+           case when v_extrema_supported then
+             round(percentile_cont(0.99) within group (
+                     order by key_bucket.bcnt * v_si
+                       / (least(key_bucket.bstart + v_bucket_secs, v_end_ts)
+                          - greatest(key_bucket.bstart, v_start_ts))
+                   )::numeric, 2)
+           end as p99_aas
     from key_bucket
     group by key_bucket.key, key_bucket.key_num, key_bucket.total
   )
@@ -5009,6 +5309,9 @@ begin
     per_key.key,
     per_key.key_num,
     v_source,
+    ash.ts_to_timestamptz(v_start_ts),
+    ash.ts_to_timestamptz(v_end_ts),
+    v_bucket_secs * interval '1 second',
     per_key.avg_aas,
     per_key.peak_aas,
     per_key.p99_aas,
@@ -5059,6 +5362,14 @@ create or replace function ash.compare(
 returns table (
   key text,
   query_text text,
+  source_1 text,
+  source_2 text,
+  period_start_1 timestamptz,
+  period_end_1 timestamptz,
+  period_start_2 timestamptz,
+  period_end_2 timestamptz,
+  effective_bucket_1 interval,
+  effective_bucket_2 interval,
   avg_aas_1 numeric,
   avg_aas_2 numeric,
   avg_delta numeric,
@@ -5079,6 +5390,23 @@ declare
   v_aas2 record;
   v_cov1 boolean;
   v_cov2 boolean;
+  v_from1 timestamptz := coalesce(since_1, now() - interval '1 hour');
+  v_to1 timestamptz := coalesce(until_1, now());
+  v_from2 timestamptz := coalesce(since_2, now() - interval '1 hour');
+  v_to2 timestamptz := coalesce(until_2, now());
+  v_start1 int4;
+  v_end1 int4;
+  v_start2 int4;
+  v_end2 int4;
+  v_requested_bucket_secs numeric;
+  v_effective_bucket_secs1 int4;
+  v_effective_bucket_secs2 int4;
+  v_grain1 int4;
+  v_grain2 int4;
+  v_source1 text;
+  v_source2 text;
+  v_top_tie boolean;
+  v_extrema_mismatch boolean;
 begin
   -- validate here, in compare's own frame, so the error names ash.compare
   -- and never leaks the internal delegation to ash.top.
@@ -5119,21 +5447,163 @@ begin
       v_aas2.period_start, v_aas2.period_end;
   end if;
 
+  /*
+   * The displayed bucket can be the same even when one side consists of one
+   * retained hour average and the other consists of minute observations.
+   * Track that underlying read grain separately: equal bucket labels alone
+   * do not make the extrema distributions comparable.
+   */
+  v_grain1 := case
+    when v_aas1.source in ('rollup_1h', 'rollup_1h_flat')
+         and (
+           v_aas1.source = 'rollup_1h_flat'
+           or wait_event_type is not null
+           or wait_event is not null
+           or query_id is not null
+         ) then 3600
+    else 60
+  end;
+  v_grain2 := case
+    when v_aas2.source in ('rollup_1h', 'rollup_1h_flat')
+         and (
+           v_aas2.source = 'rollup_1h_flat'
+           or wait_event_type is not null
+           or wait_event is not null
+           or query_id is not null
+         ) then 3600
+    else 60
+  end;
+
   if dimension is null then
+    v_extrema_mismatch :=
+      v_grain1 <> v_grain2
+      or v_aas1.effective_bucket <> v_aas2.effective_bucket;
     return query
     select
       'overall'::text, null::text,
+      v_aas1.source,
+      v_aas2.source,
+      v_aas1.period_start,
+      v_aas1.period_end,
+      v_aas2.period_start,
+      v_aas2.period_end,
+      v_aas1.effective_bucket,
+      v_aas2.effective_bucket,
       case when v_cov1 then v_aas1.avg_aas end,
       case when v_cov2 then v_aas2.avg_aas end,
       case when v_cov1 and v_cov2
            then round(v_aas2.avg_aas - v_aas1.avg_aas, 2) end,
-      case when v_cov1 then v_aas1.peak_aas end,
-      case when v_cov2 then v_aas2.peak_aas end,
-      case when v_cov1 then v_aas1.p99_aas end,
-      case when v_cov2 then v_aas2.p99_aas end,
+      case when v_cov1 and not v_extrema_mismatch
+           then v_aas1.peak_aas end,
+      case when v_cov2 and not v_extrema_mismatch
+           then v_aas2.peak_aas end,
+      case when v_cov1 and not v_extrema_mismatch
+           then v_aas1.p99_aas end,
+      case when v_cov2 and not v_extrema_mismatch
+           then v_aas2.p99_aas end,
       null::numeric, null::numeric;
     return;
   end if;
+
+  /*
+   * Plan the dimensional windows independently. This cannot reuse aas()'s
+   * effective grain: an unfiltered scalar rollup_1h read can use minute_counts
+   * while a wait/query breakdown over that same physical source is hourly.
+   */
+  v_requested_bucket_secs := extract(epoch from bucket);
+  v_start1 := (ash.ts_from_timestamptz(v_from1) / 60) * 60;
+  v_end1 := (ash.ts_from_timestamptz(v_to1) / 60) * 60;
+  if v_end1 <= v_start1 then
+    v_end1 := least(v_start1::bigint + 60, 2147483647)::int4;
+  end if;
+  v_start2 := (ash.ts_from_timestamptz(v_from2) / 60) * 60;
+  v_end2 := (ash.ts_from_timestamptz(v_to2) / 60) * 60;
+  if v_end2 <= v_start2 then
+    v_end2 := least(v_start2::bigint + 60, 2147483647)::int4;
+  end if;
+
+  v_top_tie := (
+    dimension in ('wait_event_type', 'wait_event')
+    and query_id is not null
+  ) or (
+    dimension = 'query_id'
+    and (wait_event_type is not null or wait_event is not null)
+  ) or (
+    dimension = 'database'
+    and query_id is not null
+    and (wait_event_type is not null or wait_event is not null)
+  );
+
+  if v_top_tie then
+    v_source1 := 'raw';
+    v_source2 := 'raw';
+  else
+    v_source1 := ash._pick_source_agg(
+      ash.ts_to_timestamptz(v_start1),
+      ash.ts_to_timestamptz(v_end1)
+    );
+    v_source2 := ash._pick_source_agg(
+      ash.ts_to_timestamptz(v_start2),
+      ash.ts_to_timestamptz(v_end2)
+    );
+  end if;
+  v_grain1 := case when v_source1 = 'rollup_1h' then 3600 else 60 end;
+  v_grain2 := case when v_source2 = 'rollup_1h' then 3600 else 60 end;
+
+  if v_source1 = 'rollup_1h'
+     and dimension = 'database'
+     and wait_event_type is null
+     and wait_event is null
+     and query_id is null then
+    if ash._rollup_1h_has_flat(v_start1, v_end1, database) then
+      v_source1 := 'rollup_1h_flat';
+    else
+      v_grain1 := 60;
+    end if;
+  end if;
+  if v_source2 = 'rollup_1h'
+     and dimension = 'database'
+     and wait_event_type is null
+     and wait_event is null
+     and query_id is null then
+    if ash._rollup_1h_has_flat(v_start2, v_end2, database) then
+      v_source2 := 'rollup_1h_flat';
+    else
+      v_grain2 := 60;
+    end if;
+  end if;
+
+  if v_grain1 = 3600 then
+    v_start1 := ((v_start1::bigint / 3600) * 3600)::int4;
+    v_end1 := least(
+      ((v_end1::bigint + 3599) / 3600) * 3600,
+      2147483647
+    )::int4;
+  end if;
+  if v_grain2 = 3600 then
+    v_start2 := ((v_start2::bigint / 3600) * 3600)::int4;
+    v_end2 := least(
+      ((v_end2::bigint + 3599) / 3600) * 3600,
+      2147483647
+    )::int4;
+  end if;
+  v_effective_bucket_secs1 := (
+    (
+      greatest(ceil(v_requested_bucket_secs)::int4, v_grain1)::bigint
+      + v_grain1 - 1
+    )
+    / v_grain1 * v_grain1
+  )::int4;
+  v_effective_bucket_secs2 := (
+    (
+      greatest(ceil(v_requested_bucket_secs)::int4, v_grain2)::bigint
+      + v_grain2 - 1
+    )
+    / v_grain2 * v_grain2
+  )::int4;
+  v_extrema_mismatch :=
+    v_grain1 <> v_grain2
+    or v_effective_bucket_secs1 <> v_effective_bucket_secs2;
 
   return query
   with window1 as (
@@ -5147,6 +5617,14 @@ begin
   select
     coalesce(window1.key, window2.key),
     coalesce(window1.query_text, window2.query_text),
+    v_source1,
+    v_source2,
+    ash.ts_to_timestamptz(v_start1),
+    ash.ts_to_timestamptz(v_end1),
+    ash.ts_to_timestamptz(v_start2),
+    ash.ts_to_timestamptz(v_end2),
+    v_effective_bucket_secs1 * interval '1 second',
+    v_effective_bucket_secs2 * interval '1 second',
     window1.avg_aas, window2.avg_aas,
     /*
      * a key absent from a COVERED window is a true zero; an UNCOVERED window
@@ -5155,8 +5633,10 @@ begin
     case when v_cov1 and v_cov2
          then round(coalesce(window2.avg_aas, 0)
                     - coalesce(window1.avg_aas, 0), 2) end,
-    window1.peak_aas, window2.peak_aas,
-    window1.p99_aas, window2.p99_aas,
+    case when not v_extrema_mismatch then window1.peak_aas end,
+    case when not v_extrema_mismatch then window2.peak_aas end,
+    case when not v_extrema_mismatch then window1.p99_aas end,
+    case when not v_extrema_mismatch then window2.p99_aas end,
     window1.pct, window2.pct
   from window1
   /*
@@ -5937,17 +6417,46 @@ begin
     v_bucket_secs := case when v_span <= 6 * 3600 then 60
                           when v_span <= 7 * 86400 then 3600 else 86400 end;
   else
-    v_bucket_secs := extract(epoch from bucket)::int4;
-    if v_bucket_secs is null or v_bucket_secs < 60 then
+    if extract(epoch from bucket) < 60 then
       raise exception 'bucket must be at least 1 minute, got %', bucket;
     end if;
+    v_bucket_secs := ceil(extract(epoch from bucket))::int4;
+  end if;
+
+  v_si := ash._sample_interval_secs();
+  v_source := ash._pick_source_agg(ash.ts_to_timestamptz(v_start_ts),
+                                   ash.ts_to_timestamptz(v_end_ts));
+  if v_source = 'none' then v_source := 'rollup_1m'; end if;
+  v_grain_secs := case when v_source = 'rollup_1h' then 3600 else 60 end;
+  if v_grain_secs = 3600 then
+    v_start_ts := ((v_start_ts::bigint / 3600) * 3600)::int4;
+    v_end_ts := least(
+      ((v_end_ts::bigint + 3599) / 3600) * 3600,
+      2147483647
+    )::int4;
+  end if;
+  -- snap to a whole grain multiple (see ash.aas): a non-multiple bucket
+  -- misaligns with the grain rows and fabricates per-bucket AAS.
+  v_bucket_secs := (
+    (greatest(v_bucket_secs, v_grain_secs)::bigint + v_grain_secs - 1)
+    / v_grain_secs * v_grain_secs
+  )::int4;
+  v_span := v_end_ts - v_start_ts;
+
+  /*
+   * chart has no metadata columns, so disclose its effective hour-grain plan
+   * with a NOTICE instead of silently changing the requested window.
+   */
+  if v_source = 'rollup_1h' then
+    raise notice
+      'ash.chart: source rollup_1h uses effective window [% to %) and bucket %',
+      ash.ts_to_timestamptz(v_start_ts),
+      ash.ts_to_timestamptz(v_end_ts),
+      v_bucket_secs * interval '1 second';
   end if;
 
   /*
-   * Bound the emitted-row count (same cap as ash.timeline): one row per
-   * bucket, so an explicit fine bucket over a very wide window can blow up
-   * (1 minute over 10 years ~ 5M rows). Cap at 100000 and tell the caller
-   * to widen bucket.
+   * Bound the emitted-row count (same cap as ash.timeline) after widening.
    */
   if (v_span::bigint / v_bucket_secs) > 100000 then
     raise exception
@@ -5955,19 +6464,6 @@ begin
       'bucket (or bucket => null for auto grain)',
       (v_span::bigint / v_bucket_secs);
   end if;
-
-  v_si := ash._sample_interval_secs();
-  v_source := ash._pick_source_agg(ash.ts_to_timestamptz(v_start_ts),
-                                   ash.ts_to_timestamptz(v_end_ts));
-  if v_source = 'none' then v_source := 'rollup_1m'; end if;
-  if v_source = 'rollup_1h' and v_bucket_secs < 3600 then
-    v_source := 'rollup_1m';
-  end if;
-  v_grain_secs := case when v_source = 'rollup_1h' then 3600 else 60 end;
-  -- snap to a whole grain multiple (see ash.aas): a non-multiple bucket
-  -- misaligns with the grain rows and fabricates per-bucket AAS.
-  v_bucket_secs := (greatest(v_bucket_secs, v_grain_secs) / v_grain_secs)
-                   * v_grain_secs;
 
   /*
    * Legend/series events: the window-wide top-n PLUS any event that is
@@ -6145,7 +6641,7 @@ begin
   return query select 'period_start'::text, v_aas.period_start::text;
   return query select 'period_end'::text, v_aas.period_end::text;
   return query select 'source'::text, v_aas.source;
-  return query select 'minutes_with_data'::text, v_aas.buckets_with_data::text;
+  return query select 'buckets_with_data'::text, v_aas.buckets_with_data::text;
   return query select 'avg_aas'::text, v_aas.avg_aas::text;
   return query select 'peak_aas'::text, v_aas.peak_aas::text;
   return query select 'p99_aas'::text, v_aas.p99_aas::text;
@@ -6190,19 +6686,19 @@ $$;
  * everywhere user-facing.
  */
 comment on function ash.periods(timestamptz) is
-$$START HERE (US-1 triage): AAS for six standard trailing windows (1m, 5m, 1h, 1d, 1w, 1mo) ending at until (default now()), one row each. Columns (period, period_start, period_end, source, bucket, buckets_with_data, avg_aas, peak_aas, p99_aas): peak/p99 vs avg distinguishes a spike from sustained load; buckets_with_data counts covered buckets at the grain named by bucket (always 1 minute here). Rollup-backed (source = rollup_1m|rollup_1h). Next: locate the spike in time with ash.timeline(), then drill with ash.top().$$;
+$$START HERE (US-1 triage): AAS for six standard trailing windows (1m, 5m, 1h, 1d, 1w, 1mo) requested to end at until (default now()), one row each. Columns (period, period_start, period_end, source, bucket, buckets_with_data, avg_aas, peak_aas, p99_aas): period bounds are effective and may snap outward for hour-only reads; peak/p99 vs avg distinguishes a spike from sustained load; buckets_with_data counts covered buckets at the effective grain named by bucket. Genuine rollup_1h.minute_counts keeps minute grain; legacy/incomplete detail on a minute-capable plan reports source = rollup_1h_flat, bucket = 1 hour, and NULL sub-hour peak/p99 instead of fabricated minute extremes. Next: locate the spike in time with ash.timeline(), then drill with ash.top().$$;
 
 comment on function ash.aas(timestamptz, timestamptz, text, text, bigint, name, interval) is
-$$Scalar AAS summary for one window [since, until) (defaults: last 1 hour). Optional uniform filters wait_event_type/wait_event/query_id/database. Columns (period_start, period_end, source, buckets_expected, buckets_with_data, avg_aas, peak_aas, p99_aas, backend_seconds); peak/p99 are over per-bucket AAS. Buckets are calendar-aligned (floored to bucket in UTC: an hour bucket starts on the hour, a day bucket on the UTC day) — the same absolute window always produces the same buckets. Also the US-4 leaf event summary: ash.aas(wait_event => 'IO:DataFileRead'). Combining a wait filter with query_id needs raw samples and raises past raw retention. source = raw|rollup_1m|rollup_1h. Next: ash.top('query_id', wait_event => ...).$$;
+$$Scalar AAS summary for one requested window [since, until) (defaults: last 1 hour). Optional uniform filters wait_event_type/wait_event/query_id/database. Columns (period_start, period_end, source, effective_bucket, buckets_expected, buckets_with_data, avg_aas, peak_aas, p99_aas, backend_seconds). period_start/period_end are effective bounds: hour-only rollup_1h reads snap partial bounds outward, and avg/backend_seconds are exact for those disclosed bounds. peak/p99 are NULL when retained grain exceeds the requested bucket, never hour averages presented as minute extremes. Genuine minute_counts preserves minute grain for unfiltered/database-only reads; legacy/incomplete detail on that minute-capable plan reports source = rollup_1h_flat. Combining a wait filter with query_id needs raw samples and raises past raw retention. source = raw|rollup_1m|rollup_1h|rollup_1h_flat|none. Next: ash.top('query_id', wait_event => ...).$$;
 
 comment on function ash.timeline(timestamptz, timestamptz, interval, text, text, bigint, name) is
-$$AAS time series (US-2 locate / US-6 capacity): one row per bucket across [since, until). bucket => null auto-selects grain by span (<= 6h: 1 minute, <= 7d: 1 hour, else 1 day). bucket_start is calendar-aligned (floored to bucket in UTC: hour buckets start on the hour, day buckets on the UTC day), so the same absolute window always returns identical bucket_start labels; the first bucket may start before since and edge buckets average over their in-window part only. Columns (bucket_start, source, data_points, avg_aas, peak_aas, p99_aas): data_points = 0 with null AAS marks a no-data bucket (distinct from measured-zero). Order by peak_aas desc nulls last to find the worst buckets (no-data buckets carry null peak_aas, which sorts first under a bare desc and would bury the real spike), then drill that window with ash.top(). peak_aas/p99_aas are per-minute even on rollup_1h-backed windows (per-minute totals are preserved in rollup_1h.minute_counts); p99_aas is null only for wait/query-filtered rollup_1h-backed buckets (hour grain).$$;
+$$AAS time series (US-2 locate / US-6 capacity): one row per effective bucket. bucket => null auto-selects requested grain by span (<= 6h: 1 minute, <= 7d: 1 hour, else 1 day); hour-only rollup_1h reads widen partial bounds/buckets instead of falling through to missing rollup_1m data. Columns (bucket_start, source, data_points, avg_aas, peak_aas, p99_aas). data_points counts retained-grain rows, not one-second samples; 0 with NULL AAS means no stored observation. take_sample() also writes no row for a sampled idle tick, so idle and uncovered time remain indistinguishable until #137. Genuine minute_counts preserves minute extremes; legacy/incomplete detail on a minute-capable plan reports source = rollup_1h_flat. peak/p99 are NULL whenever retained grain exceeds the requested bucket. Order by peak_aas desc nulls last, then drill with ash.top().$$;
 
 comment on function ash.top(text, timestamptz, timestamptz, text, text, bigint, name, int, interval, text) is
-$$The single vertical drill (US-3): AAS broken down by dimension in wait_event_type|wait_event|query_id|database over [since, until). Every row carries avg_aas, peak_aas, p99_aas, backend_seconds, and pct (share of window total). order_by in avg|peak|p99 (default avg) picks the ranking metric BEFORE the top-n cut — use order_by => 'peak' during incident triage so a query that spiked for one minute outranks steady background rows. For the query_id dimension, a NULL key is the unattributed bucket (activity whose query_id was not captured: not run with a queryid-reporting client, truncated, or utility/idle-in-transaction work) — it is real load, not an error. Filters compose: ash.top('wait_event', wait_event_type => 'IO') is the level-2 drill; ash.top('query_id', wait_event => 'IO:DataFileRead') is the US-4 leaf. query_text is filled for the query_id dimension when pg_stat_statements is present AND the caller can read other roles pg_stat_statements text — i.e. holds pg_read_all_stats (e.g. via membership in pg_monitor); a plain ash.grant_reader() role without it sees query_text NULL even though pgss is installed, because pgss restricts query text to the owning role. When pgss lives outside public, the caller also needs USAGE on that schema, else query_text is NULL. Crossing the wait<->query tie (query_id dimension + wait filter, or a wait dimension + query_id) reads raw samples and raises past raw retention. source = raw|rollup_1m|rollup_1h.$$;
+$$The single vertical drill (US-3): AAS broken down by wait_event_type|wait_event|query_id|database. Columns (key, query_text, source, period_start, period_end, effective_bucket, avg_aas, peak_aas, p99_aas, backend_seconds, pct). Hour-only rollup_1h dimensions snap partial bounds outward; the effective bounds/bucket disclose that degradation and peak/p99 are NULL when retained grain exceeds the requested bucket. Plain database breakdowns retain minute precision through per-(hour,datid) minute_counts; database plus wait/query filters remains hour-grain. order_by in avg|peak|p99 applies before n; when the requested extreme is unavailable it falls back to avg ordering. A NULL query_id key is real unattributed load. The wait<->query tie reads raw and raises past raw retention. source = raw|rollup_1m|rollup_1h|rollup_1h_flat|none.$$;
 
 comment on function ash.compare(timestamptz, timestamptz, timestamptz, timestamptz, text, int, text, text, bigint, name, interval) is
-$$Before/after comparison of two windows (US-7): window 1 = [since_1, until_1), window 2 = [since_2, until_2). dimension => null gives one overall row; a dimension gives the top n keys by abs(avg_delta) via a full outer join (a key present in only one window still appears). Columns (key, query_text, avg_aas_1, avg_aas_2, avg_delta, peak_aas_1, peak_aas_2, p99_aas_1, p99_aas_2, pct_1, pct_2); avg_delta = window 2 minus window 1. A window with no data coverage (e.g. past retention) reports NULL on its side and a NULL avg_delta (plus a NOTICE) — never a fake zero baseline; within a covered window an absent key is a true zero. Use to tell whether a deploy regressed load and where.$$;
+$$Before/after comparison of two windows (US-7). dimension => null gives one overall row; a dimension gives top keys by abs(avg_delta). Columns (key, query_text, source_1, source_2, period_start_1, period_end_1, period_start_2, period_end_2, effective_bucket_1, effective_bucket_2, avg_aas_1, avg_aas_2, avg_delta, peak_aas_1, peak_aas_2, p99_aas_1, p99_aas_2, pct_1, pct_2). Sources and effective plans are disclosed per window. If retained read grains differ, both peak values and both p99 values are NULL as incomparable even when explicit effective buckets match; honest averages/delta remain. No-coverage sides and avg_delta are NULL plus a NOTICE; within a covered window an absent key is a true zero.$$;
 
 comment on function ash.samples(timestamptz, timestamptz, int, text, text, bigint, name) is
 $$Decoded raw sample rows, newest first (US-5 raw evidence) over [since, until) (default last 1 hour), up to n. Uniform filters wait_event_type/wait_event/query_id/database. Columns (sample_time, database_name, active_backends, wait_event, query_id, query_text). query_text needs pg_stat_statements AND that the caller holds pg_read_all_stats (e.g. via pg_monitor membership); it is null otherwise — a plain ash.grant_reader() role without pg_read_all_stats sees null even with pgss installed, because pgss restricts query text to the owning role. When pgss lives outside public, the caller also needs USAGE on that schema, else query_text is null. Reads ash.sample directly (raw retention only).$$;
@@ -6211,17 +6707,17 @@ comment on function ash.report(timestamptz, timestamptz, int, int) is
 $$Machine-readable load report as one jsonb (US-8) for [since, until) (default last 1 day). Per wait class (cpu=CPU*, io=IO, ipc=IPC, lock=Lock, lwlock=LWLock; total = their sum) at 1-minute resolution: aas_avg / aas_worst1m / aas_p99 / aas_p999. Plus top_events_{worst1m,p99,p999} (keys io/ipc/lock/lwlock, entries "event(aas)") and top_queryids_{worst1m,p99,p999} (keys total+the four non-cpu classes, entries "queryid(aas)"). Query attribution is decided per extreme minute: a top_queryids key appears when raw samples still cover that class's worst/percentile minute(s), even if the window start predates raw retention (percentile sets attribute over their raw-covered minutes). top_queryids_available (boolean, always present) says whether any attribution was possible — branch on it, not on key absence. coverage {from, to, source, minutes_expected, minutes_with_data, raw_retention_start} reconciles the payload against ash.aas()/ash.top() and flags degraded resolution; raw_retention_start is the logical planning/loss boundary, not the physical query-attribution cutoff. vcpus (echoed, never used) and cluster_name are pass-throughs. Returns null when the window has no coverage; never raises. Payload contract is frozen per 2.0 minor line (keys only added, never renamed/removed); scoring/normalization is the consumer's job.$$;
 
 comment on function ash.chart(timestamptz, timestamptz, interval, int, int, boolean) is
-$$Human render helper: stacked ASCII per-bucket AAS chart over [since, until) (default last 1 hour). Series/legend = the window-wide top n wait events PLUS any event that is top-1 in at least one bucket (so a single-bucket spike culprit is always visible), plus Other. bucket => null auto-selects grain by span; buckets are calendar-aligned like ash.timeline(). Presentation-only (columns bucket_start, aas, detail, chart); for typed data use ash.timeline(). Enable ANSI color with color => true or "set ash.color = on".$$;
+$$Human render helper: stacked ASCII per-bucket AAS chart over [since, until) (default last 1 hour). Series/legend = the window-wide top n wait events PLUS any event that is top-1 in at least one bucket, plus Other. bucket => null auto-selects grain by span. On rollup_1h the chart snaps partial bounds/buckets outward and emits a NOTICE naming source and effective plan; it never silently falls through to unavailable rollup_1m data. Presentation-only (bucket_start, aas, detail, chart); for typed data use ash.timeline(). Enable ANSI color with color => true or "set ash.color = on".$$;
 
 comment on function ash.summary(timestamptz, timestamptz) is
-$$Human render helper: key/value AAS overview for one window [since, until) (default last 1 hour) — the companion to ash.periods(). Returns (metric, value): period bounds, source, minutes_with_data, avg/peak/p99 AAS, backend_seconds, databases_active, and top waits/queries. Presentation-only; for typed data use ash.aas() and ash.top().$$;
+$$Human render helper: key/value AAS overview for one window [since, until) (default last 1 hour) — the companion to ash.periods(). Returns (metric, value): effective period bounds, source, buckets_with_data, avg/peak/p99 AAS, backend_seconds, databases_active, and top waits/queries. Presentation-only; source = rollup_1h_flat means the bucket count is hourly. For typed data use ash.aas() and ash.top().$$;
 
 /*
  * Schema-level map: one obj_description() lookup orients a human or agent on
  * the whole surface (readers vs operations) before any \df spelunking.
  */
 comment on schema ash is
-$$pg_ash: Active Session History for Postgres (pure SQL, no extension). Reader entry points (start with ash.periods()): periods, aas, timeline, top, compare, samples, report, chart, summary, status — every reader reports load in AAS (Average Active Sessions) and names its data source. Operations/admin (owner-only, not granted by grant_reader): start, stop, take_sample, rotate, rollup_minute, rollup_hour, rollup_cleanup, rebuild_partitions, set_debug_logging, uninstall, grant_reader, revoke_reader. Each function documents itself: select obj_description('ash.<name>(<argtypes>)'::regprocedure).$$;
+$$pg_ash: Active Session History for Postgres (pure SQL, no extension). Reader entry points (start with ash.periods()): periods, aas, timeline, top, compare, samples, report, chart, summary, status — readers report load in AAS (Average Active Sessions), and their function comments state how provenance is exposed. Operations/admin (owner-only, not granted by grant_reader): start, stop, take_sample, rotate, rollup_minute, rollup_hour, rollup_cleanup, rebuild_partitions, set_debug_logging, uninstall, grant_reader, revoke_reader. Each function documents itself: select obj_description('ash.<name>(<argtypes>)'::regprocedure).$$;
 
 /*
  * Operational / admin surface: obj_description for every entry point, so the
@@ -6246,7 +6742,7 @@ comment on function ash.rollup_minute(int) is
 $$Admin: fold completed minutes of raw samples into ash.rollup_1m (the every-minute job scheduled by ash.start()); batch_limit caps catch-up minutes per call. Returns minutes processed. Readers pick rollups automatically — this only needs manual calls when pg_cron is absent.$$;
 
 comment on function ash.rollup_hour() is
-$$Admin: fold completed hours of ash.rollup_1m into ash.rollup_1h, preserving per-minute totals in minute_counts so long-window peak/p99 stay minute-grain (the hourly job scheduled by ash.start()). Returns hours processed.$$;
+$$Admin: fold completed hours of ash.rollup_1m into ash.rollup_1h. minute_counts preserves available per-minute totals and must sum to the hourly wait total; missing stored rows remain NULL slots because idle and uncovered minutes are indistinguishable (#137). Returns hours processed.$$;
 
 comment on function ash.rollup_cleanup() is
 $$Admin: delete rollup rows past retention (rollup_1m_retention_days / rollup_1h_retention_days in ash.config; the daily job scheduled by ash.start()). Rotation deliberately does not require minute rollups that this cleanup is entitled to delete. Returns a summary of rows deleted.$$;

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -6631,12 +6631,34 @@ declare
   v_aas record;
   v_rec record;
   v_rank int;
+  v_drill_source text;
+  v_drill_period_start timestamptz;
+  v_drill_period_end timestamptz;
+  v_drill_effective_bucket interval;
 begin
   select * into v_aas from ash.aas(v_from, v_to);
   if v_aas.buckets_with_data = 0 then
     return query select 'status'::text, 'no data in this time range'::text;
     return;
   end if;
+
+  /*
+   * The headline can use rollup_1h minute_counts while the embedded
+   * wait/query drills necessarily use hourly arrays. Capture that shared
+   * dimensional plan so a widened drill is never presented under the
+   * headline's narrower bounds.
+   */
+  select
+    top_row.source,
+    top_row.period_start,
+    top_row.period_end,
+    top_row.effective_bucket
+  into
+    v_drill_source,
+    v_drill_period_start,
+    v_drill_period_end,
+    v_drill_effective_bucket
+  from ash.top('wait_event', v_from, v_to, n => 1) as top_row;
 
   return query select 'period_start'::text, v_aas.period_start::text;
   return query select 'period_end'::text, v_aas.period_end::text;
@@ -6646,6 +6668,12 @@ begin
   return query select 'peak_aas'::text, v_aas.peak_aas::text;
   return query select 'p99_aas'::text, v_aas.p99_aas::text;
   return query select 'backend_seconds'::text, v_aas.backend_seconds::text;
+  return query select 'drill_source'::text, v_drill_source;
+  return query
+    select 'drill_period_start'::text, v_drill_period_start::text;
+  return query select 'drill_period_end'::text, v_drill_period_end::text;
+  return query
+    select 'drill_effective_bucket'::text, v_drill_effective_bucket::text;
 
   return query
   select 'databases_active'::text,
@@ -6710,7 +6738,7 @@ comment on function ash.chart(timestamptz, timestamptz, interval, int, int, bool
 $$Human render helper: stacked ASCII per-bucket AAS chart over [since, until) (default last 1 hour). Series/legend = the window-wide top n wait events PLUS any event that is top-1 in at least one bucket, plus Other. bucket => null auto-selects grain by span. On rollup_1h the chart snaps partial bounds/buckets outward and emits a NOTICE naming source and effective plan; it never silently falls through to unavailable rollup_1m data. Presentation-only (bucket_start, aas, detail, chart); for typed data use ash.timeline(). Enable ANSI color with color => true or "set ash.color = on".$$;
 
 comment on function ash.summary(timestamptz, timestamptz) is
-$$Human render helper: key/value AAS overview for one window [since, until) (default last 1 hour) — the companion to ash.periods(). Returns (metric, value): effective period bounds, source, buckets_with_data, avg/peak/p99 AAS, backend_seconds, databases_active, and top waits/queries. Presentation-only; source = rollup_1h_flat means the bucket count is hourly. For typed data use ash.aas() and ash.top().$$;
+$$Human render helper: key/value AAS overview for one window [since, until) (default last 1 hour) — the companion to ash.periods(). Returns (metric, value): headline effective period bounds/source, buckets_with_data, avg/peak/p99 AAS, backend_seconds, databases_active, and top waits/queries. drill_source, drill_period_start/end, and drill_effective_bucket separately disclose the shared wait/query drill plan, which may widen beyond the headline's minute-precise window on rollup_1h. Presentation-only; source = rollup_1h_flat means the bucket count is hourly. For typed data use ash.aas() and ash.top().$$;
 
 /*
  * Schema-level map: one obj_description() lookup orients a human or agent on

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -3956,8 +3956,13 @@ as $$
     from ash.rollup_1h as rollup_hour
     left join pg_database as db
       on db.oid = rollup_hour.datid
-    where rollup_hour.ts::bigint < end_ts::bigint
-      and rollup_hour.ts::bigint + 3600 > start_ts::bigint
+    /*
+     * Keep the primary-key ts range indexable. Moving the arithmetic to the
+     * bigint parameter side avoids int4 overflow without casting the column.
+     */
+    where rollup_hour.ts < _rollup_1h_has_flat.end_ts::bigint
+      and rollup_hour.ts
+            > _rollup_1h_has_flat.start_ts::bigint - 3600
       and (
         _rollup_1h_has_flat.database is null
         or db.datname = _rollup_1h_has_flat.database


### PR DESCRIPTION
## Summary

Fixes the `rollup_1h` grain collapse by separating requested/effective buckets from the grain actually retained, exposing provenance, and returning `NULL` instead of fabricated peak/p99 values when retained data is too coarse.

- makes `ash.aas()`, `ash.timeline()`, `ash.top()`, and `ash.compare()` follow the same grain-honesty rule
- routes the `database` dimension through valid per-database `minute_counts`
- labels upgraded/synthesized arrays as `rollup_1h_flat`
- rejects incomplete or sum-inconsistent `minute_counts` in both `rollup_hour()` and the v1.5 → 2.0 backfill
- snaps hour-only dimensional windows outward and exposes effective bounds instead of raising
- gives `ash.summary()` separate headline and wait/query drill provenance so widened drill values cannot inherit narrower labels
- corrects the N8 catalog claim and points the coverage-model limitation to #137
- keeps zero-argument and `now()`-relative APIs working

Fixes #161.
Fixes #168.
Fixes #175.
Fixes #130.

This supersedes #131; I recommend closing #131 because this branch satisfies #130 without its hard-error/default-call and database-precision regressions.

**This PR needs a fresh rebase onto `origin/main` immediately before merge.** It is intentionally a draft and must not be merged as-is later without that rebase.

## Audit fixture behavior

| Case | Before | After |
|---|---|---|
| B1a overall `aas()` | avg/peak/p99 `1.15 / 10.00 / 4.69` | unchanged |
| B1a `top('wait_event')` | `0.77 / 0.77 / 0.77` | avg `0.77`; peak/p99 `NULL` because the read is hourly |
| B1a `top('database')` | `1.15 / 1.15 / 1.15` | `1.15 / 10.00 / 4.69` from the per-database minute array |
| B1b filtered IO | avg/peak/p99 `2.30 / 2.30 / 2.30` at a requested minute bucket | avg `2.30`, seconds `8280.00`, effective bucket `1 hour`, peak/p99 `NULL`; an explicit one-hour request remains `2.30 / 2.30` |
| B1c identical dimensional windows | no source columns; avg delta `0.00` but peaks `10.98 / 600.00` and p99 `10.98 / 246.59` | sources `rollup_1h / rollup_1m`, averages `10.98 / 10.98`, delta `0.00`, and both peak/p99 pairs `NULL` because retained grains differ |
| B1c identical overall windows | no source columns; averages `10.98 / 10.98`, peaks `600 / 600`, p99 `246.59 / 246.59` | same exact metrics plus source/effective-bucket provenance |
| B1d real v1.5 legacy hour | timeline fabricated 60 minute rows, source `rollup_1h`, points `60`, avg `0.17`, 60 non-NULL extrema | one row, source `rollup_1h_flat`, points `1`, avg `0.17`, no extrema; `aas()` also reports flat provenance and no extrema |
| N1 partial backfill | 60-slot array with minute sum `1800` vs hourly sum `3600` | `minute_counts IS NULL` |
| N1 complete backfill | not protected by a sum invariant | 60 slots, minute sum `4140` equals hourly sum `4140` |
| #130 partial dimensional window | clipped partial-hour denominator could fabricate AAS | hour-only waits snap outward and disclose bounds; database reads remain minute-precise |
| `summary()` asymmetric edge load | headline `[h+30m,h+90m)` avg `0.00`, but hour-only drill values had no separate plan metadata | headline stays exact; drill discloses `rollup_1h`, `[h,h+2h)`, bucket `1h`, and top IO avg `5.00` |

For #130 specifically, the half-hour IO `aas()` request now discloses `[h, h+1h)`, avg `1.00`, seconds `3600.00`, peak/p99 `NULL`; the crossing wait window discloses `[h, h+2h)`, avg `0.50`, seconds `3600.00`, peak/p99 `NULL`; database keeps `[h, h+30m)`, avg/peak/p99 `1.00 / 1.00 / 1.00`, seconds `1800.00`.

## RED (captured before implementation)

### B1a

```text
ERROR:  B1a aas avg=1.15 peak=10.00 p99=4.69; top wait avg=0.77 peak=0.77 p99=0.77; database avg=1.15 peak=1.15 p99=1.15
CONTEXT:  PL/pgSQL function inline_code_block line 54 at ASSERT
```

### B1b

```text
ERROR:  B1b unfiltered avg=2.32 peak=21.00 p99=9.79; IO minute avg=2.30 seconds=8280.00 peak=2.30 p99=2.30; IO hour peak=2.30 p99=2.30
CONTEXT:  PL/pgSQL function inline_code_block line 51 at ASSERT
```

### B1c

```text
ERROR:  B1c overall source=<missing>/<missing> avg=10.98/10.98 delta=0.00 peak=600.00/600.00 p99=246.59/246.59; dimension source=<missing>/<missing> avg=10.98/10.98 delta=0.00 peak=10.98/600.00 p99=10.98/246.59
CONTEXT:  PL/pgSQL function inline_code_block line 65 at ASSERT
```

### B1d (real v1.5 install upgraded through `sql/migrations/ash-1.5-to-2.0.sql`)

```text
ERROR:  B1d legacy timeline rows=60 source=rollup_1h..rollup_1h points=60 avg=0.17..0.17 nonnull_peak=60 nonnull_p99=60
CONTEXT:  PL/pgSQL function inline_code_block line 22 at ASSERT
```

### N1 (same real v1.5 upgrade)

```text
ERROR:  N1 partial backfill minute_counts cardinality=60 null_slots=30 minute_sum=1800 hour_sum=3600
CONTEXT:  PL/pgSQL function inline_code_block line 18 at ASSERT
```

The overlapping #130 assertion also failed before implementation:

```text
ERROR:  #130 aas period=2026-06-12 15:00:00+00..2026-06-12 15:30:00+00 avg=2.00 seconds=3600.00 peak=2.00 p99=2.00; wait period=<missing>..<missing> avg= seconds= peak= p99=; database period=<missing>..<missing> avg=2.00 seconds=3600.00 peak=2.00 p99=2.00
CONTEXT:  PL/pgSQL function inline_code_block line 69 at ASSERT
```

Post-review summary provenance RED:

```text
ERROR:  summary headline=2026-06-12 17:30:00+00..2026-06-12 18:30:00+00 avg=0.00; drill= .. bucket= top=IO:DataFileRead (avg_aas 5.00, 66.67%)
CONTEXT:  PL/pgSQL function inline_code_block line 80 at ASSERT
```

## GREEN (verbatim)

Focused reader block:

```text
NOTICE:  ash.chart: source rollup_1h uses effective window [2026-06-12 17:00:00+00 to 2026-06-12 19:00:00+00) and bucket 01:00:00
NOTICE:  ash.chart: source rollup_1h uses effective window [2026-07-27 16:00:00+00 to 2026-07-27 18:00:00+00) and bucket 01:00:00
NOTICE:  rollup_1h grain honesty, partial-hour, and default-call tests PASSED
```

Real-release upgrade block:

```text
NOTICE:  B1d GREEN timeline rows=1 source=rollup_1h_flat points=1 avg=0.17 nonnull_peak=0 nonnull_p99=0; aas source=rollup_1h_flat buckets=1/1 avg=0.17 peak=NULL p99=NULL seconds=600.00
NOTICE:  N1 GREEN partial minute_counts=NULL hour_sum=3600
NOTICE:  N1 GREEN complete cardinality=60 null_slots=0 first=600 quiet_slots=59 minute_sum=4140 hour_sum=4140
NOTICE:  real v1.5 rollup_1h legacy and backfill honesty PASSED
```

Summary provenance GREEN values:

```text
         metric         |                 value
------------------------+----------------------------------------
 period_start           | 2026-06-12 17:30:00+00
 period_end             | 2026-06-12 18:30:00+00
 avg_aas                | 0.00
 drill_source           | rollup_1h
 drill_period_start     | 2026-06-12 17:00:00+00
 drill_period_end       | 2026-06-12 19:00:00+00
 drill_effective_bucket | 01:00:00
 top_wait_1             | IO:DataFileRead (avg_aas 5.00, 66.67%)
(8 rows)
```

Full post-rebase local job:

```text
All tests passed for PostgreSQL 17 (pg_cron=off)
```

## Validation

- final HEAD `2af229a44095aac4a983f38f5a07311f61c08158`, rebased onto `origin/main` at `64265009e25acc8f23187e3e2f40e3754b7724af`
- PostgreSQL 17.10: full 58-step local CI-equivalent no-cron job passed, including real release upgrades, reapply, schema equivalence, and degraded modes
- PostgreSQL 19beta2: fresh install, reapply, B1/#130, summary provenance, real v1.5 upgrade, and #133 completion/lock behavior passed
- pre-rebase PostgreSQL 14.23, 15.18, 16.14, 18.4, and 19beta2 focused matrices passed
- GitHub Actions: docs-lint, PostgreSQL 14/15/16/17/18/19beta1, PG17 no-cron, and CodeQL all pass on final HEAD
- workflow YAML parsed; documentation checks and `git diff --check` passed

## API/documentation changes

`blueprints/AAS_API.md` now documents exact return schemas and the new provenance/effective-window fields, requested versus effective bounds, upward bucket widening, hour-only dimensional snapping, database minute precision, flat legacy hours, cross-grain compare suppression, summary headline-versus-drill provenance, chart NOTICE behavior, and the #137 idle-versus-uncovered limitation. Related examples, user stories, spec, README, and catalog comments use the same contract.

## Deliberately not attempted

This does not add coverage markers capable of distinguishing a sampled idle minute from an uncovered minute. The current storage model cannot represent that distinction; #137 is the architectural follow-up. Wait/query dimensions also cannot recover minute extrema once only hourly aggregates remain, so these readers now return exact averages/totals but honestly return `NULL` extrema instead of inventing detail.