### PR TITLE
release: prevent cleanup from deadlocking rotation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5491,7 +5491,7 @@ jobs:
             select 1 from ash.config where singleton for update;
             select pg_advisory_xact_lock(
               hashtext('pg_ash')::int4,
-              hashtext('pg_ash_rollup')::int4
+              hashtext('pg_ash_config_test')::int4
             );
             select pg_sleep(5);
             commit;
@@ -5503,7 +5503,7 @@ jobs:
               from pg_locks
               where locktype = 'advisory'
                 and classid = hashtext('pg_ash')::int4::oid
-                and objid = hashtext('pg_ash_rollup')::int4::oid
+                and objid = hashtext('pg_ash_config_test')::int4::oid
                 and granted
                 and pid <> pg_backend_pid()
             )
@@ -5521,6 +5521,86 @@ jobs:
           ")"
           if [ "$rotate_state" != "0 0" ]; then
             echo "::error::outer lock failure changed state: $rotate_state" >&2
+            exit 1
+          fi
+
+          echo "=== #81F: expired-only rotation must serialize with rollup ==="
+          reset_issue_81_state
+          "${psql_base[@]}" << 'SQL'
+          begin;
+          set local session_replication_role = replica;
+          update ash.config
+          set rollup_1m_retention_days = 1
+          where singleton;
+          insert into ash.sample (
+            sample_ts, datid, active_count, data, slot
+          )
+          values (
+            ash.ts_from_timestamptz(
+              date_trunc('minute', now()) - interval '36 hours'
+            ),
+            0::oid,
+            1::smallint,
+            array[-1,1,0]::integer[],
+            2::smallint
+          );
+          commit;
+          SQL
+          "${psql_base[@]}" -c "
+            begin;
+            select pg_advisory_xact_lock(
+              hashtext('pg_ash')::int4,
+              hashtext('pg_ash_rollup')::int4
+            );
+            lock table ash.sample_2 in access share mode;
+            select pg_sleep(1);
+            update ash.config
+            set last_rollup_1m_ts = last_rollup_1m_ts
+            where singleton;
+            commit;
+          " &
+          expired_rollup_pid=$!
+          wait_until_sql_true "rollup advisory and sample_2 locks" "
+            select exists (
+              select 1
+              from pg_locks advisory_lock
+              where advisory_lock.locktype = 'advisory'
+                and advisory_lock.classid = hashtext('pg_ash')::int4::oid
+                and advisory_lock.objid = hashtext('pg_ash_rollup')::int4::oid
+                and advisory_lock.granted
+                and advisory_lock.pid <> pg_backend_pid()
+                and exists (
+                  select 1
+                  from pg_locks sample_lock
+                  where sample_lock.pid = advisory_lock.pid
+                    and sample_lock.locktype = 'relation'
+                    and sample_lock.relation = 'ash.sample_2'::regclass
+                    and sample_lock.mode = 'AccessShareLock'
+                    and sample_lock.granted
+                )
+            )
+          "
+          rotate_result="$("${psql_base[@]}" -tAc "select ash.rotate()")"
+          if [ "$rotate_result" != "failed: pre-truncation rollup busy; slot 2 not truncated" ]; then
+            echo "::error::expired-only busy-rollup result mismatch: $rotate_result" >&2
+            exit 1
+          fi
+          wait "$expired_rollup_pid"
+          assert_raw_sample_survived "expired-only rollup race"
+          rotate_result="$("${psql_base[@]}" -tAc "select ash.rotate()")"
+          if [ "$rotate_result" != "rotated: slot 0 -> 1, truncated slot 2 (sample + query_map)" ]; then
+            echo "::error::expired-only rotation did not recover: $rotate_result" >&2
+            exit 1
+          fi
+          expired_state="$("${psql_base[@]}" -tAc "
+            select current_slot || ' ' ||
+                   (select count(*) from ash.sample_2) || ' ' ||
+                   consecutive_rotate_failures
+            from ash.config
+            where singleton
+          ")"
+          if [ "$expired_state" != "1 0 0" ]; then
+            echo "::error::expired-only recovery state mismatch: $expired_state" >&2
             exit 1
           fi
 
@@ -5649,6 +5729,7 @@ jobs:
             v_enabled boolean;
             v_input interval;
             v_message text;
+            v_other_rotation_job bigint;
             v_raised boolean;
             v_rotation_job bigint;
             v_sqlstate text;
@@ -5808,8 +5889,49 @@ jobs:
                 select schedule
                 from cron.job
                 where jobname = 'ash_rotation'
+                  and username = current_user
+                  and database = current_database()
               ) = '0 0 * * *',
                 'ash_rotation must keep its daily schedule';
+
+              /*
+               * A superuser can see every pg_cron row despite its RLS
+               * policy. An unrelated user's same-named job must therefore
+               * neither satisfy our idempotency lookup nor be repaired.
+               */
+              perform cron.unschedule(v_rotation_job);
+              insert into cron.job (
+                schedule,
+                command,
+                database,
+                username,
+                jobname
+              )
+              values (
+                '*/7 * * * *',
+                'select 1',
+                current_database(),
+                'ash_issue162_other',
+                'ash_rotation'
+              )
+              returning jobid into v_other_rotation_job;
+
+              perform 1 from ash.start();
+              assert (
+                select schedule
+                from cron.job
+                where jobid = v_other_rotation_job
+              ) = '*/7 * * * *',
+                'ash.start changed another user''s rotation schedule';
+              assert (
+                select count(*)
+                from cron.job
+                where jobname = 'ash_rotation'
+                  and username = current_user
+                  and database = current_database()
+                  and schedule = '0 0 * * *'
+              ) = 1,
+                'ash.start did not create the caller''s daily rotation job';
             end if;
           end;
           $$;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5240,8 +5240,10 @@ jobs:
             set current_slot = 0,
               rotated_at = now() - interval '2 days',
               rotation_period = interval '1 day',
+              rollup_1m_retention_days = 30,
               last_rollup_1m_ts = null,
               last_rollup_1h_ts = null,
+              consecutive_rotate_failures = 0,
               sampling_enabled = true
             where singleton;
             select ash._register_wait('active', 'Issue81', 'RotateLoss');
@@ -5378,9 +5380,41 @@ jobs:
             )
           "
           rotate_result="$("${psql_base[@]}" -tAc "select ash.rotate()")"
+          if [ "$rotate_result" != "failed: pre-truncation rollup busy; slot 2 not truncated" ]; then
+            echo "::error::first busy-rollup failure text mismatch: $rotate_result" >&2
+            exit 1
+          fi
+          rotate_result="$("${psql_base[@]}" -tAc "select ash.rotate()")"
+          if [ "$rotate_result" != "failed: pre-truncation rollup busy; slot 2 not truncated" ]; then
+            echo "::error::second busy-rollup failure text mismatch: $rotate_result" >&2
+            exit 1
+          fi
+          rotate_failures="$("${psql_base[@]}" -tAc "
+            select value
+            from ash.status()
+            where metric = 'consecutive_rotate_failures'
+          ")"
+          if [ "$rotate_failures" != "2" ]; then
+            echo "::error::consecutive rotate failures expected 2, got $rotate_failures" >&2
+            exit 1
+          fi
           wait "$rollup_lock_pid"
           echo "rotate result with busy rollup lock: $rotate_result"
           assert_raw_sample_survived "busy rollup advisory lock"
+          rotate_result="$("${psql_base[@]}" -tAc "select ash.rotate()")"
+          if [ "$rotate_result" != "rotated: slot 0 -> 1, truncated slot 2 (sample + query_map)" ]; then
+            echo "::error::post-failure rotation did not recover: $rotate_result" >&2
+            exit 1
+          fi
+          rotate_failures="$("${psql_base[@]}" -tAc "
+            select value
+            from ash.status()
+            where metric = 'consecutive_rotate_failures'
+          ")"
+          if [ "$rotate_failures" != "0" ]; then
+            echo "::error::successful rotation did not reset failures: $rotate_failures" >&2
+            exit 1
+          fi
 
           echo "=== #81C: rotate must not truncate when pre-rollup hits lock_timeout ==="
           reset_issue_81_state
@@ -5408,12 +5442,96 @@ jobs:
           echo "rotate result with rollup_1m lock_timeout: $rotate_result"
           assert_raw_sample_survived "rollup_1m lock_timeout"
 
