### PR TITLE
release: make SQL installer atomic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -285,6 +285,158 @@ jobs:
         run: |
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f "$(python3 devel/scripts/ash_sql_chain.py fresh-install-path)"
 
+      - name: Test SQL entrypoints fail atomically
+        env:
+          PGPASSWORD: postgres
+        run: |
+          set -Eeuo pipefail
+          IFS=$'\n\t'
+
+          psql_base=(
+            psql
+            --no-psqlrc
+            --host=localhost
+            --username=postgres
+          )
+          install_path="$(python3 devel/scripts/ash_sql_chain.py fresh-install-path)"
+          failure_log_dir="$(mktemp -d)"
+          trap 'rm -rf -- "${failure_log_dir}"' EXIT
+
+          "${psql_base[@]}" --dbname=postgres --set=ON_ERROR_STOP=1 << 'EOF'
+          drop database if exists ash_install_failure_test with (force);
+          create database ash_install_failure_test;
+          drop database if exists ash_atomic_failure_test with (force);
+          create database ash_atomic_failure_test;
+          EOF
+
+          "${psql_base[@]}" \
+            --dbname=ash_install_failure_test \
+            --set=ON_ERROR_STOP=1 << 'EOF'
+          create schema ash;
+          create view ash.config as select true as singleton;
+          EOF
+
+          set +e
+          "${psql_base[@]}" \
+            --dbname=ash_install_failure_test \
+            --file="${install_path}" \
+            >"${failure_log_dir}/install.log" 2>&1
+          install_rc=$?
+          set -e
+          if (( install_rc != 3 )); then
+            cat "${failure_log_dir}/install.log" >&2
+            echo "fresh installer exit code: expected 3, got ${install_rc}" >&2
+            exit 1
+          fi
+
+          "${psql_base[@]}" \
+            --dbname=ash_install_failure_test \
+            --set=ON_ERROR_STOP=1 << 'EOF'
+          do $$
+          begin
+            assert to_regclass('ash.config') is not null,
+              'pre-existing failure fixture must survive rollback';
+            assert not exists (
+              select from pg_proc as proc
+              join pg_namespace as nsp on nsp.oid = proc.pronamespace
+              where nsp.nspname = 'ash'
+            ), 'failed installer left functions behind';
+            assert not exists (
+              select from pg_tables where schemaname = 'ash'
+            ), 'failed installer left tables behind';
+          end $$;
+          EOF
+
+          expected_function_count="$(
+            "${psql_base[@]}" \
+              --dbname=postgres \
+              --tuples-only \
+              --no-align \
+              --command="
+                select count(*)
+                from pg_proc as proc
+                join pg_namespace as nsp on nsp.oid = proc.pronamespace
+                where nsp.nspname = 'ash'
+              "
+          )"
+          echo "complete installer function count: ${expected_function_count}"
+
+          "${psql_base[@]}" \
+            --dbname=ash_atomic_failure_test \
+            --set=ON_ERROR_STOP=1 << 'EOF'
+          create function public.fail_ash_rollup_1m()
+          returns event_trigger
+          language plpgsql
+          as $$
+          declare
+            command record;
+          begin
+            for command in
+              select * from pg_event_trigger_ddl_commands()
+            loop
+              if command.object_type = 'table'
+                 and command.schema_name = 'ash'
+                 and command.object_identity = 'ash.rollup_1m' then
+                raise exception 'forced mid-install failure at ash.rollup_1m';
+              end if;
+            end loop;
+          end $$;
+
+          create event trigger fail_ash_rollup_1m
+            on ddl_command_end
+            when tag in ('CREATE TABLE')
+            execute function public.fail_ash_rollup_1m();
+          EOF
+
+          set +e
+          "${psql_base[@]}" \
+            --dbname=ash_atomic_failure_test \
+            --set=ON_ERROR_STOP=1 \
+            --file="${install_path}" \
+            >"${failure_log_dir}/atomic.log" 2>&1
+          atomic_rc=$?
+          set -e
+          if (( atomic_rc != 3 )); then
+            cat "${failure_log_dir}/atomic.log" >&2
+            echo "forced failure exit code: expected 3, got ${atomic_rc}" >&2
+            exit 1
+          fi
+          if ! grep -Fq \
+              "forced mid-install failure at ash.rollup_1m" \
+              "${failure_log_dir}/atomic.log"; then
+            cat "${failure_log_dir}/atomic.log" >&2
+            echo "installer did not reach the forced mid-install failure" >&2
+            exit 1
+          fi
+
+          "${psql_base[@]}" \
+            --dbname=ash_atomic_failure_test \
+            --set=ON_ERROR_STOP=1 \
+            --set=expected_function_count="${expected_function_count}" << 'EOF'
+          select set_config(
+            'pg_ash.expected_function_count',
+            :'expected_function_count',
+            false
+          );
+
+          do $$
+          declare
+            surviving_function_count int;
+          begin
+            select count(*)
+            into surviving_function_count
+            from pg_proc as proc
+            join pg_namespace as nsp on nsp.oid = proc.pronamespace
+            where nsp.nspname = 'ash';
+
+            assert to_regnamespace('ash') is null, format(
+              'failed installer left a partial ash schema (%s of %s functions survive)',
+              surviving_function_count,
+              current_setting('pg_ash.expected_function_count')
+            );
+          end $$;
+          EOF
+
       - name: Test schema and infrastructure
         env:
           PGPASSWORD: postgres

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -46,6 +46,12 @@ surface has been replaced by the AAS-oriented 2.0 API:
   array contains a NULL wait marker, count, or query-map id, matching the
   storage validator instead of emitting a fabricated row or raising an
   internal PL/pgSQL error. (issue #143)
+- **Installer failures now roll back partial schemas.** The fresh installer
+  enables `ON_ERROR_STOP` and owns a transaction; the 1.3-to-1.4,
+  1.4-to-1.5, and 1.5-to-2.0 paths inherit that behavior when they delegate to
+  it. The three earlier legacy migration legs remain unchanged. Invoking the
+  installer with `\i` inside an existing transaction commits the caller's outer
+  work when the installer reaches its final `COMMIT`. (issue #124)
 
 Known security limitation: advisory-lock squat DoS remains possible for roles
 that can intentionally hold pg_ash advisory locks. See

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -8,8 +8,14 @@
  * Upgrade from 1.3: \i sql/migrations/ash-1.3-to-1.4.sql, then \i sql/migrations/ash-1.4-to-1.5.sql, then \i sql/migrations/ash-1.5-to-2.0.sql
  * Upgrade from 1.4: \i sql/migrations/ash-1.4-to-1.5.sql, then \i sql/migrations/ash-1.5-to-2.0.sql
  * Upgrade from 1.5: \i sql/migrations/ash-1.5-to-2.0.sql
+ *
+ * Transaction behavior: this entrypoint enables ON_ERROR_STOP and owns its
+ * transaction. When invoked with \i inside an existing transaction, its final
+ * COMMIT also commits the caller's outer work.
  */
 
+\set ON_ERROR_STOP on
+begin;
 
 /*
  * Preserve function EXECUTE grants across the drop/recreate below (#107).
@@ -6404,3 +6410,5 @@ exception when others then
     'ignore to leave pg_monitor without access',
     sqlstate, sqlerrm;
 end $$;
+
+commit;

--- a/sql/migrations/ash-1.5-to-2.0.sql
+++ b/sql/migrations/ash-1.5-to-2.0.sql
@@ -31,6 +31,4 @@
  */
 
 \set ON_ERROR_STOP on
-begin;
 \ir ../ash-install.sql
-commit;


### PR DESCRIPTION
## What changed

- moves `ON_ERROR_STOP` and transaction ownership into `sql/ash-install.sql`
- lets `sql/migrations/ash-1.5-to-2.0.sql` delegate transaction ownership to the installer
- replaces #125's non-discriminating namespace check with a forced mid-install failure that asserts the `ash` schema is absent
- retains the three discriminating incompatible-config rollback assertions from #125
- documents that `\i` inside an existing transaction commits the caller's outer work

## Scope

This supersedes and rescopes draft PR #125. It intentionally does not modify the five finalized migration scripts protected by `docs/RELEASE_PROCESS.md:65`.

The rescope protects the fresh installer and the three canonical migration legs that replay it (1.3→1.4, 1.4→1.5, and 1.5→2.0): 4 of 7 primary documented entrypoints, or 3 of 6 canonical migration legs plus fresh install. Any path that reaches the installer no longer leaves the audited 23-of-62 partial schema after a mid-installer failure.

It does not make the early 1.0→1.1, 1.1→1.2, or 1.2→1.3 canonical legs atomic. Upgrade starts at 1.0, 1.1, or 1.2 therefore retain unsafe early legs. The frozen 1.4→1.5 shim also retains its own transaction bookends, so the full chain succeeds with PostgreSQL's expected nested/no-transaction warnings.

Relates to #124.

## RED on current `origin/main`

```text
complete installer exit code: 0
complete installer function count: 62
forced installer exit code: 3
psql:sql/ash-install.sql:2643: ERROR:  forced mid-install failure at ash.rollup_1m
1 schema, 23 of 62 functions survive
ERROR:  failed installer left a partial ash schema (23 of 62 functions survive)
CONTEXT:  PL/pgSQL function inline_code_block line 11 at ASSERT
RED assertion exit code: 3
ERROR:  function ash._color_on() does not exist
broken ash.status() exit code: 1
```

The retained incompatible-config fixture is also RED on main:

```text
fresh installer exit code: expected 3, got 0
53 functions, 3 tables remain
```

## GREEN on PostgreSQL 17.9

```text
complete_installer_function_count=62
incompatible_psql_rc=3
incompatible_three_assertions=GREEN
event_psql_rc=3
event_schema_count=0
event_surviving_function_count=0
DO
event_atomicity_assertion=GREEN
caller_marker_rows_after_caller_rollback=1
caller_transaction_persistence_assertions=GREEN
```

Additional validation:

- helper-discovered fresh install: exit 0, 62 routines, version `2.0-beta1`
- installer re-apply twice: exit 0, count remains 62, seeded config state preserved
- helper-discovered full 1.0→2.0 chain: exit 0, 62 routines, readers callable
- YAML parse, docs-lint/SQL-guard simulation, `git diff --check`, and frozen-file diff: pass