### PR TITLE
release: clarify AAS cadence and coverage limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,9 @@ It includes:
 - wait classes: `total`, `cpu`, `io`, `ipc`, `lock`, `lwlock`
 - top wait events and top query IDs for extreme minutes
 - `top_queryids_available`, so scrapers can branch without guessing
-- `coverage`, so consumers can reconcile against `ash.aas()` and `ash.top()`
+- `coverage`, so consumers can reconcile against `ash.aas()` and `ash.top()`;
+  its `minutes_with_data` counts activity-bearing rollup minutes, not verified
+  sampler heartbeats
 
 `ash.report()` reads `ash.rollup_1m` only. If a requested window exists only
 in raw samples or `ash.rollup_1h`, it returns SQL `NULL` and emits a NOTICE
@@ -512,6 +514,19 @@ Postgres.
   exhaust it faster on older Postgres versions.
 - Parallel workers share the leader query ID and count as separate active
   backends.
+- 2.0 does not persist the cadence in force for historical samples. AAS readers
+  weight every stored appearance with the current
+  `ash.config.sample_interval`, so changing it rescales earlier raw and rollup
+  history. Keep the interval fixed while that history is needed. At intervals
+  greater than one minute, the full tick weight lands in one minute, so
+  one-minute peaks and report worst-minute values can exceed the concurrency
+  actually observed.
+- Successful idle sampler ticks write no row. `data_points`,
+  `buckets_with_data`, and report `minutes_with_data` describe
+  facts derived from stored activity, not verified sampling coverage; a
+  sampled-idle minute and a sampler outage are indistinguishable. Monitor
+  scheduler health independently. `ash.timeline()` calls these buckets “no
+  stored observation”; that wording does not add heartbeat storage.
 - Sampling generates WAL, but pg_ash does not currently ship a maintained 2.0
   benchmark for a portable per-sample estimate. Measure WAL on the target
   workload.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -75,6 +75,21 @@ AAS-oriented 2.0 API:
   completion after SQL errors. No maintained 2.0 performance harness replaces
   it yet; validate capacity and WAL on the target workload. (issue #139)
 
+## Known limitations
+
+- **Historical cadence and idle coverage are not persisted.** AAS readers
+  weight stored appearances with the current `ash.config.sample_interval`, so
+  changing it rescales earlier raw and rollup history. Successful idle sampler
+  ticks write no row; consequently `data_points`, `buckets_with_data`, and
+  report `minutes_with_data` are derived from stored activity and do not verify
+  successful sampling; they cannot distinguish sampled zero load from a
+  sampler outage. At sampling intervals greater than one minute, the full tick
+  weight is assigned to one minute, so one-minute peaks and report
+  worst-minute values can exceed observed concurrency. Keep cadence fixed and
+  monitor scheduler health independently. `ash.timeline()` now calls these
+  buckets “no stored observation,” but that catalog correction does not add
+  heartbeat storage. (issues #137 and #175)
+
 Known security limitation: advisory-lock squat DoS remains possible for roles
 that can intentionally hold pg_ash advisory locks. See
 [SECURITY.md](SECURITY.md#advisory-lock-squat-dos).

--- a/blueprints/AAS_API.md
+++ b/blueprints/AAS_API.md
@@ -9,6 +9,20 @@ removed (see §8). Sampling, storage, rollups, and admin/lifecycle functions
 (`take_sample`, `rotate`, `rollup_*`, `start`/`stop`, `status`,
 `grant_reader`/`revoke_reader`, `uninstall`) are unchanged.
 
+> **2.0 cadence and coverage limitation.** Sampling cadence and successful
+> idle ticks are not persisted. Every AAS reader weights historical
+> appearances with the current `ash.config.sample_interval`, so changing it
+> rescales raw and rollup history. In this document, “data” and
+> `minutes_with_data` are derived from stored activity, not verified sampler
+> coverage: an idle minute, a sampler outage, and a retention gap can have the
+> same stored representation. Keep cadence fixed and monitor the scheduler
+> independently. At intervals greater than one minute, the full tick weight
+> lands in one minute, so minute extrema can exceed observed concurrency.
+> Persisted cadence and heartbeats are tracked in issue #137.
+> `ash.timeline()` now calls these buckets “no stored observation”; its
+> corrected grain semantics do not make idle time distinguishable from an
+> outage.
+
 ---
 
 ## 1. Principles
@@ -17,9 +31,10 @@ removed (see §8). Sampling, storage, rollups, and admin/lifecycle functions
    `p99_aas` (numeric, in average-active-sessions), with `backend_seconds` as
    a secondary absolute column. The v1.x units `samples` and bare
    `backend_seconds`-as-primary disappear.
-2. **One time convention.** Every reader takes
-   `since timestamptz default null` → `now() - interval '1 hour'` and
-   `until timestamptz default null` → `now()`.
+2. **One time convention.** Reader windows are `[since, until)`. With only
+   `until`, `since` defaults to `until - interval '1 hour'`; with neither bound,
+   the default is the last hour (`report` alone defaults to the last day).
+   Explicit `since > until` raises before the overflow-safe empty-window clamp.
    The `f(interval)` / `f_at(start, end)` twin pattern is dropped — that alone
    halves the surface. "Last 24 hours" is `since => now() - interval '24 hours'`.
 3. **Dimensions are parameters, not function names.** Group-by is an argument
@@ -65,7 +80,7 @@ Seven data functions, two render helpers. (v1.5 shipped ~25 readers × 2 forms.)
 ### Common parameters (uniform everywhere they appear)
 
 ```
-since           timestamptz default null   -- null → now() - '1 hour'
+since           timestamptz default null   -- null → until - '1 hour', else reader default
 until           timestamptz default null   -- null → now()
 wait_event_type text        default null   -- filter, e.g. 'IO', 'Lock', 'CPU*'
 wait_event      text        default null   -- filter, e.g. 'DataFileRead'
@@ -96,11 +111,12 @@ p99_aas numeric)`
 `period_start` / `period_end` are the effective returned bounds. They normally
 match the requested trailing window, but an hour-only plan snaps them outward,
 so `period_end` can be later than `until`. `buckets_with_data` (renamed from
-`minutes_with_data`, to match `aas()`) counts covered buckets at the effective
-grain named by `bucket`. Genuine `rollup_1h.minute_counts` keeps unfiltered
-reads at one minute. If a minute-capable plan encounters legacy/incomplete
-detail, the row reports `source = 'rollup_1h_flat'`, `bucket = '1 hour'`, and
-NULL sub-hour extrema instead of synthesizing 60 measured minutes.
+`minutes_with_data`, to match `aas()`) counts activity-bearing buckets at the
+effective grain named by `bucket`, not successful sampler ticks. Genuine
+`rollup_1h.minute_counts` keeps unfiltered reads at one minute. If a
+minute-capable plan encounters legacy/incomplete detail, the row reports
+`source = 'rollup_1h_flat'`, `bucket = '1 hour'`, and NULL sub-hour extrema
+instead of synthesizing 60 measured minutes.
 
 ### 2.2 `ash.aas(since, until, wait_event_type, wait_event, query_id, database, bucket)`
 
@@ -250,12 +266,14 @@ pct_1 numeric, pct_2 numeric)`
 
 (With `dimension => null` the single row's `key` is `overall`.)
 
-- **Zero-coverage honesty.** A window with no data coverage (e.g. entirely past
-  retention) reports **NULL** on its side and a **NULL `avg_delta`** — never a
-  fake `0.00` baseline that would read as "no change" — plus a `NOTICE` naming
-  the empty window and pointing at `ash.status()`. This is consistent across
-  **both** modes: the overall row and every per-dimension row. Within a
-  *covered* window, an absent key is a true zero.
+- **No-source-row honesty.** A window with no stored activity-bearing source row
+  (for example, entirely past retention) reports **NULL** on its side and a
+  **NULL `avg_delta`** — never a fake `0.00` baseline that would read as “no
+  change” — plus a `NOTICE` naming the empty window and pointing at
+  `ash.status()`. The same representation can also result from sampled idle
+  time or a sampler outage. This is consistent across both modes: the overall
+  row and every per-dimension row. Within a window with recorded activity, an
+  absent key is a true zero relative to that activity.
 - **Grain visibility.** `source_1` / `source_2`, effective bounds, and
   `effective_bucket_1` / `_2` are constant per window. If the two retained
   read grains differ, both peak values and both p99 values are NULL as
@@ -308,12 +326,15 @@ For `report` (and documented for all readers):
 
 ```
 ash.report(
-  since  timestamptz default null,   -- null → now() - '1 day'
-  until    timestamptz default null,   -- null → now()
+  since  timestamptz default null,
+  until  timestamptz default null,
   vcpus int         default null,   -- optional; normalization is the platform's job
   n   int         default 3       -- top-N events/queryids per window
 ) returns jsonb
 ```
+
+With neither bound, `report` uses the last day. With only `until`, it uses the
+preceding hour. Explicit `since > until` raises before the empty-window clamp.
 
 Returns one self-contained `jsonb` load report for the window — designed so
 an external monitoring or health-assessment platform can ingest pg_ash as a
@@ -352,7 +373,10 @@ key (consumers MUST treat them as optional), so a scraper reads
 `top_queryids_available` — additive and **always present** — instead of probing
 for key absence. `coverage` (also additive, always present) lets a consumer
 reconcile the payload against `ash.aas()` / `ash.top()` for the same window and
-detect degraded resolution (`minutes_with_data < minutes_expected`).
+detect incomplete activity-bearing rollups
+(`minutes_with_data < minutes_expected`). `minutes_with_data` does not verify
+sampler heartbeats: a shortfall can reflect idle time, sampler outage,
+retention, or delayed rollup.
 `raw_retention_start` is the reusable, minute-aligned raw loss/planning
 boundary (the older of configured ring capacity and retained evidence), not
 the physical query-attribution cutoff; use `top_queryids_available` and the
@@ -368,10 +392,12 @@ ever added, never renamed or removed.
 Semantics:
 
 - **1-minute resolution.** All per-class series are per-minute AAS,
-  zero-filled over the coverage of the window; hence the `…1m` key names.
-  pg_ash's seconds-grade sampling makes these more accurate than
-  coarse-scrape (e.g. 5-min) monitoring pipelines — peaks will read equal or
-  higher than such sources, which is expected.
+  zero-filled across activity-bearing `rollup_1m` timestamps; hence the
+  `…1m` key names. Minutes without source rows do not enter the series.
+  At the recommended seconds-grade cadence, pg_ash can preserve peaks that
+  coarse-scrape (for example, 5-minute) monitoring pipelines miss. This does
+  not apply to pg_ash intervals greater than one minute, whose full tick weight
+  can overstate one-minute extrema as described above.
 - `aas_worst1m.<class>` = max per-minute AAS of that class;
   `aas_p99` / `aas_p999` = `percentile_cont(0.99 / 0.999)` over the
   zero-filled per-minute series. Per-class extremes are computed
@@ -396,11 +422,13 @@ Semantics:
 - `coverage` (always present): `{from, to, source, minutes_expected,
   minutes_with_data, raw_retention_start}`. `source` is always `rollup_1m`
   (report is exclusively rollup-backed at 1-minute resolution).
+  `minutes_with_data` counts activity-bearing rollup timestamps, not successful
+  sampler ticks.
   `raw_retention_start` is the minute-aligned planning/loss boundary; it can
   predate the oldest physical sample after a fresh install or sampler outage.
 - Never raises for missing data: classes with no samples report `0`; if
-  the whole window has no coverage at all, returns `null` (consumers should
-  skip ingestion for the period).
+  the whole window has no activity-bearing rollup row, returns `null`
+  (consumers should skip ingestion for the period; the cause is not encoded).
 - Callable by the `grant_reader` role; degrades without pg_stat_statements
   (query ids still come from samples; only `query_text` is pgss-dependent and
   is not part of this payload anyway).

--- a/blueprints/AAS_EXAMPLES.md
+++ b/blueprints/AAS_EXAMPLES.md
@@ -11,8 +11,9 @@ tail behind it.
 Conventions that repeat below, stated once:
 
 - v1.5 has two functions per reader: `f(p_interval, …)` and
-  `f_at(p_start, p_end, …)`. 2.0 has one: `f(since, until, …)`, both
-  defaulting so that a bare call means "the last hour."
+  `f_at(p_start, p_end, …)`. 2.0 has one: `f(since, until, …)`. A bare call
+  means “the last hour” except for `report`, whose no-bounds default is the
+  last day; an `until`-only call means the preceding hour.
 - v1.5 units vary by function — `samples` (raw readers), `backend_seconds`
   (rollup readers), active sessions (chart only). 2.0 always answers in AAS
   (`avg_aas` / `peak_aas` / `p99_aas`), with `backend_seconds` as a secondary
@@ -21,6 +22,12 @@ Conventions that repeat below, stated once:
   [AAS_API.md](AAS_API.md). `summary` uses separate headline and wait/query
   drill source/bounds metrics because the two plans can have different
   effective windows.
+- 2.0 does not persist historical cadence or successful idle ticks. The
+  examples assume one unchanged 1-second interval. Empty source buckets cannot
+  distinguish idle load from a sampler outage (issue #137). The corrected
+  `ash.timeline()` wording and grain semantics do not add heartbeats. Sampling
+  intervals greater than one minute can also overstate one-minute extrema
+  because the full tick weight lands in one minute.
 
 ---
 
@@ -65,12 +72,13 @@ Reading: the last hour peaked at 41 while the average is 3.2 — a spike, not a
 sustained shift. (`ash.summary()` renders the same picture for humans and
 labels a widened wait/query plan with `drill_source`, `drill_period_start`,
 `drill_period_end`, and `drill_effective_bucket`.) The
-`buckets_with_data` column (renamed from `minutes_with_data`) counts covered
-buckets at the effective grain named by `bucket`. Valid `minute_counts` keeps
-one-minute grain; a legacy/incomplete hour reports `rollup_1h_flat` and an
-hour bucket instead of synthetic minute observations. `period_start` /
-`period_end` are effective bounds, so an hour-only row can snap outward and
-end after the requested `until`.
+`buckets_with_data` column (renamed from `minutes_with_data`) counts
+activity-bearing buckets, not successful sampler ticks, at the effective grain
+named by `bucket`. Valid `minute_counts` keeps one-minute grain; a
+legacy/incomplete hour reports `rollup_1h_flat` and an hour bucket instead of
+synthetic minute observations. `period_start` / `period_end` are effective
+bounds, so an hour-only row can snap outward and end after the requested
+`until`.
 
 ## 2. Locate
 
@@ -455,11 +463,12 @@ absence): attribution is decided per extreme minute. `raw_retention_start` is
 the reusable, minute-aligned planning/loss boundary, not the physical
 attribution cutoff; after a fresh install or sampler outage it can predate the
 oldest sample. `coverage` lets the consumer reconcile this payload against
-`ash.aas()` / `ash.top()` for the same window and spot degraded resolution
-(`minutes_with_data < minutes_expected`). When no extreme minute has raw
-evidence, the `top_queryids_*` objects are omitted and
-`top_queryids_available` is `false` — the `aas_*` keys still carry the load
-numbers.
+`ash.aas()` / `ash.top()` for the same window. `minutes_with_data` counts
+activity-bearing rollup minutes; a shortfall
+does not distinguish idle time, a sampler outage, retention, or delayed rollup.
+When no extreme minute has raw evidence, the `top_queryids_*` objects are
+omitted and `top_queryids_available` is `false` — the `aas_*` keys still carry
+the load numbers.
 
 ---
 

--- a/blueprints/AAS_USER_STORIES.md
+++ b/blueprints/AAS_USER_STORIES.md
@@ -8,9 +8,17 @@ the API against.
 - **AAS** = Average Active Sessions — the average number of backends actively
   running (Oracle/ASH term of art). `avg_aas` is backend-time per wall-clock
   second; `peak_aas` / `p99_aas` are the max / 99th-percentile of per-bucket AAS.
-  All values scale by the configured sample interval.
+  In 2.0, all historical values scale by the **current** configured sample
+  interval because cadence is not persisted.
 - Related work: decided 2.0 API in **[AAS_API.md](AAS_API.md)**, design
   discussion in **issue #113**; earlier drafts: PR #106, PR #112.
+
+> **Open trust gap (#137).** The current storage model records neither
+> successful idle ticks nor historical cadence. Requirements below that depend
+> on distinguishing measured zero from missing sampling, or on changing
+> cadence without rescaling history, remain partial even when the reader API
+> shape is implemented. Intervals greater than one minute can also overstate
+> minute extrema by assigning the full tick weight to one minute.
 
 ## Status legend (per-story coverage of the 2.0 API design)
 
@@ -65,7 +73,8 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   3. Works across full rollup retention: the wide windows (1h and up) answer from rollups — no raw dependency — while the narrow 1m/5m windows read raw (cheap and freshest at that size). Aggregate readers prefer `rollup_1m` for any >1h window it fully covers, so triage never pays raw-decode cost.
   4. Meets the performance budget for a rollup read (see §6).
 - **Primary API:** `ash.periods(until)`.
-- **Coverage:** ✅ Covered (adds a `source` column in 2.0).
+- **Coverage:** 🟡 Partial. The API shape is implemented, but historical AAS
+  assumes the current cadence applies to every retained row (issue #137).
 
 ### US-2 — Locate: find when it spiked
 
@@ -81,7 +90,9 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   4. Marks buckets with no stored observation; sampled-idle and uncovered
      time remain indistinguishable until issue #137 persists cadence/coverage.
 - **Primary API:** `ash.timeline(since, until, bucket)`.
-- **Coverage:** ✅ Covered by design ([AAS_API.md §2.3](AAS_API.md)); adds per-bucket `p99_aas` and explicit no-data rows.
+- **Coverage:** 🟡 Partial. The reader/catalog grain semantics are implemented,
+  but storage cannot distinguish idle sampling from a sampler outage
+  ([AAS_API.md §2.3](AAS_API.md), issue #137).
 
 ### US-3 — Drill to culprit: type → event → query, with p99
 
@@ -97,7 +108,8 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   4. **Every breakdown row carries `avg_aas`, `peak_aas`, AND `p99_aas`** — not avg alone — so a spiky member is distinguishable from a steadily-busy one.
   5. The doc/comment is explicit that the deeper event→query tie is NOT recoverable from rollups (see US-4).
 - **Primary API:** `ash.top(dimension, …)` — one function; the drill levels are `top('wait_event_type')` → `top('wait_event', wait_event_type => …)` → `top('query_id', …)`.
-- **Coverage:** ✅ Covered by design — every `top` row carries `avg_aas`, `peak_aas`, `p99_aas` ([AAS_API.md §2.4](AAS_API.md)).
+- **Coverage:** 🟡 Partial. The drill shape is implemented, but its AAS values
+  share the historical-cadence limitation (issue #137).
 
 ### US-4 — Leaf: for a specific wait event, which queries?
 
@@ -112,7 +124,8 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   3. Because rollups do not preserve the wait_event ↔ query_id association, this **reads raw samples** within raw retention.
   4. **MUST signal clearly** when the requested window exceeds raw retention, so the result is never silently empty or partial (see US-5 criterion 3).
 - **Primary API:** `ash.aas(wait_event => …)` for the event summary; `ash.top('query_id', wait_event => …)` for the per-query breakdown (raw-samples-backed; raises past raw retention).
-- **Coverage:** ✅ Covered by design ([AAS_API.md §2.2/§2.4](AAS_API.md)); no dedicated leaf function needed — the filter grammar expresses it.
+- **Coverage:** 🟡 Partial. No dedicated leaf function is needed, but its AAS
+  values share the historical-cadence limitation (issue #137).
 
 ---
 
@@ -132,12 +145,13 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   4. Self-describing catalog comments (`obj_description`) covering the term, the columns, and the recommended next call.
   5. Callable by the least-privilege reader role, and degrades gracefully when pg_stat_statements is absent.
 - **Primary API:** cross-cutting across the whole family.
-- **Coverage:** ✅ Covered by design — typed aggregate readers expose `source`
-  fields, while `report` uses JSON coverage, `summary` has separate headline
-  and wait/query drill provenance metrics, `chart` a planning `NOTICE`, and
-  `samples` is raw-only; retention rows live in
-  `ash.status()`, with a raise-don't-return-empty rule for unanswerable drills
-  ([AAS_API.md §5–§6](AAS_API.md)).
+- **Coverage:** 🟡 Partial. Typed aggregate readers expose source fields;
+  `compare` exposes per-window provenance, `report` uses JSON coverage,
+  `summary` has separate headline and drill provenance, `chart` emits a
+  planning `NOTICE`, and `samples` is raw-only. Retention rows live in
+  `ash.status()`, with a raise-don't-return-empty rule for unanswerable drills.
+  Availability fields still derive from stored activity rather than verified
+  sampler coverage ([AAS_API.md §5–§6](AAS_API.md), issue #137).
 - **Drivable from the catalog alone.** pg_ash self-documents in-DB, which is what
   lets an agent navigate it without external docs: `COMMENT ON SCHEMA ash` names
   the reader entry points and the reader-vs-ops split, and **every** function —
@@ -160,10 +174,11 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   2. Per-bucket `peak_aas` (and ideally `p99_aas`) preserved at hour/day grain.
   3. Works to the limit of `rollup_1h` retention and signals that horizon.
 - **Primary API:** `ash.timeline` over long spans.
-- **Coverage:** ✅ Covered — auto `rollup_1h` selection; valid
-  `rollup_1h.minute_counts` preserves unfiltered/database-only minute totals.
+- **Coverage:** 🟡 Partial. Auto `rollup_1h` selection and valid
+  `rollup_1h.minute_counts` preserve unfiltered/database-only minute totals.
   Wait/query dimensions and legacy/incomplete `rollup_1h_flat` data retain
-  hour grain and NULL extrema requested below that grain.
+  hour grain and NULL extrema requested below that grain. Long-term AAS still
+  assumes one current cadence for all retained history (issue #137).
 
 ### US-7 — Before/after comparison
 
@@ -177,7 +192,8 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   2. Support overall and at least one breakdown dimension (wait type and/or query).
   3. Sort/highlight the largest regressions by delta.
 - **Primary API:** `ash.compare(since_1, until_1, since_2, until_2, dimension, …)`.
-- **Coverage:** ✅ Covered by design ([AAS_API.md §2.5](AAS_API.md)).
+- **Coverage:** 🟡 Partial. The comparison shape is implemented, but comparing
+  history collected at different cadences is not trustworthy (issue #137).
 
 ### US-8 — Machine load-report ingest
 
@@ -191,9 +207,12 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   2. `total` = cpu+io+ipc+lock+lwlock; `Activity`/`Client`/`Timeout` excluded (not real load).
   3. All series at 1-minute resolution, zero-filled.
   4. The payload carries raw AAS only — scoring/normalization (e.g. against vCPUs) is the consumer's job; a caller-supplied `vcpus` is echoed, never used.
-  5. Degrades honestly: `top_queryids_*` omitted when the needed raw samples are gone; `null` when the window has no coverage at all; callable by `grant_reader`.
+  5. Degrades honestly: `top_queryids_*` omitted when the needed raw samples
+     are gone; `null` when the window has no activity-bearing rollup row;
+     callable by `grant_reader`.
 - **Primary API:** `ash.report(since, until, vcpus, n)` ([AAS_API.md §4](AAS_API.md)).
-- **Coverage:** ✅ Covered by design.
+- **Coverage:** 🟡 Partial. The payload shape is implemented, but its
+  `minutes_with_data` field is not verified sampler coverage (issue #137).
 
 ---
 
@@ -201,14 +220,14 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
 
 | Story | Primary function(s) | Coverage | Gap to close |
 |---|---|---|---|
-| US-1 Triage | `periods` | ✅ | — |
-| US-2 Locate | `timeline` | ✅ | — |
-| US-3 Drill | `top(dimension, filters…)` | ✅ | — |
-| US-4 Leaf | `aas(event…)` + `top('query_id', event…)` | ✅ | — |
-| US-5 Programmatic | whole family (explicit provenance, retention in `status()`) | ✅ | — |
-| US-6 Capacity | `timeline` (long span) | ✅ | — |
-| US-7 Before/after | `compare` | ✅ | — |
-| US-8 Load report | `report` | ✅ | — |
+| US-1 Triage | `periods` | 🟡 | Historical AAS uses current cadence (#137) |
+| US-2 Locate | `timeline` | 🟡 | Idle and sampler gaps are indistinguishable (#137) |
+| US-3 Drill | `top(dimension, filters…)` | 🟡 | Historical AAS uses current cadence (#137) |
+| US-4 Leaf | `aas(event…)` + `top('query_id', event…)` | 🟡 | Historical AAS uses current cadence (#137) |
+| US-5 Programmatic | whole family (explicit provenance, retention in `status()`) | 🟡 | Cadence and sampler coverage are not persisted (#137) |
+| US-6 Capacity | `timeline` (long span) | 🟡 | Historical cadence is not persisted (#137) |
+| US-7 Before/after | `compare` | 🟡 | Cross-cadence comparisons rescale history (#137) |
+| US-8 Load report | `report` | 🟡 | `minutes_with_data` derives from stored activity (#137) |
 
 Coverage above is **by design** ([AAS_API.md](AAS_API.md)); implementation
 tracks in the 2.0 branch.
@@ -223,7 +242,11 @@ These apply to every story above.
   declare their source by window; when a requested drill or window cannot be
   answered (rollup can't tie event→query; window exceeds retention), it signals
   this explicitly rather than returning a silent empty/partial result.
-- **Time addressing convention (2.0).** Every reader takes `since timestamptz default null` (→ `now() - '1 hour'`) and `until timestamptz default null` (→ `now()`). The v1.x `f(p_interval)` / `f_at(p_start, p_end)` twin convention is dropped — 2.0 breaks compat, and the single convention halves the surface. ([AAS_API.md §1](AAS_API.md))
+- **Time addressing convention (2.0).** Reader windows are `[since, until)`.
+  No bounds means the last hour (`report`: last day); `until` alone means its
+  preceding hour; explicit inversion raises. The v1.x `f(p_interval)` /
+  `f_at(p_start, p_end)` twin convention is dropped — 2.0 breaks compat, and
+  the single convention halves the surface. ([AAS_API.md §1](AAS_API.md))
 - **Naming.** Function and column names use full domain terms — no abbreviations in user-facing names. Drill dimensions and filters spell out `wait_event_type` / `wait_event` / `query_id` / `database`, as the `dimension` values and parameter names of `top`. The on-CPU class is spelled `CPU*` — the asterisk marks "on CPU *or* uninstrumented wait" and must not be dropped.
 - **Dual audience.** Data functions are typed and presentation-free; ASCII bars/charts live only in dedicated rendering helpers.
 - **Privileges & degradation.** Every reader is callable by the `grant_reader` role and degrades gracefully without pg_stat_statements (show `query_id`, NULL `query_text`) and without pg_cron.

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -299,6 +299,9 @@ create table if not exists ash.config (
 -- Insert initial row if not exists.
 insert into ash.config (singleton) values (true) on conflict do nothing;
 
+comment on column ash.config.sample_interval is
+$$Current nominal sampler interval, not a historical record. In 2.0, sample and rollup rows do not persist the interval in force when collected, so AAS readers weight all retained appearances with this current value; changing it rescales history. Intervals greater than one minute can assign the full tick weight to one minute and overstate minute extrema. Successful idle ticks also write no sample row, so activity-row availability cannot distinguish idle sampling from an outage (issues #137 and #175).$$;
+
 /*
  * Migration: add v1.4 columns if upgrading from pre-1.4. Must run before any
  * code reads these columns. Uses per-column IF NOT EXISTS so the block is


### PR DESCRIPTION
## Summary

- documents that 2.0 weights retained raw and rollup appearances with the current `ash.config.sample_interval`, so changing cadence rescales history
- documents that successful idle ticks write no row, so stored activity cannot prove sampler coverage or distinguish idle sampling from an outage
- documents that intervals greater than one minute can assign a full tick to one minute and overstate minute extrema
- marks all affected AAS user stories partial and adds the limitation to the README, release notes, API/example blueprints, and the `sample_interval` catalog comment

## Release decision

No genuinely low-risk behavioral fix exists this late in 2.0. A heartbeat alone would not fix historical weighting, while a per-row interval alone would not represent sampled idle time. The complete storage fix remains tracked for a later release in #137; this PR contains the release-local documentation and catalog containment, including #175's corrected no-observation language.

## Rebase and conflict resolution

Hand-rebased onto current `main` at `28136cfcadb6628975363aaaf17dd7b46d2f6f1a`.

The overlapping documentation was resolved by retaining:

- #182's effective grain, per-window provenance, and `rollup_1h_flat` contracts
- #180's reader inversion, until-only defaults, report last-day default, rollup_1m-only report disclosure, and NULL+NOTICE behavior
- #189's distinction between the logical `raw_retention_start` planning boundary and physical attribution evidence
- #187's statement that no maintained 2.0 benchmark replaces the retired suite

The examples-wide default sentence was also corrected after review: bare readers mean the last hour except `report()` (last day), while until-only means the preceding hour.

## RED reproduction

On current main before this documentation/catalog change:

- the same 12 appearances read as `backend_seconds = 12.00`, `avg_aas = 0.20` at a 1-second config, then `60.00` / `1.00` after changing only the current config to 5 seconds; the same 5× rescaling persisted after minute rollup and raw truncation
- 12 successful idle `take_sample()` calls stored zero rows and produced the same `data_points = 0`, NULL-AAS timeline representation as a minute with no sampler calls
- issue #137's greater-than-one-minute reproduction assigns a whole coarse tick to one minute and can report a one-minute peak above observed concurrency

## GREEN verification

Exact head `18a90f1fa54bc04db3fe2092af1515892ac7ebd4`:

- fresh PostgreSQL 17 install from an exact archive: PASS
- installed `ash.config.sample_interval` catalog comment contains current-cadence rescaling, >1-minute extrema overstatement, and idle-vs-outage limitations: PASS
- all six changed files carry the intended limitation; all 8 user stories are marked partial: PASS
- neighboring #182/#180/#189/#187 contract guards: PASS
- `git diff --check` and stale wording scans: PASS
- static Codex review: no merge-blocking findings

Refs #137
Refs #175