+          echo "=== #81D: counter lock timeout must not mask failure text ==="
+          reset_issue_81_state
+          seed_endangered_sample
+          "${psql_base[@]}" -c "
+            begin;
+            select 1 from ash.config where singleton for update;
+            select pg_advisory_xact_lock(
+              hashtext('pg_ash')::int4,
+              hashtext('pg_ash_rollup')::int4
+            );
+            select pg_sleep(5);
+            commit;
+          " &
+          config_lock_pid=$!
+          wait_until_sql_true "combined config and rollup lock" "
+            select exists (
+              select 1
+              from pg_locks
+              where locktype = 'advisory'
+                and classid = hashtext('pg_ash')::int4::oid
+                and objid = hashtext('pg_ash_rollup')::int4::oid
+                and granted
+                and pid <> pg_backend_pid()
+            )
+          "
+          rotate_result="$("${psql_base[@]}" -tAc "select ash.rotate()")"
+          if [ "$rotate_result" != "failed: pre-truncation rollup busy; slot 2 not truncated" ]; then
+            echo "::error::config lock masked rotation failure: $rotate_result" >&2
+            exit 1
+          fi
+          wait "$config_lock_pid"
+          assert_raw_sample_survived "failure-counter config lock_timeout"
+          rotate_failures="$("${psql_base[@]}" -tAc "
+            select value
+            from ash.status()
+            where metric = 'consecutive_rotate_failures'
+          ")"
+          if [ "$rotate_failures" != "0" ]; then
+            echo "::error::timed-out counter update changed value: $rotate_failures" >&2
+            exit 1
+          fi
+
+          echo "=== #81E: outer lock handler must keep bounded failure text ==="
+          reset_issue_81_state
+          "${psql_base[@]}" -c "
+            begin;
+            select 1 from ash.config where singleton for update;
+            select pg_advisory_xact_lock(
+              hashtext('pg_ash')::int4,
+              hashtext('pg_ash_rollup')::int4
+            );
+            select pg_sleep(5);
+            commit;
+          " &
+          config_update_lock_pid=$!
+          wait_until_sql_true "config update lock marker" "
+            select exists (
+              select 1
+              from pg_locks
+              where locktype = 'advisory'
+                and classid = hashtext('pg_ash')::int4::oid
+                and objid = hashtext('pg_ash_rollup')::int4::oid
+                and granted
+                and pid <> pg_backend_pid()
+            )
+          "
+          rotate_result="$("${psql_base[@]}" -tAc "select ash.rotate()")"
+          if [ "$rotate_result" != "failed: lock timeout on partition truncate, will retry next cycle" ]; then
+            echo "::error::outer lock handler result mismatch: $rotate_result" >&2
+            exit 1
+          fi
+          wait "$config_update_lock_pid"
+          rotate_state="$("${psql_base[@]}" -tAc "
+            select current_slot || ' ' || consecutive_rotate_failures
+            from ash.config
+            where singleton
+          ")"
+          if [ "$rotate_state" != "0 0" ]; then
+            echo "::error::outer lock failure changed state: $rotate_state" >&2
+            exit 1
+          fi
+
           echo "Critical bug #81 regression tests PASSED"
 
       - name: "Blocker #162: cleanup/rotation compatibility and config geometry"
         env:
           PGPASSWORD: postgres
         run: |
+          set -euo pipefail
+
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
           /*
            * The cleanup deadlock remains covered independently of the
@@ -5631,7 +5749,9 @@ jobs:
               assert v_message = format(
                 'pg_ash: rotation_period must be a whole number of days '
                 '(minimum 1 day); sub-day and fractional-day rotation are '
-                'unsupported because ash.rotate() is scheduled daily; got %s',
+                'unsupported because ash.rotate() is scheduled daily; got %s; '
+                'set ash.config.rotation_period to a whole-day interval '
+                '(for example, 1 day) before retrying',
                 v_input
               ),
                 'rotation_period message mismatch: ' || v_message;
@@ -5757,6 +5877,78 @@ jobs:
           end;
           $$;
           EOF
+
+          # Upgrade regression: older installers accepted sub-day periods.
+          # Reapplication must stop with the actionable validator message,
+          # rather than PostgreSQL's generic CHECK failure.
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          alter table ash.config
+            drop constraint config_rotation_period_day_check;
+          alter table ash.config
+            disable trigger config_validate_rotation;
+          update ash.config
+          set rotation_period = interval '12 hours'
+          where singleton;
+          alter table ash.config
+            enable trigger config_validate_rotation;
+          create or replace function ash.rotate()
+          returns text
+          language plpgsql
+          set search_path = pg_catalog, ash
+          as $$
+          begin
+            return 'legacy-upgrade sentinel';
+          end;
+          $$;
+          EOF
+
+          install_sql="$(
+            python3 devel/scripts/ash_sql_chain.py fresh-install-path
+          )"
+          set +e
+          upgrade_output="$(
+            psql -h localhost -U postgres -d postgres \
+              -v ON_ERROR_STOP=1 -f "$install_sql" 2>&1
+          )"
+          upgrade_status=$?
+          set -e
+
+          if [ "$upgrade_status" != "3" ]; then
+            echo "::error::legacy sub-day upgrade expected status 3, got $upgrade_status" >&2
+            exit 1
+          fi
+          upgrade_error="$(
+            printf '%s\n' "$upgrade_output" |
+              sed -n 's/^psql:.*ERROR:  //p' |
+              tail -n 1
+          )"
+          expected_upgrade_error="pg_ash: rotation_period must be a whole number of days "
+          expected_upgrade_error+="(minimum 1 day); sub-day and fractional-day rotation are "
+          expected_upgrade_error+="unsupported because ash.rotate() is scheduled daily; "
+          expected_upgrade_error+="got 12:00:00; set ash.config.rotation_period to a "
+          expected_upgrade_error+="whole-day interval (for example, 1 day) before retrying"
+          if [ "$upgrade_error" != "$expected_upgrade_error" ]; then
+            echo "::error::legacy sub-day upgrade error mismatch: $upgrade_error" >&2
+            exit 1
+          fi
+          upgrade_core_installed="$(
+            psql -h localhost -U postgres -d postgres -tAc "
+              select position(
+                'v_rollup_1m_cutoff'
+                in pg_get_functiondef('ash.rotate()'::regprocedure)
+              ) > 0
+            "
+          )"
+          if [ "$upgrade_core_installed" != "t" ]; then
+            echo "::error::legacy rejection happened before rotate() was replaced" >&2
+            exit 1
+          fi
+
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
+            -c "update ash.config set rotation_period = interval '1 day' where singleton"
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
+            -f "$install_sql" >/dev/null
+          echo "Legacy sub-day upgrade rejection PASSED"
 
       - name: "Test 2.0 readers over rollup sources"
         env:
@@ -6497,6 +6689,16 @@ jobs:
               'status should include skipped_samples';
             assert 'raw_retention' = any(v_metrics),
               'status should include raw_retention';
+            assert 'rotation_period_contract' = any(v_metrics),
+              'status should include rotation_period_contract';
+            assert (
+              select value
+              from ash.status()
+              where metric = 'rotation_period_contract'
+            ) = 'day-granular; minimum 1 day',
+              'status should document the exact rotation-period contract';
+            assert 'consecutive_rotate_failures' = any(v_metrics),
+              'status should include consecutive_rotate_failures';
             assert 'rollup_1m_rows' = any(v_metrics),
               'status should include rollup_1m_rows';
             assert 'rollup_1m_retention' = any(v_metrics),

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5880,7 +5880,8 @@ jobs:
 
           # Upgrade regression: older installers accepted sub-day periods.
           # Reapplication must stop with the actionable validator message,
-          # rather than PostgreSQL's generic CHECK failure.
+          # rather than PostgreSQL's generic CHECK failure, and #184's
+          # file-level transaction must roll the attempted upgrade back.
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
           alter table ash.config
             drop constraint config_rotation_period_day_check;
@@ -5931,16 +5932,26 @@ jobs:
             echo "::error::legacy sub-day upgrade error mismatch: $upgrade_error" >&2
             exit 1
           fi
-          upgrade_core_installed="$(
-            psql -h localhost -U postgres -d postgres -tAc "
-              select position(
-                'v_rollup_1m_cutoff'
-                in pg_get_functiondef('ash.rotate()'::regprocedure)
-              ) > 0
+          upgrade_atomic_state="$(
+            psql -h localhost -U postgres -d postgres -tA -F '|' -c "
+              select
+                rotation_period::text,
+                position(
+                  'legacy-upgrade sentinel'
+                  in pg_get_functiondef('ash.rotate()'::regprocedure)
+                ) > 0,
+                exists (
+                  select
+                  from pg_constraint
+                  where conname = 'config_rotation_period_day_check'
+                    and conrelid = 'ash.config'::regclass
+                )
+              from ash.config
+              where singleton
             "
           )"
-          if [ "$upgrade_core_installed" != "t" ]; then
-            echo "::error::legacy rejection happened before rotate() was replaced" >&2
+          if [ "$upgrade_atomic_state" != "12:00:00|t|f" ]; then
+            echo "::error::legacy rejection left a partial upgrade: $upgrade_atomic_state" >&2
             exit 1
           fi
 
@@ -5948,7 +5959,26 @@ jobs:
             -c "update ash.config set rotation_period = interval '1 day' where singleton"
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
             -f "$install_sql" >/dev/null
-          echo "Legacy sub-day upgrade rejection PASSED"
+          upgrade_recovered_state="$(
+            psql -h localhost -U postgres -d postgres -tA -F '|' -c "
+              select
+                position(
+                  'v_rollup_1m_cutoff'
+                  in pg_get_functiondef('ash.rotate()'::regprocedure)
+                ) > 0,
+                exists (
+                  select
+                  from pg_constraint
+                  where conname = 'config_rotation_period_day_check'
+                    and conrelid = 'ash.config'::regclass
+                )
+            "
+          )"
+          if [ "$upgrade_recovered_state" != "t|t" ]; then
+            echo "::error::corrected legacy upgrade did not converge: $upgrade_recovered_state" >&2
+            exit 1
+          fi
+          echo "Legacy sub-day atomic rejection and recovery PASSED"
 
       - name: "Test 2.0 readers over rollup sources"
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5603,6 +5603,7 @@ jobs:
             echo "::error::expired-only recovery state mismatch: $expired_state" >&2
             exit 1
           fi
+          reset_issue_81_state
 
           echo "Critical bug #81 regression tests PASSED"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5553,7 +5553,7 @@ jobs:
               hashtext('pg_ash_rollup')::int4
             );
             lock table ash.sample_2 in access share mode;
-            select pg_sleep(1);
+            select pg_sleep(5);
             update ash.config
             set last_rollup_1m_ts = last_rollup_1m_ts
             where singleton;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5410,6 +5410,354 @@ jobs:
 
           echo "Critical bug #81 regression tests PASSED"
 
+      - name: "Blocker #162: cleanup/rotation compatibility and config geometry"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          /*
+           * The cleanup deadlock remains covered independently of the
+           * geometry validator. This is the audited 3-partition / 1-day
+           * rotation / 1-day minute-retention path with a 36-hour-old minute.
+           * session_replication_role models a value already present when this
+           * validator is installed; supported config writes are tested below.
+           */
+          begin;
+          truncate ash.sample, ash.rollup_1m, ash.rollup_1h;
+          set local session_replication_role = replica;
+          update ash.config
+          set current_slot = 0,
+            num_partitions = 3,
+            rotation_period = interval '1 day',
+            rollup_1m_retention_days = 1,
+            rotated_at = now() - interval '2 days',
+            last_rollup_1m_ts = null,
+            last_rollup_1h_ts = null
+          where singleton;
+          set local session_replication_role = origin;
+
+          do $$
+          declare
+            v_wait_id smallint;
+            v_old_ts int4;
+            v_result_int int;
+            v_result_text text;
+          begin
+            select ash._register_wait('active', 'Issue162', 'CleanupDeadlock')
+            into v_wait_id;
+            v_old_ts := ash.ts_from_timestamptz(
+              date_trunc('minute', now()) - interval '36 hours'
+            );
+
+            insert into ash.sample (
+              sample_ts,
+              datid,
+              active_count,
+              data,
+              slot
+            )
+            values (
+              v_old_ts,
+              (select oid from pg_database where datname = current_database()),
+              1,
+              array[-v_wait_id, 1, 0]::int[],
+              2
+            );
+
+            update ash.config
+            set last_rollup_1m_ts = v_old_ts
+            where singleton;
+            select ash.rollup_minute(1) into v_result_int;
+            assert v_result_int = 1,
+              format('precondition rollup expected 1, got %s', v_result_int);
+            assert (select count(*) from ash.rollup_1m) = 1,
+              'precondition expected exactly 1 minute-rollup row';
+
+            /*
+             * Model the shipped minute job advancing normally before the
+             * daily cleanup and rotation jobs run.
+             */
+            update ash.config
+            set last_rollup_1m_ts = ash.ts_from_timestamptz(
+              date_trunc('minute', now())
+            )
+            where singleton;
+            select ash.rollup_cleanup() into v_result_text;
+            assert v_result_text =
+              'cleanup: deleted 1 minute rows, 0 hourly rows',
+              'cleanup result mismatch: ' || v_result_text;
+            assert (select count(*) from ash.rollup_1m) = 0,
+              'cleanup must delete exactly the expired minute rollup';
+            select ash.rollup_minute(1000000) into v_result_int;
+            assert v_result_int = 0,
+              format(
+                'forward-only catch-up expected 0, got %s',
+                v_result_int
+              );
+
+            select ash.rotate() into v_result_text;
+            /*
+             * RED on the pre-fix baseline:
+             * failed: pre-truncation rollup incomplete for 1 group(s) in
+             * slot 2; slot not truncated
+             */
+            assert v_result_text =
+              'rotated: slot 0 -> 1, truncated slot 2 (sample + query_map)',
+              'rotation did not escape cleanup deadlock: ' || v_result_text;
+            assert (select current_slot from ash.config where singleton) = 1,
+              'successful rotation must advance current_slot to 1';
+            assert (select count(*) from ash.sample_2) = 0,
+              'successful rotation must truncate sample_2';
+            assert (select count(*) from ash.rollup_1m) = 0,
+              'rotation must not recreate data beyond configured retention';
+            assert (
+              select value::bigint
+              from ash.status()
+              where metric = 'consecutive_rotate_failures'
+            ) = 0,
+              'successful rotation must leave consecutive failures at 0';
+          end;
+          $$;
+          rollback;
+
+          /*
+           * Every supported config mutation must reject unsafe retention
+           * geometry and non-day-granular rotation periods before changing
+           * state.
+           */
+          begin;
+          do $$
+          declare
+            v_enabled boolean;
+            v_input interval;
+            v_message text;
+            v_raised boolean;
+            v_rotation_job bigint;
+            v_sqlstate text;
+          begin
+            update ash.config
+            set num_partitions = 3,
+              rotation_period = interval '1 day',
+              rollup_1m_retention_days = 30,
+              sampling_enabled = true
+            where singleton;
+
+            v_raised := false;
+            begin
+              update ash.config
+              set rollup_1m_retention_days = 1
+              where singleton;
+            exception when others then
+              v_raised := true;
+              get stacked diagnostics
+                v_message = message_text,
+                v_sqlstate = returned_sqlstate;
+            end;
+            assert v_raised,
+              '1-day rollup retention must reject 3-partition geometry';
+            assert v_sqlstate = '23514',
+              format('retention SQLSTATE expected 23514, got %s', v_sqlstate);
+            assert v_message =
+              'pg_ash: invalid retention geometry: '
+              '(num_partitions - 1) * rotation_period = '
+              '(3 - 1) * 1 day = 2 days exceeds '
+              'rollup_1m_retention_days = 1 day; increase '
+              'rollup_1m_retention_days or reduce num_partitions or '
+              'rotation_period',
+              'retention message mismatch: ' || v_message;
+            assert (
+              select rollup_1m_retention_days
+              from ash.config
+              where singleton
+            ) = 30,
+              'rejected retention update changed config';
+
+            select sampling_enabled into v_enabled
+            from ash.config
+            where singleton;
+            v_raised := false;
+            begin
+              perform ash.rebuild_partitions(32, 'yes');
+            exception when others then
+              v_raised := true;
+              get stacked diagnostics
+                v_message = message_text,
+                v_sqlstate = returned_sqlstate;
+            end;
+            assert v_raised,
+              '32 partitions must reject stock 30-day retention geometry';
+            assert v_sqlstate = '23514',
+              format('rebuild SQLSTATE expected 23514, got %s', v_sqlstate);
+            assert v_message =
+              'pg_ash: invalid retention geometry: '
+              '(num_partitions - 1) * rotation_period = '
+              '(32 - 1) * 1 day = 31 days exceeds '
+              'rollup_1m_retention_days = 30 days; increase '
+              'rollup_1m_retention_days or reduce num_partitions or '
+              'rotation_period',
+              'rebuild message mismatch: ' || v_message;
+            assert (
+              select num_partitions from ash.config where singleton
+            ) = 3,
+              'rejected rebuild changed num_partitions';
+            assert (
+              select sampling_enabled from ash.config where singleton
+            ) = v_enabled,
+              'rejected rebuild changed sampling_enabled';
+            assert to_regclass('ash.sample_31') is null,
+              'rejected rebuild created sample_31';
+
+            foreach v_input in array
+              array[interval '12 hours', interval '36 hours']
+            loop
+              v_raised := false;
+              begin
+                update ash.config
+                set rotation_period = v_input
+                where singleton;
+              exception when others then
+                v_raised := true;
+                get stacked diagnostics
+                  v_message = message_text,
+                  v_sqlstate = returned_sqlstate;
+              end;
+              assert v_raised,
+                'non-day-granular rotation_period must be rejected';
+              assert v_sqlstate = '23514',
+                format(
+                  'rotation_period SQLSTATE expected 23514, got %s',
+                  v_sqlstate
+                );
+              assert v_message = format(
+                'pg_ash: rotation_period must be a whole number of days '
+                '(minimum 1 day); sub-day and fractional-day rotation are '
+                'unsupported because ash.rotate() is scheduled daily; got %s',
+                v_input
+              ),
+                'rotation_period message mismatch: ' || v_message;
+            end loop;
+            assert (
+              select rotation_period from ash.config where singleton
+            ) = interval '1 day',
+              'rejected rotation_period update changed config';
+
+            update ash.config
+            set rotation_period = interval '2 days'
+            where singleton;
+            assert (
+              select rotation_period from ash.config where singleton
+            ) = interval '2 days',
+              'safe whole-day rotation_period must be accepted';
+            assert (
+              select value from ash.status() where metric = 'rotation_period'
+            ) = '2 days',
+              'status must report an accepted multi-day rotation_period';
+            update ash.config
+            set rotation_period = interval '1 day'
+            where singleton;
+
+            assert (
+              select value from ash.status() where metric = 'rotation_period'
+            ) = '1 day',
+              'status rotation_period value must remain machine-readable';
+            assert (
+              select value
+              from ash.status()
+              where metric = 'rotation_period_contract'
+            ) = 'day-granular; minimum 1 day',
+              'status must document the day-granular rotation contract';
+
+            if ash._pg_cron_available() then
+              perform 1 from ash.start();
+              select jobid into v_rotation_job
+              from cron.job
+              where jobname = 'ash_rotation';
+              perform cron.alter_job(
+                job_id := v_rotation_job,
+                schedule := '*/5 * * * *'
+              );
+              assert (
+                select schedule
+                from cron.job
+                where jobname = 'ash_rotation'
+              ) = '*/5 * * * *',
+                'precondition: rotation schedule drift was not installed';
+
+              perform 1 from ash.start();
+              assert (
+                select schedule
+                from cron.job
+                where jobname = 'ash_rotation'
+              ) = '0 0 * * *',
+                'ash_rotation must keep its daily schedule';
+            end if;
+          end;
+          $$;
+          rollback;
+
+          /*
+           * The formerly documented 32-partition sequence stays covered at
+           * the safe 31-day minute-rollup boundary.
+           */
+          begin;
+          do $$
+          declare
+            v_expected smallint[] := array[
+              2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+              17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
+              31, 0, 1, 2, 3, 4, 5
+            ]::smallint[];
+            v_result text;
+            v_target smallint;
+            v_targets smallint[] := '{}'::smallint[];
+          begin
+            update ash.config
+            set rollup_1m_retention_days = 31
+            where singleton;
+            select ash.rebuild_partitions(32, 'yes') into v_result;
+            assert v_result =
+              'rebuilt: 3 -> 32 partitions. all raw data cleared. '
+              'call ash.start() to resume sampling.',
+              'safe rebuild result mismatch: ' || v_result;
+
+            for i in 1 .. 36 loop
+              update ash.config
+              set rotated_at = now() - interval '2 days'
+              where singleton;
+              select ash.rotate() into v_result;
+              v_target := ((i + 1) % 32)::smallint;
+              assert v_result = format(
+                'rotated: slot %s -> %s, truncated slot %s '
+                '(sample + query_map)',
+                (i - 1) % 32,
+                i % 32,
+                v_target
+              ),
+                format('rotation %s result mismatch: %s', i, v_result);
+              v_targets := array_append(v_targets, v_target);
+            end loop;
+
+            assert v_targets = v_expected,
+              format(
+                'truncate targets expected %s, got %s',
+                v_expected,
+                v_targets
+              );
+            assert (
+              select current_slot from ash.config where singleton
+            ) = 4,
+              '36 rotations from slot 0 must end at slot 4';
+          end;
+          $$;
+          rollback;
+
+          do $$
+          begin
+            raise notice 'issue #162 cleanup/rotation regression tests PASSED';
+          end;
+          $$;
+          EOF
+
       - name: "Test 2.0 readers over rollup sources"
         env:
           PGPASSWORD: postgres

--- a/README.md
+++ b/README.md
@@ -365,10 +365,24 @@ This requires a restart because `cron.log_run` is postmaster-context.
 Raw samples use a PGQ-style ring of partitions. Defaults:
 
 - `num_partitions = 3`
-- `rotation_period = '1 day'`
+- `rotation_period = '1 day'` (whole days only; minimum 1 day)
 - readable raw retention is roughly `(num_partitions - 2) * rotation_period`
 - `rollup_1m` retention is 30 days
 - `rollup_1h` retention is 5 years
+
+`ash.start()` checks rotation once a day. Multi-day periods work because early
+checks skip until the configured period is due; sub-day and fractional-day
+periods are rejected. The minute rollup must outlive the raw slot that rotation
+is about to truncate:
+
+```text
+(num_partitions - 1) * rotation_period <= rollup_1m_retention_days
+```
+
+Configuration changes and `ash.rebuild_partitions()` reject unsafe geometry
+with the full arithmetic and name the knobs to adjust. For example, 32
+one-day partitions require at least 31 days of `rollup_1m` retention; the
+default 30-day retention supports at most 31 partitions.
 
 Increase raw retention:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -52,6 +52,13 @@ surface has been replaced by the AAS-oriented 2.0 API:
   it. The three earlier legacy migration legs remain unchanged. Invoking the
   installer with `\i` inside an existing transaction commits the caller's outer
   work when the installer reaches its final `COMMIT`. (issue #124)
+- **Reader upgrades remove a legacy admin-helper grant.** Reapplying or
+  upgrading intentionally revokes reader-role `EXECUTE` on
+  `ash._admin_funcs()` (including delegated grants), because it is an
+  administrative implementation detail used by `grant_reader()` and
+  `revoke_reader()`. Other reader-function grants remain preserved, and
+  complete reader bundles still gain newly introduced reader helpers.
+  (issue #166; [PR #181](https://github.com/NikolayS/pg_ash/pull/181))
 
 ## Retired tooling
 

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -1572,18 +1572,24 @@ begin
     into v_endangered_rows
     using v_rollup_1m_cutoff;
 
-    if v_endangered_rows > 0 then
-      if not pg_try_advisory_xact_lock(
-           hashtext('pg_ash')::int4,
-           hashtext('pg_ash_rollup')::int4
-         ) then
-        perform ash._record_rotate_failure();
-        return format(
-          'failed: pre-truncation rollup busy; slot %s not truncated',
-          v_truncate_slot
-        );
-      end if;
+    /*
+     * Every truncate must serialize with rollup_minute(), even when the
+     * target contains only expired rows. Otherwise rotate() can lock config
+     * and wait for rollup's sample-table lock while rollup waits for config,
+     * creating a deadlock on the cleanup/rotation escape path (#162).
+     */
+    if not pg_try_advisory_xact_lock(
+         hashtext('pg_ash')::int4,
+         hashtext('pg_ash_rollup')::int4
+       ) then
+      perform ash._record_rotate_failure();
+      return format(
+        'failed: pre-truncation rollup busy; slot %s not truncated',
+        v_truncate_slot
+      );
+    end if;
 
+    if v_endangered_rows > 0 then
       v_rotation_minutes :=
         greatest(extract(epoch from v_rotation_period)::int / 60, 1);
 
@@ -2271,7 +2277,9 @@ begin
   -- Check for existing rotation job (idempotent)
   select jobid into v_rotation_job
   from cron.job
-  where jobname = 'ash_rotation';
+  where jobname = 'ash_rotation'
+    and username = current_user
+    and database = current_database();
 
   if v_rotation_job is not null then
     /*

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -361,8 +361,10 @@ $$;
  * Ensure retention CHECK constraints exist for both fresh and upgrade paths.
  * ADD COLUMN IF NOT EXISTS above doesn't apply CHECKs to pre-existing columns,
  * so add them explicitly here (guarded by a not-exists probe for idempotency).
- * The rotation-period CHECK is installed at the end, after every replacement
- * function is safely in place for a legacy invalid-value upgrade.
+ * The rotation-period CHECK is installed at the end so a legacy invalid value
+ * reaches the actionable validator before PostgreSQL can emit a generic CHECK
+ * error. The file-level transaction rolls the attempted upgrade back; after
+ * correcting the legacy value, the operator re-runs the installer.
  */
 do $$
 begin
@@ -6844,10 +6846,11 @@ end $$;
 /*
  * Enforce the day-granular rotation contract last. A legacy install may
  * already contain a sub-day value that older versions accepted. The
- * actionable error must still stop that unsupported configuration, but only
- * after this autocommit-friendly installer has replaced rotate() and the rest
- * of the operational surface. The operator can set a whole-day value and
- * re-run the installer to add the declarative CHECK.
+ * actionable error must still stop that unsupported configuration. Because
+ * this installer is file-transactional, the error rolls every replacement
+ * back. The operator can update the pre-existing config to a whole-day value
+ * and re-run the installer to atomically install the operational surface and
+ * declarative CHECK.
  */
 do $$
 begin

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -260,7 +260,16 @@ create table if not exists ash.config (
   skipped_samples            int4 not null default 0,
   missed_samples             bigint not null default 0,
   sample_interval            interval not null default '1 second',
-  rotation_period            interval not null default '1 day',
+  -- Keep this predicate aligned with _validate_rotation_period() below.
+  rotation_period            interval not null default '1 day'
+                               constraint config_rotation_period_day_check
+                               check (
+                                 rotation_period >= interval '1 day'
+                                 and extract(year from rotation_period) = 0
+                                 and extract(month from rotation_period) = 0
+                                 and extract(epoch from rotation_period)
+                                   % 86400 = 0
+                               ),
   include_bg_workers         bool not null default false,
   debug_logging              bool not null default false,
   encoding_version           smallint not null default 1,
@@ -277,7 +286,9 @@ create table if not exists ash.config (
   -- M-BUG-4: rows silently dropped by take_sample()'s inner exception handler.
   insert_errors              bigint not null default 0,
   -- M-BUG-6 / H-SEC-3: _register_wait dictionary-cap hit counter.
-  register_wait_cap_hits     bigint not null default 0
+  register_wait_cap_hits     bigint not null default 0,
+  -- Consecutive rotate() failure returns; reset by a successful rotation.
+  consecutive_rotate_failures bigint not null default 0
 );
 
 -- Insert initial row if not exists.
@@ -309,18 +320,56 @@ alter table ash.config
    * registrations are being silently dropped for that sample (those sessions
    * won't appear in encoded data for this tick). Surfaced by ash.status().
    */
-  add column if not exists register_wait_cap_hits bigint not null default 0;
+  add column if not exists register_wait_cap_hits bigint not null default 0,
+  add column if not exists consecutive_rotate_failures bigint not null
+    default 0;
+
+/*
+ * Keep the day-granularity error reusable and actionable. The explicit call
+ * before ADD CONSTRAINT makes upgrades from a formerly accepted sub-day value
+ * fail with remediation text instead of PostgreSQL's generic CHECK message.
+ */
+create or replace function ash._validate_rotation_period(
+  rotation_period interval
+)
+returns void
+language plpgsql
+immutable
+set search_path = pg_catalog, ash
+as $$
+begin
+  -- This predicate mirrors both the declarative CHECKs below.
+  if rotation_period < interval '1 day'
+     or extract(year from rotation_period) <> 0
+     or extract(month from rotation_period) <> 0
+     or extract(epoch from rotation_period) % 86400 <> 0 then
+    raise exception using
+      errcode = '23514',
+      message = format(
+        'pg_ash: rotation_period must be a whole number of days '
+        '(minimum 1 day); sub-day and fractional-day rotation are '
+        'unsupported because ash.rotate() is scheduled daily; got %s; '
+        'set ash.config.rotation_period to a whole-day interval '
+        '(for example, 1 day) before retrying',
+        rotation_period
+      );
+  end if;
+end;
+$$;
 
 /*
  * Ensure retention CHECK constraints exist for both fresh and upgrade paths.
  * ADD COLUMN IF NOT EXISTS above doesn't apply CHECKs to pre-existing columns,
  * so add them explicitly here (guarded by a not-exists probe for idempotency).
+ * The rotation-period CHECK is installed at the end, after every replacement
+ * function is safely in place for a legacy invalid-value upgrade.
  */
 do $$
 begin
   if not exists (
     select from pg_constraint
     where conname = 'config_rollup_1m_retention_days_check'
+      and conrelid = 'ash.config'::regclass
   ) then
     alter table ash.config
       add constraint config_rollup_1m_retention_days_check
@@ -329,12 +378,100 @@ begin
   if not exists (
     select from pg_constraint
     where conname = 'config_rollup_1h_retention_days_check'
+      and conrelid = 'ash.config'::regclass
   ) then
     alter table ash.config
       add constraint config_rollup_1h_retention_days_check
       check (rollup_1h_retention_days >= 1);
   end if;
 end $$;
+
+/*
+ * Validate the ring geometry whenever one of its three knobs changes.
+ * This is deliberately an UPDATE-OF trigger rather than a cross-column CHECK:
+ * an existing 32-slot / 30-day install must be able to re-apply this installer
+ * and use rotate()'s expired-data escape hatch. The next attempted knob change
+ * is rejected until the geometry is safe.
+ */
+create or replace function ash._validate_rotation_config(
+  num_partitions int,
+  rotation_period interval,
+  rollup_1m_retention_days int
+)
+returns void
+language plpgsql
+immutable
+set search_path = pg_catalog, ash
+as $$
+declare
+  v_geometry interval;
+begin
+  perform ash._validate_rotation_period(rotation_period);
+
+  v_geometry := (num_partitions - 1) * rotation_period;
+  if v_geometry >
+     rollup_1m_retention_days * interval '1 day' then
+    raise exception using
+      errcode = '23514',
+      message = format(
+        'pg_ash: invalid retention geometry: '
+        '(num_partitions - 1) * rotation_period = '
+        '(%s - 1) * %s = %s exceeds '
+        'rollup_1m_retention_days = %s; increase '
+        'rollup_1m_retention_days or reduce num_partitions or '
+        'rotation_period',
+        num_partitions,
+        rotation_period,
+        v_geometry,
+        rollup_1m_retention_days
+          || case
+               when rollup_1m_retention_days = 1 then ' day'
+               else ' days'
+             end
+      );
+  end if;
+end;
+$$;
+
+create or replace function ash._validate_config_update()
+returns trigger
+language plpgsql
+set search_path = pg_catalog, ash
+as $$
+begin
+  perform ash._validate_rotation_config(
+    new.num_partitions,
+    new.rotation_period,
+    new.rollup_1m_retention_days
+  );
+  return new;
+end;
+$$;
+
+drop trigger if exists config_validate_rotation on ash.config;
+create trigger config_validate_rotation
+before insert or update of
+  num_partitions,
+  rotation_period,
+  rollup_1m_retention_days
+on ash.config
+for each row
+execute function ash._validate_config_update();
+
+comment on column ash.config.rotation_period is
+$$Whole-day partition rotation period (minimum 1 day). ash.start() checks for rotation daily; sub-day and fractional-day values are unsupported.$$;
+
+comment on column ash.config.rollup_1m_retention_days is
+$$Minute-rollup retention in days. Must cover the endangered raw-slot age: (num_partitions - 1) * rotation_period.$$;
+
+comment on function ash._validate_rotation_config(int, interval, int) is
+$$Internal validator for day-granular rotation_period and safe raw-ring/minute-rollup retention geometry.$$;
+
+comment on function ash._validate_rotation_period(interval) is
+$$Internal validator for the whole-day rotation_period contract; raises an actionable check-violation message.$$;
+
+comment on function ash._validate_config_update() is
+$$Internal trigger enforcing rotation and retention geometry whenever its ash.config knobs change.$$;
 
 /*
  * Stamp the version on both fresh installs and upgrades. On an existing
@@ -1318,6 +1455,31 @@ $$Wall-clock convenience: same as decode_sample(int4) but accepts timestamptz, c
 --------------------------------------------------------------------------------
 
 /*
+ * Record a returned rotate() failure without letting observability
+ * bookkeeping replace the operation's stable text result. rotate() sets a
+ * short lock_timeout before touching partitions; a concurrent config writer
+ * can therefore make this counter update time out too.
+ */
+create or replace function ash._record_rotate_failure()
+returns void
+language plpgsql
+set search_path = pg_catalog, ash
+set lock_timeout = '250ms'
+as $$
+begin
+  update ash.config
+  set consecutive_rotate_failures = consecutive_rotate_failures + 1
+  where singleton;
+exception when lock_not_available then
+  raise warning
+    'ash.rotate: config row locked; could not record rotate failure';
+end;
+$$;
+
+comment on function ash._record_rotate_failure() is
+$$Internal best-effort increment for consecutive_rotate_failures; config-row lock timeout must not mask rotate()'s failure result.$$;
+
+/*
  * Rotate partitions: advance current_slot, truncate the old previous
  * partition and its matching query_map partition (lockstep TRUNCATE — zero
  * bloat everywhere). Uses dynamic SQL with modulo-N for configurable
@@ -1334,6 +1496,8 @@ declare
   v_truncate_slot smallint;
   v_num_partitions smallint;
   v_rotation_period interval;
+  v_rollup_1m_retention_days smallint;
+  v_rollup_1m_cutoff int4;
   v_rotated_at timestamptz;
   v_rotation_minutes int;
   v_rollup_result int;
@@ -1357,8 +1521,18 @@ begin
 
   begin
     -- Get current config.
-    select current_slot, num_partitions, rotation_period, rotated_at
-    into v_old_slot, v_num_partitions, v_rotation_period, v_rotated_at
+    select
+      current_slot,
+      num_partitions,
+      rotation_period,
+      rollup_1m_retention_days,
+      rotated_at
+    into
+      v_old_slot,
+      v_num_partitions,
+      v_rotation_period,
+      v_rollup_1m_retention_days,
+      v_rotated_at
     from ash.config
     where singleton;
 
@@ -1372,24 +1546,36 @@ begin
 
     -- The partition to truncate is the one after the new slot.
     v_truncate_slot := (v_new_slot + 1) % v_num_partitions;
+    v_rollup_1m_cutoff := ash.ts_from_timestamptz(
+      now() - v_rollup_1m_retention_days * interval '1 day'
+    );
 
     -- Set lock timeout to avoid blocking on long-running queries.
     set local lock_timeout = '2s';
 
     /*
      * Pre-truncation rollup: process endangered minutes before they are lost.
-     * This is no longer best-effort: if the endangered raw slot has rows and
-     * we cannot prove they are represented in rollup_1m, skip rotation rather
-     * than deleting the only copy of the samples (#81).
+     * For minutes still promised by rollup_1m retention, this is no longer
+     * best-effort: if we cannot prove they are represented in rollup_1m,
+     * skip rotation rather than deleting the only copy (#81). Older minutes
+     * are outside the configured rollup contract and must not deadlock the
+     * raw ring after rollup_cleanup() has intentionally deleted them (#162).
      */
-    execute format('select count(*) from ash.sample_%s', v_truncate_slot)
-    into v_endangered_rows;
+    execute format(
+      'select count(*) '
+      'from ash.sample_%s '
+      'where (sample_ts / 60) * 60 >= $1',
+      v_truncate_slot
+    )
+    into v_endangered_rows
+    using v_rollup_1m_cutoff;
 
     if v_endangered_rows > 0 then
       if not pg_try_advisory_xact_lock(
            hashtext('pg_ash')::int4,
            hashtext('pg_ash_rollup')::int4
          ) then
+        perform ash._record_rotate_failure();
         return format(
           'failed: pre-truncation rollup busy; slot %s not truncated',
           v_truncate_slot
@@ -1402,6 +1588,7 @@ begin
       begin
         select ash.rollup_minute(v_rotation_minutes) into v_rollup_result;
       exception when undefined_function then
+        perform ash._record_rotate_failure();
         return format(
           'failed: rollup_minute() unavailable; slot %s not truncated',
           v_truncate_slot
@@ -1409,6 +1596,7 @@ begin
       when others then
         raise warning 'ash.rotate: rollup_minute failed [%]: %',
           sqlstate, sqlerrm;
+        perform ash._record_rotate_failure();
         return format(
           'failed: pre-truncation rollup failed [%s]; slot %s not truncated',
           sqlstate,
@@ -1422,6 +1610,7 @@ begin
         '         count(distinct sample_ts)::smallint as samples,'
         '         max(active_count)::smallint as peak_backends'
         '  from ash.sample_%1$s'
+        '  where (sample_ts / 60) * 60 >= $1'
         '  group by 1, 2'
         ') '
         'select count(*) '
@@ -1432,9 +1621,12 @@ begin
         '   or rollup_min.samples < raw.samples '
         '   or rollup_min.peak_backends < raw.peak_backends',
         v_truncate_slot
-      ) into v_unrolled_groups;
+      )
+      into v_unrolled_groups
+      using v_rollup_1m_cutoff;
 
       if v_unrolled_groups > 0 then
+        perform ash._record_rotate_failure();
         return format(
           'failed: pre-truncation rollup incomplete for %s group(s) '
           'in slot %s; slot not truncated',
@@ -1447,7 +1639,8 @@ begin
     -- Advance current_slot first (before truncate).
     update ash.config
     set current_slot = v_new_slot,
-      rotated_at = now()
+      rotated_at = now(),
+      consecutive_rotate_failures = 0
     where singleton;
 
     /*
@@ -1468,6 +1661,7 @@ begin
       v_old_slot, v_new_slot, v_truncate_slot);
 
   exception when lock_not_available then
+    perform ash._record_rotate_failure();
     return 'failed: lock timeout on partition truncate, will retry next cycle';
   when others then
     raise;
@@ -1495,6 +1689,8 @@ declare
   v_old_n int;
   v_new_n int;
   v_rec record;
+  v_rotation_period interval;
+  v_rollup_1m_retention_days int;
 begin
   /*
    * Destructive: drops all raw sample partitions. Require explicit
@@ -1507,7 +1703,14 @@ begin
       'select ash.rebuild_partitions(%, ''yes'')', num_partitions;
   end if;
 
-  select config_row.num_partitions into v_old_n
+  select
+    config_row.num_partitions,
+    config_row.rotation_period,
+    config_row.rollup_1m_retention_days
+  into
+    v_old_n,
+    v_rotation_period,
+    v_rollup_1m_retention_days
   from ash.config as config_row
   where config_row.singleton;
   v_new_n := coalesce(rebuild_partitions.num_partitions, v_old_n);
@@ -1515,6 +1718,17 @@ begin
   if v_new_n < 3 or v_new_n > 32 then
     raise exception 'num_partitions must be between 3 and 32, got: %', v_new_n;
   end if;
+
+  /*
+   * Reject unsafe geometry before disabling sampling, changing cron jobs, or
+   * touching partitions. The endangered slot is (num_partitions - 1)
+   * rotation periods old, so its minute rollups must still be retained.
+   */
+  perform ash._validate_rotation_config(
+    v_new_n,
+    v_rotation_period,
+    v_rollup_1m_retention_days
+  );
 
   -- Step 1: mark sampling disabled. take_sample() checks this and returns
   -- early.
@@ -2058,9 +2272,17 @@ begin
   where jobname = 'ash_rotation';
 
   if v_rotation_job is not null then
+    /*
+     * The supported rotation contract is day-granular. Repair any manually
+     * drifted or legacy sub-day cron expression on every idempotent start.
+     */
+    perform cron.alter_job(
+      job_id := v_rotation_job,
+      schedule := '0 0 * * *'
+    );
     job_type := 'rotation';
     job_id := v_rotation_job;
-    status := 'already exists';
+    status := 'already exists — schedule reset to 0 0 * * *';
     return next;
   else
     -- Create rotation job (daily at midnight UTC).
@@ -2598,6 +2820,9 @@ begin
   metric := 'current_slot'; value := v_config.current_slot::text; return next;
   metric := 'sample_interval'; value := v_config.sample_interval::text; return next;
   metric := 'rotation_period'; value := v_config.rotation_period::text; return next;
+  metric := 'rotation_period_contract';
+  value := 'day-granular; minimum 1 day';
+  return next;
   metric := 'raw_retention';
   value := ((v_config.num_partitions - 2) * v_config.rotation_period)::text
     || ' + current partial';
@@ -2615,6 +2840,9 @@ begin
   metric := 'rotated_at'; value := v_config.rotated_at::text; return next;
   metric := 'time_since_rotation';
   value := (now() - v_config.rotated_at)::text;
+  return next;
+  metric := 'consecutive_rotate_failures';
+  value := v_config.consecutive_rotate_failures::text;
   return next;
 
   if v_last_sample_ts is not null then
@@ -5922,10 +6150,10 @@ $$pg_ash: Active Session History for Postgres (pure SQL, no extension). Reader e
  * reader-vs-ops split is legible from \df+ alone.
  */
 comment on function ash.status() is
-$$Installation health snapshot (readable by monitoring roles): sampling state and interval, pg_cron job status, partition slots and sizes, rollup progress/lag, retention starts (raw_retention_start, rollup_1m_retention_start, rollup_1h_retention_start — use these to plan reader windows), error counters (insert_errors, register_wait_cap_hits, missed/skipped samples), and version. Returns (metric, value) rows. Start here when pg_ash misbehaves; readers are documented on the schema: obj_description('ash'::regnamespace).$$;
+$$Installation health snapshot (readable by monitoring roles): sampling state and interval, the day-granular rotation_period contract (whole days, minimum 1 day), pg_cron job status, partition slots and sizes, rollup progress/lag, retention starts (raw_retention_start, rollup_1m_retention_start, rollup_1h_retention_start — use these to plan reader windows), error counters (consecutive_rotate_failures, insert_errors, register_wait_cap_hits, missed/skipped samples), and version. Returns (metric, value) rows. Start here when pg_ash misbehaves; readers are documented on the schema: obj_description('ash'::regnamespace).$$;
 
 comment on function ash.start(interval) is
-$$Admin: start sampling — schedules take_sample() at the given interval (every => ..., default 1 second; accepts 1–59 whole seconds, whole minutes, or whole hours up to 23h) plus rollup_minute()/rollup_hour()/rollup_cleanup() and rotation via pg_cron when available; without pg_cron it enables sampling and prints the jobs to schedule externally. Idempotent. Inverse: ash.stop(). Check with ash.status().$$;
+$$Admin: start sampling — schedules take_sample() at the given interval (every => ..., default 1 second; accepts 1–59 whole seconds, whole minutes, or whole hours up to 23h) plus rollup_minute()/rollup_hour()/rollup_cleanup() and a daily rotation check via pg_cron when available. rotation_period accepts whole days only (minimum 1 day); early daily checks skip until it is due. Without pg_cron, start enables sampling and prints the jobs to schedule externally. Idempotent. Inverse: ash.stop(). Check with ash.status().$$;
 
 comment on function ash.stop() is
 $$Admin: stop sampling — unschedules the pg_cron jobs created by ash.start() (or disables sampling when pg_cron is absent). Collected data is kept and remains readable. Inverse: ash.start().$$;
@@ -5934,7 +6162,7 @@ comment on function ash.take_sample() is
 $$Admin/internal: take one wait-event sample of pg_stat_activity into the current slot (the every-second worker that ash.start() schedules). Returns the number of active backends captured. Call manually only for testing; continuous sampling belongs to ash.start().$$;
 
 comment on function ash.rotate() is
-$$Admin: rotate to the next partition slot, rolling up and truncating the oldest (the daily job scheduled by ash.start()). Readable raw retention is approximately (num_partitions - 2) * rotation_period. Safe to call manually to force a rotation.$$;
+$$Admin: rotate to the next partition slot, rolling up and truncating the oldest (checked daily by ash.start()). Readable raw retention is roughly (num_partitions - 2) * rotation_period plus the current partial period. The pre-truncation guard requires minute rollups only while they remain inside rollup_1m_retention_days. Failed attempts increment consecutive_rotate_failures in ash.status(); successful rotation resets it. Safe to call manually to force a due rotation.$$;
 
 comment on function ash.rollup_minute(int) is
 $$Admin: fold completed minutes of raw samples into ash.rollup_1m (the every-minute job scheduled by ash.start()); batch_limit caps catch-up minutes per call. Returns minutes processed. Readers pick rollups automatically — this only needs manual calls when pg_cron is absent.$$;
@@ -5943,10 +6171,10 @@ comment on function ash.rollup_hour() is
 $$Admin: fold completed hours of ash.rollup_1m into ash.rollup_1h, preserving per-minute totals in minute_counts so long-window peak/p99 stay minute-grain (the hourly job scheduled by ash.start()). Returns hours processed.$$;
 
 comment on function ash.rollup_cleanup() is
-$$Admin: delete rollup rows past retention (rollup_1m_retention_days / rollup_1h_retention_days in ash.config; the daily job scheduled by ash.start()). Returns a summary of rows deleted.$$;
+$$Admin: delete rollup rows past retention (rollup_1m_retention_days / rollup_1h_retention_days in ash.config; the daily job scheduled by ash.start()). Rotation deliberately does not require minute rollups that this cleanup is entitled to delete. Returns a summary of rows deleted.$$;
 
 comment on function ash.rebuild_partitions(int, text) is
-$$Admin, DESTRUCTIVE: drop and recreate the sample/query-map partitions and query_map_all view with num_partitions slots (3-32). Readable raw retention is approximately (num_partitions - 2) * rotation_period. Requires confirm => 'yes'. DELETES ALL RAW SAMPLES (rollups are kept). Complete ash.grant_reader() bundles, including the default pg_monitor bundle, are preserved across the rebuild.$$;
+$$Admin, DESTRUCTIVE: drop and recreate the sample/query-map partitions and query_map_all view with num_partitions slots (3-32). Before changing state, rejects geometry where (num_partitions - 1) * rotation_period exceeds rollup_1m_retention_days; rotation_period is whole-day only. Readable raw retention is roughly (num_partitions - 2) * rotation_period plus the current partial period. Requires confirm => 'yes'. DELETES ALL RAW SAMPLES (rollups are kept). Complete ash.grant_reader() bundles, including the default pg_monitor bundle, are preserved across the rebuild.$$;
 
 comment on function ash.set_debug_logging(bool) is
 $$Admin: toggle debug logging for the sampler and rollup jobs (null argument reports the current setting). Returns the resulting state.$$;
@@ -6075,7 +6303,8 @@ as $$
     'rollup_hour', 'rollup_cleanup', '_drop_all_partitions',
     '_rebuild_query_map_view', '_merge_wait_counts', '_merge_query_counts',
     '_truncate_pairs', '_int4_array_cat_agg', '_int8_array_cat_agg',
-    '_register_wait',
+    '_register_wait', '_validate_rotation_period', '_record_rotate_failure',
+    '_validate_rotation_config', '_validate_config_update',
     /*
      * The privilege helpers and their canonical exclusion-list helper are
      * administrative. Granting grant_reader/revoke_reader to a monitoring
@@ -6214,9 +6443,10 @@ end $$;
  *     rollup_minute, rollup_hour, rollup_cleanup, _drop_all_partitions,
  *     _rebuild_query_map_view, _merge_wait_counts, _merge_query_counts,
  *     _truncate_pairs, _int4_array_cat_agg, _int8_array_cat_agg,
- *     _register_wait, _admin_funcs). Defining "reader" by exclusion
- *     (rather than enumeration) keeps the helpers correct as new readers
- *     and reader-internal helpers are added.
+ *     _register_wait, _validate_rotation_period, _record_rotate_failure,
+ *     _validate_rotation_config, _validate_config_update, _admin_funcs).
+ *     Defining "reader" by exclusion (rather than enumeration) keeps the
+ *     helpers correct as new readers and reader-internal helpers are added.
  *   - SELECT on ash.sample (+ every sample_N partition), ash.query_map_all
  *     (+ every query_map_N partition), ash.config, ash.wait_event_map,
  *     ash.rollup_1m, ash.rollup_1h.
@@ -6608,6 +6838,37 @@ begin
         v_hourly_job.command
       );
     end loop;
+  end if;
+end $$;
+
+/*
+ * Enforce the day-granular rotation contract last. A legacy install may
+ * already contain a sub-day value that older versions accepted. The
+ * actionable error must still stop that unsupported configuration, but only
+ * after this autocommit-friendly installer has replaced rotate() and the rest
+ * of the operational surface. The operator can set a whole-day value and
+ * re-run the installer to add the declarative CHECK.
+ */
+do $$
+begin
+  perform ash._validate_rotation_period(
+    (select rotation_period from ash.config where singleton)
+  );
+
+  if not exists (
+    select from pg_constraint
+    where conname = 'config_rotation_period_day_check'
+      and conrelid = 'ash.config'::regclass
+  ) then
+    -- Keep this predicate aligned with _validate_rotation_period() above.
+    alter table ash.config
+      add constraint config_rotation_period_day_check
+      check (
+        rotation_period >= interval '1 day'
+        and extract(year from rotation_period) = 0
+        and extract(month from rotation_period) = 0
+        and extract(epoch from rotation_period) % 86400 = 0
+      );
   end if;
 end $$;
 

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -6172,7 +6172,7 @@ comment on function ash.take_sample() is
 $$Admin/internal: take one wait-event sample of pg_stat_activity into the current slot (the every-second worker that ash.start() schedules). Returns the number of active backends captured. Call manually only for testing; continuous sampling belongs to ash.start().$$;
 
 comment on function ash.rotate() is
-$$Admin: rotate to the next partition slot, rolling up and truncating the oldest (checked daily by ash.start()). Readable raw retention is roughly (num_partitions - 2) * rotation_period plus the current partial period. The pre-truncation guard requires minute rollups only while they remain inside rollup_1m_retention_days. Failed attempts increment consecutive_rotate_failures in ash.status(); successful rotation resets it. Safe to call manually to force a due rotation.$$;
+$$Admin: rotate to the next partition slot, rolling up and truncating the oldest (checked daily by ash.start()). Readable raw retention is approximately (num_partitions - 2) * rotation_period. The current partial period may add more. The pre-truncation guard requires minute rollups only while they remain inside rollup_1m_retention_days. Failed attempts increment consecutive_rotate_failures in ash.status(); successful rotation resets it. Safe to call manually to force a due rotation.$$;
 
 comment on function ash.rollup_minute(int) is
 $$Admin: fold completed minutes of raw samples into ash.rollup_1m (the every-minute job scheduled by ash.start()); batch_limit caps catch-up minutes per call. Returns minutes processed. Readers pick rollups automatically — this only needs manual calls when pg_cron is absent.$$;
@@ -6184,7 +6184,7 @@ comment on function ash.rollup_cleanup() is
 $$Admin: delete rollup rows past retention (rollup_1m_retention_days / rollup_1h_retention_days in ash.config; the daily job scheduled by ash.start()). Rotation deliberately does not require minute rollups that this cleanup is entitled to delete. Returns a summary of rows deleted.$$;
 
 comment on function ash.rebuild_partitions(int, text) is
-$$Admin, DESTRUCTIVE: drop and recreate the sample/query-map partitions and query_map_all view with num_partitions slots (3-32). Before changing state, rejects geometry where (num_partitions - 1) * rotation_period exceeds rollup_1m_retention_days; rotation_period is whole-day only. Readable raw retention is roughly (num_partitions - 2) * rotation_period plus the current partial period. Requires confirm => 'yes'. DELETES ALL RAW SAMPLES (rollups are kept). Complete ash.grant_reader() bundles, including the default pg_monitor bundle, are preserved across the rebuild.$$;
+$$Admin, DESTRUCTIVE: drop and recreate the sample/query-map partitions and query_map_all view with num_partitions slots (3-32). Before changing state, rejects geometry where (num_partitions - 1) * rotation_period exceeds rollup_1m_retention_days; rotation_period is whole-day only. Readable raw retention is approximately (num_partitions - 2) * rotation_period. The current partial period may add more. Requires confirm => 'yes'. DELETES ALL RAW SAMPLES (rollups are kept). Complete ash.grant_reader() bundles, including the default pg_monitor bundle, are preserved across the rebuild.$$;
 
 comment on function ash.set_debug_logging(bool) is
 $$Admin: toggle debug logging for the sampler and rollup jobs (null argument reports the current setting). Returns the resulting state.$$;


### PR DESCRIPTION
Fixes #162
Refs #167

## Summary

`ash.rollup_cleanup()` could delete minute rollups that `ash.rotate()`'s pre-truncation completeness guard still required. Because `ash.rollup_minute()` advances its watermark only forward, rotation then failed forever and the raw partition ring stopped draining.

This change deliberately excludes raw minute groups already older than `rollup_1m_retention_days` from the pre-truncation gate. Those groups are consciously abandoned: cleanup is entitled to delete their rollups, rewinding would recreate data that cleanup would immediately remove, and it would turn rotation into an unbounded historical catch-up. Supported configurations are prevented from reaching this state by validating:

```text
(num_partitions - 1) * rotation_period <= rollup_1m_retention_days
```

The validator runs on relevant `ash.config` writes and before `ash.rebuild_partitions()` changes any state. Existing unsafe legacy geometry can still load the installer and drain through the expired-data escape hatch; the next geometry-changing write must make it safe.

## Observability and contract

Known text-return failure paths increment `ash.status()` metric `consecutive_rotate_failures`; a successful rotation resets it to `0`. Counter recording has its own bounded, best-effort lock timeout so observability cannot mask the stable `rotate()` result when `ash.config` is concurrently locked.

I retained the text return contract. Raising this late would change the public/admin API and, in the same transaction, roll back the counter meant to expose the failure. The status metric is the conservative compatible signal.

## Rotation-period decision

The C3 half of #167 is implemented as decided: sub-day and fractional-day `rotation_period` values are unsupported. A declarative CHECK plus trigger validator accepts whole days only (minimum one day), with actionable remediation. A file-level installer transaction makes a legacy sub-day value return the exact actionable validation error and rolls the attempted upgrade back atomically; after correcting the value, the operator reruns the installer. `ash.start()` keeps the owned rotation job on the documented daily `0 0 * * *` schedule; multi-day periods work through `rotate()`'s due-time check. README, catalog comments, and `ash.status()` document the contract.

## RED / GREEN

Both RED paths produced exactly:

```text
failed: pre-truncation rollup incomplete for 1 group(s) in slot 2; slot not truncated
```

The one-day-retention reproduction also proved forward catch-up returned `0`. The stock 32-partition run reproduced the truncate-target sequence:

```text
2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 0 1 2 3 4 5
```

GREEN is exactly:

```text
rotated: slot 0 -> 1, truncated slot 2 (sample + query_map)
```

The expired rollup stays deleted, the raw target is truncated, and the failure metric is `0` after success.

## Validation

- PostgreSQL 14.23, 15.18, 16.14, 17.9, 18.4, and 19beta2: fresh install, #162 behavior/geometry/sub-day/32-slot coverage, installer reapply — PASS
- Complete #81 concurrency suite, including counter-row lock timeout and outer exception-handler timeout — PASS on PostgreSQL 14–19
- Expired-only rollup/rotation lock-order regression: RED deadlock, GREEN bounded busy result, raw preservation, successful retry — PASS on PostgreSQL 17
- pg_cron same-name cross-owner collision: unrelated job unchanged, caller-owned daily job created — PASS on PostgreSQL 17
- Full discovered upgrade chain and fresh-vs-upgrade schema equivalence on PostgreSQL 17.9 — PASS
- Legacy 12-hour installer path: exact actionable rejection with full rollback, then correction to one day and CHECK restoration — PASS on PostgreSQL 14–19
- Workflow YAML, extracted Bash syntax, docs lint, and `git diff --check` — PASS
- Local five-lens REV fallback — PASS; cloud `claude ultrareview` could not launch because its free-review quota was exhausted. Initial actionable findings were fixed and re-reviewed.

