### PR TITLE
release: add Docker release gate and normalize config upgrade

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,8 +70,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # PG19 is still beta, so the official image tag is 19beta1 until GA.
-        postgres: [14, 15, 16, 17, 18, 19beta1]
+        # PG19 is still beta, so the official image tag is 19beta2 until GA.
+        postgres: [14, 15, 16, 17, 18, 19beta2]
         # Quoted so YAML doesn't coerce on/off into booleans — GitHub Actions
         # compares these as strings in the step-level `if`/conditionals.
         cron: ["on"]
@@ -1312,36 +1312,8 @@ jobs:
           # Give the sleepers a moment to register in pg_stat_activity.
           sleep 2
 
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
-          -- Clean slate: stop any prior sampler, truncate raw partitions
-          -- so the post-baseline count is unambiguous.
-          select ash.stop();
-          truncate ash.sample_0, ash.sample_1, ash.sample_2;
-
-          -- Capture pre-start baseline (should be 0 across all slots).
-          do $$
-          declare
-            v_baseline bigint;
-          begin
-            select count(*) into v_baseline from ash.sample;
-            assert v_baseline = 0,
-              format('expected 0 samples after truncate, got %s', v_baseline);
-          end $$;
-
-          -- Schedule sampling at 1 Hz via pg_cron.
-          select ash.start('1 second');
-
-          -- Sanity: cron.job has the ash row.
-          do $$
-          declare
-            v_jobs int;
-          begin
-            select count(*) into v_jobs
-            from cron.job where jobname like 'ash_%';
-            assert v_jobs >= 1,
-              format('expected ash_* job(s) in cron.job, got %s', v_jobs);
-          end $$;
-          EOF
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
+            -f devel/tests/cron_path.sql
 
           # Poll for actual job runs. With cron.use_background_workers=on
           # the jobs fire as bgworkers — but cron.job_run_details is only
@@ -5895,77 +5867,16 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
-          cat > /tmp/ash_schema_snapshot.sql << 'SNAPSQL'
-          \pset tuples_only on
-          \pset format unaligned
-          select 'FUNC', p.proname,
-                 pg_get_function_identity_arguments(p.oid),
-                 pg_get_function_result(p.oid),
-                 md5(p.prosrc)
-          from pg_proc p
-          join pg_namespace n on n.oid = p.pronamespace
-          where n.nspname = 'ash'
-          order by p.proname, pg_get_function_identity_arguments(p.oid);
-
-          select 'COL', c.relname, a.attname,
-                 pg_catalog.format_type(a.atttypid, a.atttypmod),
-                 a.attnotnull,
-                 pg_get_expr(d.adbin, d.adrelid)
-          from pg_class c
-          join pg_namespace n on n.oid = c.relnamespace
-          join pg_attribute a on a.attrelid = c.oid
-          left join pg_attrdef d on d.adrelid = a.attrelid and d.adnum = a.attnum
-          where n.nspname = 'ash' and c.relkind in ('r','p') and a.attnum > 0 and not a.attisdropped
-          order by c.relname, a.attname;
-
-          select 'IDX', c.relname, pg_get_indexdef(i.indexrelid)
-          from pg_index i
-          join pg_class c on c.oid = i.indexrelid
-          join pg_namespace n on n.oid = c.relnamespace
-          where n.nspname = 'ash'
-          order by c.relname;
-
-          select 'VIEW', viewname, md5(definition)
-          from pg_views
-          where schemaname = 'ash'
-          order by viewname;
-
-          -- Issue #66: include CHECK / NOT NULL / PK / UNIQUE / FK constraints.
-          -- Covers parent partitioned tables AND their partitions (relkind r,p).
-          -- pg_get_constraintdef gives a stable canonical text form, so any
-          -- divergence (e.g. sample_data_check `>= 2` vs `>= 3` from #49)
-          -- surfaces here.
-          select 'CON', c.relname, con.conname, pg_get_constraintdef(con.oid)
-          from pg_constraint con
-          join pg_class c on c.oid = con.conrelid
-          join pg_namespace n on n.oid = c.relnamespace
-          where n.nspname = 'ash' and c.relkind in ('r','p')
-          order by c.relname, con.conname;
-
-          -- Issue #107: privilege state must be equivalent too. proacl is
-          -- NULL until the first GRANT/REVOKE touches a function; the
-          -- installer's REVOKE-from-PUBLIC hardening always runs, so a fresh
-          -- install and the full upgrade chain must converge to identical
-          -- explicit function ACLs.
-          select 'FACL', p.proname,
-                 pg_get_function_identity_arguments(p.oid),
-                 coalesce(p.proacl::text, '<default>')
-          from pg_proc p
-          join pg_namespace n on n.oid = p.pronamespace
-          where n.nspname = 'ash'
-          order by p.proname, pg_get_function_identity_arguments(p.oid);
-          SNAPSQL
-
           python3 devel/scripts/ash_sql_chain.py full-upgrade-chain > /tmp/ash_full_upgrade_chain.sql
 
           # 1) Fresh install → snapshot
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f "$(python3 devel/scripts/ash_sql_chain.py fresh-install-path)" > /dev/null 2>&1
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f /tmp/ash_schema_snapshot.sql > /tmp/fresh_schema.txt
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f devel/tests/schema_snapshot.sql > /tmp/fresh_schema.txt
           psql -h localhost -U postgres -d postgres -c "select ash.uninstall('yes')" > /dev/null 2>&1
 
           # 2) Full upgrade path → snapshot
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f /tmp/ash_full_upgrade_chain.sql > /dev/null 2>&1
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f /tmp/ash_schema_snapshot.sql > /tmp/upgraded_schema.txt
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f devel/tests/schema_snapshot.sql > /tmp/upgraded_schema.txt
           psql -h localhost -U postgres -d postgres -c "select ash.uninstall('yes')" > /dev/null 2>&1
 
           # 3) Compare
@@ -6032,71 +5943,8 @@ jobs:
             -c "drop extension if exists pg_stat_statements"
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f "$(python3 devel/scripts/ash_sql_chain.py fresh-install-path)" > /dev/null
 
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
-          -- Degraded mode: pg_ash freshly installed WITHOUT pg_stat_statements.
-          -- Every 2.0 reader must work; query_text degrades to NULL and is never spoofed
-          -- by a user-created public.pg_stat_statements relation (#87).
-          insert into ash.wait_event_map (state, type, event) values
-            ('active', 'CPU*', 'CPU*') on conflict do nothing;
-          insert into ash.query_map_0 (query_id) values (999999) on conflict do nothing;
-
-          do $$
-          declare
-            v_cpu smallint; v_q1 int4; v_ts int4; v_from timestamptz;
-            n int; tcnt int; j jsonb;
-          begin
-            select id into v_cpu from ash.wait_event_map where type = 'CPU*';
-            select id into v_q1 from ash.query_map_0 where query_id = 999999;
-            -- Minute-aligned 3 minutes back so a window from here reads raw.
-            v_ts := (ash.ts_from_timestamptz(date_trunc('minute', now() - interval '3 minutes')) / 60) * 60;
-            v_from := ash.ts_to_timestamptz(v_ts);
-            insert into ash.sample (sample_ts, datid, active_count, data, slot)
-              values (v_ts, 1, 1, array[-v_cpu, 1, v_q1]::integer[], 0);
-            perform ash.rollup_minute();
-
-            -- Every reader runs without pgss; query_text is NULL, no error, no WARNING.
-            perform ash.periods();
-            perform * from ash.aas(v_from, now());
-            perform * from ash.timeline(v_from, now());
-            perform * from ash.compare(v_from, now(), v_from, now());
-            perform * from ash.summary(v_from, now());
-            perform * from ash.chart(v_from, now());
-            assert (select query_text from ash.top('query_id', v_from, now()) limit 1) is null,
-              'top query_text should be NULL without pgss';
-            assert (select query_text from ash.samples(v_from, now()) limit 1) is null,
-              'samples query_text should be NULL without pgss';
-
-            -- report still produces query ids (they come from samples, not pgss).
-            j := ash.report(v_from, now());
-            assert j is not null, 'report should work without pgss';
-            assert j->'top_queryids_worst1m' ? 'total', 'report top_queryids total should be present';
-
-            perform ash.take_sample();
-            perform ash.status();
-            perform ash.set_debug_logging();
-
-            -- #87: a user-made public.pg_stat_statements must NOT be trusted as the real
-            -- extension — no row fan-out, no spoofed query_text.
-            create table public.pg_stat_statements (
-              queryid bigint, query text, calls bigint,
-              total_exec_time double precision, mean_exec_time double precision, dbid oid);
-            insert into public.pg_stat_statements values
-              (999999, 'select same from user_a', 10, 100.0, 10.0, 1::oid),
-              (999999, 'select same from user_b', 20, 400.0, 20.0, 2::oid);
-
-            select count(*), count(query_text) into n, tcnt
-              from ash.top('query_id', v_from, now()) where key = '999999';
-            assert n = 1 and tcnt = 0,
-              format('top must ignore spoofed pg_stat_statements, got rows=%s text_rows=%s', n, tcnt);
-            select count(*), count(query_text) into n, tcnt
-              from ash.samples(v_from, now()) where query_id = 999999;
-            assert n = 1 and tcnt = 0,
-              format('samples must ignore spoofed pg_stat_statements, got rows=%s text_rows=%s', n, tcnt);
-
-            drop table public.pg_stat_statements;
-            raise notice 'All degraded-mode (no pgss) 2.0 reader tests PASSED';
-          end $$;
-          EOF
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
+            -f devel/tests/degraded_no_pgss.sql
 
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -c "select ash.uninstall('yes')"
 
@@ -6116,48 +5964,8 @@ jobs:
             -c "drop extension if exists pg_cron cascade"
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f "$(python3 devel/scripts/ash_sql_chain.py fresh-install-path)" > /dev/null
 
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
-          do $$
-          declare
-            v_rec record;
-            v_status_val text;
-          begin
-            -- start() should work without pg_cron (no error, prints hints)
-            select status into v_status_val
-            from ash.start('1 second')
-            where job_type = 'sampler';
-            assert v_status_val like '%schedule externally%',
-              'start() without pg_cron should say schedule externally, got: ' || v_status_val;
-
-            -- stop() should work without pg_cron
-            select status into v_status_val
-            from ash.stop()
-            limit 1;
-            assert v_status_val like '%external scheduler%',
-              'stop() without pg_cron should mention external scheduler, got: ' || v_status_val;
-
-            -- status() should show pg_cron_available = no
-            select value into v_status_val
-            from ash.status()
-            where metric = 'pg_cron_available';
-            assert v_status_val like '%no%',
-              'status() should show pg_cron not available, got: ' || v_status_val;
-
-            -- take_sample() should work without pg_cron
-            perform ash.take_sample();
-
-            -- All 2.0 reader functions should work
-            perform ash.periods();
-            perform * from ash.top('wait_event', now() - interval '1 hour', now());
-            perform * from ash.samples(now() - interval '1 hour', now());
-            perform * from ash.chart(now() - interval '1 hour', now());
-
-            raise notice 'All degraded-mode (no pg_cron) tests PASSED';
-          end;
-          $$;
-
-          select ash.uninstall('yes');
-          EOF
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
+            -f devel/tests/degraded_no_cron.sql
 
       - name: Final summary
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5337,6 +5337,48 @@ jobs:
           select ash.uninstall('yes');
           EOF
 
+      - name: "Upgrade path: ash.config canonical column order and preservation"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          python3 devel/scripts/ash_sql_chain.py full-upgrade-chain > /tmp/ash_full_upgrade_chain.sql
+          sed '$d' /tmp/ash_full_upgrade_chain.sql > /tmp/ash_chain_before_latest.sql
+          tail -n 1 /tmp/ash_full_upgrade_chain.sql > /tmp/ash_latest_upgrade.sql
+          test -s /tmp/ash_chain_before_latest.sql
+          test -s /tmp/ash_latest_upgrade.sql
+
+          cat > /tmp/ash_config_ordinal_driver.sql << 'EOF'
+          \i /tmp/ash_chain_before_latest.sql
+          \i devel/tests/config_ordinal_setup.sql
+          \i /tmp/ash_latest_upgrade.sql
+          \i devel/tests/config_ordinal_assert.sql
+
+          create temporary table config_ordinal_oid_after
+          on commit preserve rows
+          as
+          select 'ash.config'::regclass::oid as relation_oid;
+
+          -- The released migration remains safe to re-apply after normalization.
+          \i /tmp/ash_latest_upgrade.sql
+          \i devel/tests/config_ordinal_assert.sql
+
+          do $$
+          begin
+            assert 'ash.config'::regclass::oid = (
+              select relation_oid from config_ordinal_oid_after
+            ), 'canonical ash.config was rebuilt during migration re-apply';
+          end $$;
+
+          select ash.uninstall('yes');
+          drop owned by config_ordinal_owner, config_ordinal_reader;
+          drop role config_ordinal_owner;
+          drop role config_ordinal_reader;
+          EOF
+
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
+            -v expected_version="$(python3 devel/scripts/ash_sql_chain.py fresh-install-version)" \
+            -f /tmp/ash_config_ordinal_driver.sql
+
       - name: "Issue #49: sample_data_check tightened by discovered upgrade chain"
         env:
           PGPASSWORD: postgres

--- a/devel/docker/Dockerfile
+++ b/devel/docker/Dockerfile
@@ -1,0 +1,26 @@
+# pg_cron-capable PostgreSQL image for the release gate.
+#
+# Keep the image tag separate from PostgreSQL's numeric major. In particular,
+# postgres:19beta2 exports PG_MAJOR=19, which is the value required by the
+# postgresql-19-cron package name.
+ARG POSTGRES_TAG=18
+FROM postgres:${POSTGRES_TAG}
+
+# pg_cron versions differ by PostgreSQL major and follow the pinned base
+# image's PGDG repository snapshot.
+# hadolint ignore=DL3008
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends "postgresql-${PG_MAJOR}-cron" \
+ && rm -rf /var/lib/apt/lists/*
+
+# initdb copies this sample into each new cluster, so both libraries are loaded
+# on first start. cron.database_name is intentionally not baked in: callers can
+# select the database at runtime with:
+#
+#   postgres -c cron.database_name=<database>
+RUN printf '%s\n' \
+    '' \
+    '# pg_ash release-gate defaults' \
+    "shared_preload_libraries = 'pg_cron,pg_stat_statements'" \
+    'cron.use_background_workers = on' \
+    >> /usr/share/postgresql/postgresql.conf.sample

--- a/devel/scripts/ci_step_script.py
+++ b/devel/scripts/ci_step_script.py
@@ -1,0 +1,697 @@
+#!/usr/bin/env python3
+"""Select canonical Bash step bodies from the pg_ash CI workflow.
+
+This intentionally implements only the small YAML subset used by
+`.github/workflows/test.yml`: mapping keys, sequence entries, scalar step
+names, and literal (`|`) run blocks.  Keeping the parser strict makes workflow
+format drift fail loudly instead of silently extracting the wrong script.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_WORKFLOW = ROOT / ".github" / "workflows" / "test.yml"
+ENV_NAME_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*\Z")
+LITERAL_BLOCK_RE = re.compile(r"\|(?P<chomp>[+-]?)(?:\s+#.*)?\Z")
+
+
+class WorkflowError(ValueError):
+    """The workflow cannot be selected or parsed unambiguously."""
+
+
+@dataclass(frozen=True)
+class Step:
+    """One named step in jobs.test."""
+
+    ordinal: int
+    line: int
+    name: str
+    run: str | None
+
+
+def _without_eol(line: str) -> str:
+    return line.rstrip("\r\n")
+
+
+def _indent(line: str, *, line_number: int) -> int | None:
+    """Return structural indentation, ignoring blank and comment-only lines."""
+    text = _without_eol(line)
+    leading = text[: len(text) - len(text.lstrip(" \t"))]
+    if "\t" in leading:
+        raise WorkflowError(
+            f"line {line_number}: tabs are not valid YAML indentation"
+        )
+    if not text.strip() or text.lstrip().startswith("#"):
+        return None
+    return len(leading)
+
+
+def _is_mapping_key(line: str, indent: int, key: str) -> bool:
+    text = _without_eol(line)
+    prefix = " " * indent + key + ":"
+    if not text.startswith(prefix):
+        return False
+    remainder = text[len(prefix) :]
+    return not remainder or remainder.isspace() or remainder.lstrip().startswith("#")
+
+
+def _unique_key(
+    lines: Sequence[str],
+    *,
+    start: int,
+    end: int,
+    indent: int,
+    key: str,
+    context: str,
+) -> int:
+    matches = [
+        idx
+        for idx in range(start, end)
+        if _is_mapping_key(lines[idx], indent, key)
+    ]
+    if not matches:
+        raise WorkflowError(f"{context}: missing {key!r} key")
+    if len(matches) > 1:
+        locations = ", ".join(str(idx + 1) for idx in matches)
+        raise WorkflowError(
+            f"{context}: duplicate {key!r} keys at lines {locations}"
+        )
+    return matches[0]
+
+
+def _block_end(
+    lines: Sequence[str], *, start: int, end: int, parent_indent: int
+) -> int:
+    for idx in range(start, end):
+        indentation = _indent(lines[idx], line_number=idx + 1)
+        if indentation is not None and indentation <= parent_indent:
+            return idx
+    return end
+
+
+def _split_inline_comment(value: str) -> str:
+    """Strip an unquoted YAML comment (` # ...`) from a plain scalar."""
+    match = re.search(r"\s+#", value)
+    return value[: match.start()] if match else value
+
+
+def _parse_scalar(value: str, *, line_number: int, field: str) -> str:
+    value = value.strip()
+    if not value:
+        raise WorkflowError(f"line {line_number}: empty {field}")
+
+    if value.startswith('"'):
+        try:
+            parsed, offset = json.JSONDecoder().raw_decode(value)
+        except json.JSONDecodeError as exc:
+            raise WorkflowError(
+                f"line {line_number}: invalid double-quoted {field}: {exc.msg}"
+            ) from exc
+        remainder = value[offset:].strip()
+        if remainder and not remainder.startswith("#"):
+            raise WorkflowError(
+                f"line {line_number}: unexpected text after {field}: {remainder!r}"
+            )
+        if not isinstance(parsed, str):
+            raise WorkflowError(f"line {line_number}: {field} must be a string")
+        result = parsed
+    elif value.startswith("'"):
+        chars: list[str] = []
+        idx = 1
+        while idx < len(value):
+            if value[idx] != "'":
+                chars.append(value[idx])
+                idx += 1
+                continue
+            if idx + 1 < len(value) and value[idx + 1] == "'":
+                chars.append("'")
+                idx += 2
+                continue
+            idx += 1
+            remainder = value[idx:].strip()
+            if remainder and not remainder.startswith("#"):
+                raise WorkflowError(
+                    f"line {line_number}: unexpected text after {field}: "
+                    f"{remainder!r}"
+                )
+            break
+        else:
+            raise WorkflowError(
+                f"line {line_number}: unterminated single-quoted {field}"
+            )
+        result = "".join(chars)
+    else:
+        result = _split_inline_comment(value).rstrip()
+
+    if not result:
+        raise WorkflowError(f"line {line_number}: empty {field}")
+    if "\n" in result or "\r" in result or "\0" in result:
+        raise WorkflowError(
+            f"line {line_number}: {field} contains an unsupported control character"
+        )
+    return result
+
+
+def _mapping_value(line: str, *, indent: int, key: str) -> str | None:
+    text = _without_eol(line)
+    prefix = " " * indent + key + ":"
+    if not text.startswith(prefix):
+        return None
+    return text[len(prefix) :].strip()
+
+
+def _sequence_mapping_value(line: str, *, indent: int, key: str) -> str | None:
+    text = _without_eol(line)
+    prefix = " " * indent + "- " + key + ":"
+    if not text.startswith(prefix):
+        return None
+    return text[len(prefix) :].strip()
+
+
+def _deindent_literal_block(
+    lines: Sequence[str],
+    *,
+    start: int,
+    end: int,
+    parent_indent: int,
+    chomp: str,
+    run_line: int,
+) -> str:
+    block_end = end
+    for idx in range(start, end):
+        indentation = _indent(lines[idx], line_number=idx + 1)
+        if indentation is not None and indentation <= parent_indent:
+            block_end = idx
+            break
+
+    block_lines = list(lines[start:block_end])
+    nonblank_indents = [
+        len(_without_eol(line))
+        - len(_without_eol(line).lstrip(" "))
+        for line in block_lines
+        if _without_eol(line).strip()
+    ]
+    if not nonblank_indents:
+        return ""
+
+    content_indent = min(nonblank_indents)
+    if content_indent <= parent_indent:
+        raise WorkflowError(
+            f"line {run_line}: run block content must be indented more than "
+            "the run key"
+        )
+
+    deindented: list[str] = []
+    for offset, line in enumerate(block_lines, start=start + 1):
+        text = _without_eol(line)
+        newline = line[len(text) :]
+        if not text.strip():
+            deindented.append(newline)
+            continue
+        indentation = len(text) - len(text.lstrip(" "))
+        if indentation < content_indent:
+            raise WorkflowError(
+                f"line {offset}: inconsistent indentation in run block "
+                f"starting at line {run_line}"
+            )
+        deindented.append(text[content_indent:] + newline)
+
+    body = "".join(deindented)
+    if chomp == "+":
+        return body
+    stripped = body.rstrip("\r\n")
+    if chomp == "-":
+        return stripped
+    return stripped + "\n" if body else ""
+
+
+def _parse_step(
+    lines: Sequence[str],
+    *,
+    start: int,
+    end: int,
+    step_indent: int,
+    ordinal: int,
+) -> Step | None:
+    field_indent = step_indent + 2
+    name_matches: list[tuple[int, str]] = []
+    run_matches: list[tuple[int, str]] = []
+    inline_name = _sequence_mapping_value(
+        lines[start], indent=step_indent, key="name"
+    )
+    if inline_name is not None:
+        name_matches.append((start, inline_name))
+    inline_run = _sequence_mapping_value(
+        lines[start], indent=step_indent, key="run"
+    )
+    if inline_run is not None:
+        run_matches.append((start, inline_run))
+    for idx in range(start + 1, end):
+        value = _mapping_value(lines[idx], indent=field_indent, key="name")
+        if value is not None:
+            name_matches.append((idx, value))
+        value = _mapping_value(lines[idx], indent=field_indent, key="run")
+        if value is not None:
+            run_matches.append((idx, value))
+
+    # `uses:`-only steps may legitimately be unnamed and are not selectable,
+    # but silently omitting an executable step would weaken a selected range.
+    if not name_matches:
+        if run_matches:
+            locations = ", ".join(str(idx + 1) for idx, _ in run_matches)
+            raise WorkflowError(
+                f"executable step at line {start + 1} has no name "
+                f"(run key at line(s) {locations})"
+            )
+        return None
+    if len(name_matches) > 1:
+        locations = ", ".join(str(idx + 1) for idx, _ in name_matches)
+        raise WorkflowError(
+            f"step at line {start + 1}: duplicate name keys at lines {locations}"
+        )
+    name_line, name_value = name_matches[0]
+    name = _parse_scalar(name_value, line_number=name_line + 1, field="step name")
+
+    if len(run_matches) > 1:
+        locations = ", ".join(str(idx + 1) for idx, _ in run_matches)
+        raise WorkflowError(
+            f"step {name!r}: duplicate run keys at lines {locations}"
+        )
+    if not run_matches:
+        return Step(ordinal=ordinal, line=name_line + 1, name=name, run=None)
+
+    run_idx, indicator = run_matches[0]
+    match = LITERAL_BLOCK_RE.fullmatch(indicator)
+    if not match:
+        raise WorkflowError(
+            f"line {run_idx + 1}: step {name!r} must use a literal run block "
+            f"(`run: |`, `|-`, or `|+`), got {indicator!r}"
+        )
+    body = _deindent_literal_block(
+        lines,
+        start=run_idx + 1,
+        end=end,
+        parent_indent=field_indent,
+        chomp=match.group("chomp"),
+        run_line=run_idx + 1,
+    )
+    return Step(ordinal=ordinal, line=name_line + 1, name=name, run=body)
+
+
+def parse_workflow(path: Path, *, job: str = "test") -> list[Step]:
+    """Parse and validate all named steps under jobs.<job>.steps."""
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines(keepends=True)
+    except OSError as exc:
+        raise WorkflowError(f"cannot read workflow {path}: {exc}") from exc
+
+    jobs_idx = _unique_key(
+        lines,
+        start=0,
+        end=len(lines),
+        indent=0,
+        key="jobs",
+        context=str(path),
+    )
+    jobs_end = _block_end(
+        lines, start=jobs_idx + 1, end=len(lines), parent_indent=0
+    )
+    job_idx = _unique_key(
+        lines,
+        start=jobs_idx + 1,
+        end=jobs_end,
+        indent=2,
+        key=job,
+        context=f"{path}: jobs",
+    )
+    job_end = _block_end(lines, start=job_idx + 1, end=jobs_end, parent_indent=2)
+    steps_idx = _unique_key(
+        lines,
+        start=job_idx + 1,
+        end=job_end,
+        indent=4,
+        key="steps",
+        context=f"{path}: jobs.{job}",
+    )
+
+    step_indent = 6
+    starts: list[int] = []
+    for idx in range(steps_idx + 1, job_end):
+        indentation = _indent(lines[idx], line_number=idx + 1)
+        if indentation != step_indent:
+            continue
+        text = _without_eol(lines[idx])[step_indent:]
+        if text == "-" or text.startswith("- "):
+            starts.append(idx)
+
+    if not starts:
+        raise WorkflowError(f"{path}: jobs.{job}.steps has no sequence entries")
+
+    parsed: list[Step] = []
+    for offset, start in enumerate(starts):
+        end = starts[offset + 1] if offset + 1 < len(starts) else job_end
+        step = _parse_step(
+            lines,
+            start=start,
+            end=end,
+            step_indent=step_indent,
+            ordinal=offset + 1,
+        )
+        if step is not None:
+            parsed.append(step)
+
+    by_name: dict[str, list[Step]] = {}
+    for step in parsed:
+        by_name.setdefault(step.name, []).append(step)
+    duplicates = {name: values for name, values in by_name.items() if len(values) > 1}
+    if duplicates:
+        details = "; ".join(
+            f"{name!r} at lines {', '.join(str(step.line) for step in values)}"
+            for name, values in sorted(duplicates.items())
+        )
+        raise WorkflowError(f"duplicate step names in jobs.{job}: {details}")
+    return parsed
+
+
+def _step_map(steps: Sequence[Step]) -> dict[str, Step]:
+    return {step.name: step for step in steps}
+
+
+def select_named(steps: Sequence[Step], names: Sequence[str]) -> list[Step]:
+    repeated = sorted(name for name, count in Counter(names).items() if count > 1)
+    if repeated:
+        raise WorkflowError(
+            "step requested more than once: "
+            + ", ".join(repr(name) for name in repeated)
+        )
+    available = _step_map(steps)
+    missing = [name for name in names if name not in available]
+    if missing:
+        raise WorkflowError(
+            "unknown step name(s): " + ", ".join(repr(name) for name in missing)
+        )
+    return [available[name] for name in names]
+
+
+def select_range(
+    steps: Sequence[Step],
+    start_name: str,
+    end_name: str,
+    excludes: Sequence[str],
+) -> list[Step]:
+    available = _step_map(steps)
+    missing_endpoints = [
+        name for name in (start_name, end_name) if name not in available
+    ]
+    if missing_endpoints:
+        raise WorkflowError(
+            "unknown range endpoint(s): "
+            + ", ".join(repr(name) for name in missing_endpoints)
+        )
+
+    repeated = sorted(
+        name for name, count in Counter(excludes).items() if count > 1
+    )
+    if repeated:
+        raise WorkflowError(
+            "step excluded more than once: "
+            + ", ".join(repr(name) for name in repeated)
+        )
+
+    positions = {step.name: idx for idx, step in enumerate(steps)}
+    start = positions[start_name]
+    end = positions[end_name]
+    if start > end:
+        raise WorkflowError(
+            f"range start {start_name!r} occurs after end {end_name!r}"
+        )
+
+    unknown_excludes = [name for name in excludes if name not in available]
+    if unknown_excludes:
+        raise WorkflowError(
+            "unknown excluded step(s): "
+            + ", ".join(repr(name) for name in unknown_excludes)
+        )
+    outside = [
+        name for name in excludes if not start <= positions[name] <= end
+    ]
+    if outside:
+        raise WorkflowError(
+            "excluded step(s) outside selected range: "
+            + ", ".join(repr(name) for name in outside)
+        )
+
+    excluded = set(excludes)
+    return [step for step in steps[start : end + 1] if step.name not in excluded]
+
+
+def _require_run_bodies(steps: Sequence[Step]) -> None:
+    without_run = [step.name for step in steps if step.run is None]
+    if without_run:
+        raise WorkflowError(
+            "selected step(s) have no run block: "
+            + ", ".join(repr(name) for name in without_run)
+        )
+
+
+def _parse_env(assignments: Sequence[str]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for assignment in assignments:
+        if "=" not in assignment:
+            raise WorkflowError(
+                f"invalid --env {assignment!r}; expected NAME=VALUE"
+            )
+        name, value = assignment.split("=", 1)
+        if not ENV_NAME_RE.fullmatch(name):
+            raise WorkflowError(f"invalid environment variable name {name!r}")
+        if name in result:
+            raise WorkflowError(f"environment variable {name!r} set more than once")
+        result[name] = value
+    return result
+
+
+def _emit_or_run(args: argparse.Namespace, steps: Sequence[Step]) -> int:
+    _require_run_bodies(steps)
+    mode = args.mode
+
+    if args.env and mode != "run":
+        raise WorkflowError("--env is only valid with --run")
+    if args.cwd is not None and mode != "run":
+        raise WorkflowError("--cwd is only valid with --run")
+
+    if mode == "names":
+        for step in steps:
+            print(step.name)
+        return 0
+
+    if mode == "json":
+        json.dump(
+            [
+                {
+                    "ordinal": step.ordinal,
+                    "line": step.line,
+                    "name": step.name,
+                    "run": step.run,
+                }
+                for step in steps
+            ],
+            sys.stdout,
+            ensure_ascii=False,
+            indent=2,
+        )
+        sys.stdout.write("\n")
+        return 0
+
+    if mode == "null":
+        output = sys.stdout.buffer
+        for step in steps:
+            output.write(step.name.encode("utf-8"))
+            output.write(b"\0")
+            output.write((step.run or "").encode("utf-8"))
+            output.write(b"\0")
+        return 0
+
+    if mode == "run":
+        bash = shutil.which("bash")
+        if bash is None:
+            raise WorkflowError("cannot execute steps: bash is not on PATH")
+        environment = os.environ.copy()
+        environment.update(_parse_env(args.env))
+        cwd = args.cwd.resolve() if args.cwd is not None else None
+        for position, step in enumerate(steps, start=1):
+            print(
+                f"[ci-step {position}/{len(steps)}] {step.name}",
+                file=sys.stderr,
+                flush=True,
+            )
+            completed = subprocess.run(
+                [
+                    bash,
+                    "--noprofile",
+                    "--norc",
+                    "-e",
+                    "-o",
+                    "pipefail",
+                    "-c",
+                    step.run or "",
+                    "ci-step",
+                ],
+                cwd=cwd,
+                env=environment,
+                check=False,
+            )
+            if completed.returncode != 0:
+                print(
+                    f"[ci-step FAILED rc={completed.returncode}] {step.name}",
+                    file=sys.stderr,
+                )
+                return completed.returncode
+        return 0
+
+    if len(steps) != 1:
+        raise WorkflowError(
+            f"raw body output selected {len(steps)} steps; use --names-only "
+            "and request each step separately, --null, --json, or --run so "
+            "step boundaries remain unambiguous"
+        )
+    sys.stdout.write(steps[0].run or "")
+    return 0
+
+
+def _add_selection_output_options(parser: argparse.ArgumentParser) -> None:
+    modes = parser.add_mutually_exclusive_group()
+    modes.add_argument(
+        "--names-only",
+        dest="mode",
+        action="store_const",
+        const="names",
+        help="emit selected names, one per line",
+    )
+    modes.add_argument(
+        "--json",
+        dest="mode",
+        action="store_const",
+        const="json",
+        help="emit selected step metadata and exact bodies as JSON",
+    )
+    modes.add_argument(
+        "--null",
+        dest="mode",
+        action="store_const",
+        const="null",
+        help="emit repeating NAME NUL BODY NUL records",
+    )
+    modes.add_argument(
+        "--run",
+        dest="mode",
+        action="store_const",
+        const="run",
+        help=(
+            "run each selected body in a fresh GitHub-style Bash process; "
+            "workflow `if` and `env` fields are not evaluated"
+        ),
+    )
+    parser.set_defaults(mode="body")
+    parser.add_argument(
+        "--env",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help="environment override for --run; may be repeated",
+    )
+    parser.add_argument(
+        "--cwd",
+        type=Path,
+        help="working directory for --run (default: inherit current directory)",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Extract exact Bash run blocks from named jobs.test workflow steps."
+        )
+    )
+    parser.add_argument(
+        "--workflow",
+        type=Path,
+        default=DEFAULT_WORKFLOW,
+        help=f"workflow file (default: {DEFAULT_WORKFLOW})",
+    )
+    parser.add_argument(
+        "--job",
+        default="test",
+        help="job under jobs to inspect (default: test)",
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = commands.add_parser("list", help="list named steps")
+    list_parser.add_argument(
+        "--long",
+        action="store_true",
+        help="include sequence ordinal, source line, and run/uses kind",
+    )
+
+    step_parser = commands.add_parser(
+        "step", help="select one or more exact step names"
+    )
+    step_parser.add_argument("names", nargs="+", metavar="NAME")
+    _add_selection_output_options(step_parser)
+
+    range_parser = commands.add_parser(
+        "range", help="select an inclusive range in workflow order"
+    )
+    range_parser.add_argument("start", metavar="START")
+    range_parser.add_argument("end", metavar="END")
+    range_parser.add_argument(
+        "--exclude",
+        action="append",
+        nargs="+",
+        default=[],
+        metavar="NAME",
+        help="exact step name(s) to omit; may be repeated",
+    )
+    _add_selection_output_options(range_parser)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        steps = parse_workflow(args.workflow.resolve(), job=args.job)
+        if args.command == "list":
+            for step in steps:
+                if args.long:
+                    kind = "run" if step.run is not None else "no-run"
+                    print(f"{step.ordinal}\t{step.line}\t{kind}\t{step.name}")
+                else:
+                    print(step.name)
+            return 0
+
+        if args.command == "step":
+            selected = select_named(steps, args.names)
+        else:
+            excludes = [name for group in args.exclude for name in group]
+            selected = select_range(steps, args.start, args.end, excludes)
+        return _emit_or_run(args, selected)
+    except WorkflowError as exc:
+        parser.error(str(exc))
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devel/scripts/release_gate.sh
+++ b/devel/scripts/release_gate.sh
@@ -1,0 +1,997 @@
+#!/usr/bin/env bash
+# Run the pg_ash release-gate surfaces against disposable Docker PostgreSQL.
+#
+# Usage:
+#   devel/scripts/release_gate.sh <14|15|16|17|18|19beta2> [surface|all]
+#   PG_MAJORS="14 15 16 17 18 19beta2" devel/scripts/release_gate.sh all
+#
+# The GitHub Actions workflow remains the canonical source for the large
+# regression and upgrade assertion sets. ci_step_script.py selects its exact
+# run blocks, and this script executes every selected block in a fresh Bash
+# process, matching GitHub Actions' process boundaries.
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+readonly REPO_ROOT
+readonly DOCKERFILE="${REPO_ROOT}/devel/docker/Dockerfile"
+readonly CHAIN_HELPER="${SCRIPT_DIR}/ash_sql_chain.py"
+readonly CI_STEP_HELPER="${SCRIPT_DIR}/ci_step_script.py"
+readonly DEFAULT_MAJORS="14 15 16 17 18 19beta2"
+readonly IMAGE_REPOSITORY="pg-ash-release-gate"
+readonly POSTGRES_USER="postgres"
+readonly POSTGRES_DATABASE="postgres"
+readonly POSTGRES_PASSWORD="pg_ash_release_gate"
+
+readonly -a SUPPORTED_MAJORS=(14 15 16 17 18 19beta2)
+readonly -a SURFACES=(
+  fresh-install
+  upgrade-chain
+  degraded-no-cron
+  degraded-no-pgss
+  degraded-neither
+  cron-path
+)
+
+declare -a owned_containers=()
+declare -a owned_workers=()
+output_dir=""
+summary_file=""
+surface_temp_dir=""
+container_name=""
+container_id=""
+image_name=""
+any_failure=0
+
+err() {
+  printf 'release_gate: %s\n' "$*" >&2
+}
+
+usage() {
+  cat <<'EOF'
+Usage:
+  devel/scripts/release_gate.sh <major> [surface|all]
+  devel/scripts/release_gate.sh all [surface|all]
+
+Supported majors:
+  14 15 16 17 18 19beta2
+
+Supported surfaces:
+  fresh-install
+  upgrade-chain
+  degraded-no-cron
+  degraded-no-pgss
+  degraded-neither
+  cron-path
+
+Environment:
+  PG_MAJORS                 Space-separated majors for the "all" command.
+  RELEASE_GATE_JOBS         Parallel major workers (default: 2).
+  RELEASE_GATE_PULL         Set to 0 to skip docker pull (default: 1).
+  RELEASE_GATE_OUTPUT_DIR   Directory for logs and the default summary.
+  RELEASE_GATE_SUMMARY      Path for the machine-readable TSV summary.
+EOF
+}
+
+cleanup() {
+  local exit_code=$?
+  local cleanup_failed=0
+  local id
+  local owned_id
+  local pid
+  local candidate_is_owned=0
+  local -a cleanup_ids=("${owned_containers[@]}")
+
+  trap - EXIT INT TERM
+
+  for pid in "${owned_workers[@]}"; do
+    kill -TERM "${pid}" >/dev/null 2>&1 || true
+  done
+  for pid in "${owned_workers[@]}"; do
+    wait "${pid}" >/dev/null 2>&1 || true
+  done
+
+  if [[ "${container_id}" =~ ^[a-f0-9]{12,64}$ ]]; then
+    for owned_id in "${cleanup_ids[@]}"; do
+      if [[ "${owned_id}" == "${container_id}" ]]; then
+        candidate_is_owned=1
+        break
+      fi
+    done
+    if ((candidate_is_owned == 0)); then
+      cleanup_ids+=("${container_id}")
+    fi
+  fi
+
+  for id in "${cleanup_ids[@]}"; do
+    if ! docker rm --force --volumes "${id}" >/dev/null 2>&1; then
+      err "could not tear down owned container ${id}"
+      cleanup_failed=1
+    fi
+  done
+  if ((cleanup_failed != 0 && exit_code == 0)); then
+    exit_code=1
+  fi
+  exit "${exit_code}"
+}
+
+signal_exit() {
+  local exit_code=$1
+
+  trap - INT TERM
+  exit "${exit_code}"
+}
+
+require_commands() {
+  local command_name
+  local -a commands=(
+    awk
+    bash
+    diff
+    docker
+    grep
+    pg_isready
+    psql
+    python3
+    sed
+    sort
+  )
+
+  for command_name in "${commands[@]}"; do
+    if ! command -v "${command_name}" >/dev/null 2>&1; then
+      err "required command not found: ${command_name}"
+      return 1
+    fi
+  done
+}
+
+contains_value() {
+  local wanted=$1
+  shift
+  local value
+
+  for value in "$@"; do
+    if [[ "${value}" == "${wanted}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+validate_major() {
+  local major=$1
+
+  if ! contains_value "${major}" "${SUPPORTED_MAJORS[@]}"; then
+    err "unsupported PostgreSQL major: ${major}"
+    return 1
+  fi
+}
+
+validate_surface() {
+  local surface=$1
+
+  if [[ "${surface}" != "all" ]] \
+    && ! contains_value "${surface}" "${SURFACES[@]}"; then
+    err "unknown surface: ${surface}"
+    return 1
+  fi
+}
+
+safe_component() {
+  local value=$1
+  value="${value//[^a-zA-Z0-9_.-]/_}"
+  printf '%s\n' "${value}"
+}
+
+psql_gate() {
+  PAGER="cat" psql \
+    --no-psqlrc \
+    --host=localhost \
+    --port="${PGPORT}" \
+    --username="${POSTGRES_USER}" \
+    --dbname="${POSTGRES_DATABASE}" \
+    --set=ON_ERROR_STOP=1 \
+    "$@"
+}
+
+wait_for_postgres() {
+  local attempt
+
+  for ((attempt = 1; attempt <= 60; attempt++)); do
+    if PGPASSWORD="${POSTGRES_PASSWORD}" pg_isready \
+      --host=localhost \
+      --port="${PGPORT}" \
+      --username="${POSTGRES_USER}" \
+      --dbname="${POSTGRES_DATABASE}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  err "PostgreSQL did not become ready on container port ${PGPORT}"
+  return 1
+}
+
+start_container() {
+  local major=$1
+  local surface=$2
+  local preload=$3
+  local port_mapping
+  local -a postgres_args=(
+    postgres
+    -c
+    "shared_preload_libraries=${preload}"
+  )
+
+  if [[ "${preload}" == *pg_cron* ]]; then
+    postgres_args+=(
+      -c
+      "cron.database_name=${POSTGRES_DATABASE}"
+      -c
+      "cron.use_background_workers=on"
+    )
+  fi
+
+  printf 'Starting PostgreSQL %s for %s as %s\n' \
+    "${major}" "${surface}" "${container_name}"
+  if ! container_id="$(docker create \
+    --name="${container_name}" \
+    --label="org.pg-ash.release-gate=true" \
+    --env="POSTGRES_DB=${POSTGRES_DATABASE}" \
+    --env="POSTGRES_PASSWORD=${POSTGRES_PASSWORD}" \
+    --publish="127.0.0.1::5432" \
+    "${image_name}" \
+    "${postgres_args[@]}")"; then
+    err "could not create the release-gate container"
+    return 1
+  fi
+  if [[ ! "${container_id}" =~ ^[a-f0-9]{12,64}$ ]]; then
+    err "docker create returned an invalid container ID: ${container_id}"
+    return 1
+  fi
+  owned_containers+=("${container_id}")
+
+  if ! docker start "${container_id}" >/dev/null; then
+    err "could not start release-gate container ${container_id}"
+    return 1
+  fi
+
+  port_mapping="$(docker port "${container_id}" 5432/tcp)"
+  PGPORT="${port_mapping##*:}"
+  if [[ ! "${PGPORT}" =~ ^[0-9]+$ ]]; then
+    err "could not resolve ${container_name} port: ${port_mapping}"
+    return 1
+  fi
+
+  export PGPORT
+  export PGPASSWORD="${POSTGRES_PASSWORD}"
+  export PGUSER="${POSTGRES_USER}"
+  export PGDATABASE="${POSTGRES_DATABASE}"
+  export PAGER=cat
+  export PSQLRC=/dev/null
+  export CONTAINER_ID="${container_id}"
+  export CRON=on
+  wait_for_postgres
+}
+
+create_extensions() {
+  local want_cron=$1
+  local want_pgss=$2
+
+  if [[ "${want_cron}" == "t" ]]; then
+    psql_gate --command="create extension pg_cron;"
+  fi
+  if [[ "${want_pgss}" == "t" ]]; then
+    psql_gate --command="create extension pg_stat_statements;"
+  fi
+}
+
+assert_extension_state() {
+  local expected_cron=$1
+  local expected_pgss=$2
+  local actual
+  local expected="${expected_cron}|${expected_pgss}"
+
+  actual="$(psql_gate \
+    --tuples-only \
+    --no-align \
+    --command="
+      select
+        case when exists (
+          select from pg_extension where extname = 'pg_cron'
+        ) then 't' else 'f' end
+        || '|' ||
+        case when exists (
+          select from pg_extension where extname = 'pg_stat_statements'
+        ) then 't' else 'f' end;
+    ")"
+  actual="${actual//$'\r'/}"
+
+  if [[ "${actual}" != "${expected}" ]]; then
+    err "extension precondition failed: expected ${expected}; got ${actual}"
+    return 1
+  fi
+  printf 'Extension state: pg_cron=%s pg_stat_statements=%s\n' \
+    "${expected_cron}" "${expected_pgss}"
+}
+
+install_fresh() {
+  local install_path
+  install_path="$(python3 "${CHAIN_HELPER}" fresh-install-path)"
+
+  if [[ "${install_path}" == /* || ! -f "${REPO_ROOT}/${install_path}" ]]; then
+    err "fresh-install-path returned an invalid path: ${install_path}"
+    return 1
+  fi
+  printf 'Fresh installer: %s\n' "${install_path}"
+  psql_gate --file="${REPO_ROOT}/${install_path}"
+}
+
+uninstall_if_present() {
+  local schema_present
+
+  schema_present="$(psql_gate \
+    --tuples-only \
+    --no-align \
+    --command="
+      select exists (
+        select from pg_namespace where nspname = 'ash'
+      )::text;
+    ")"
+  if [[ "${schema_present//$'\r'/}" == "true" ]]; then
+    psql_gate --command="select ash.uninstall('yes');"
+  fi
+}
+
+run_ci_selection() {
+  local selection_file="${surface_temp_dir}/ci-selection.bin"
+  local step_name
+  local step_body
+  local step_count=0
+  local -a helper_args=("$@")
+
+  PYTHONDONTWRITEBYTECODE=1 python3 "${CI_STEP_HELPER}" \
+    "${helper_args[@]}" \
+    --null >"${selection_file}"
+
+  while IFS= read -r -d '' step_name \
+    && IFS= read -r -d '' step_body; do
+    ((step_count += 1))
+    printf '[ci-step %s] %s\n' "${step_count}" "${step_name}"
+
+    # Parallel major workers must not share the workflow's historical /tmp
+    # filenames. This is the only transformation made to canonical step bodies.
+    step_body="${step_body//\/tmp\//${surface_temp_dir}/}"
+    if ! bash \
+      --noprofile \
+      --norc \
+      -e \
+      -o pipefail \
+      -c "${step_body}" \
+      ci-step; then
+      err "canonical CI step failed: ${step_name}"
+      return 1
+    fi
+  done <"${selection_file}"
+
+  if ((step_count == 0)); then
+    err "CI selection returned no executable steps"
+    return 1
+  fi
+}
+
+run_fresh_install() {
+  assert_extension_state t t
+  install_fresh
+  run_ci_selection \
+    range \
+    "Test schema and infrastructure" \
+    "Test uninstall" \
+    --exclude \
+    "H-CI-3: end-to-end pg_cron fires ash.take_sample (#46)"
+}
+
+run_upgrade_chain() {
+  local major=$1
+  local reapply_chain
+  local reapply_count
+
+  assert_extension_state t t
+  reapply_chain="$(python3 "${CHAIN_HELPER}" reapply-chain)"
+  reapply_count="$(printf '%s\n' "${reapply_chain}" \
+    | awk 'NF { count++ } END { print count + 0 }')"
+  printf 'Discovered re-apply-safe migration scripts: %s\n' "${reapply_count}"
+  if ((reapply_count == 0)); then
+    printf '%s\n' \
+      'NOTE: reapply-chain is empty; installer re-apply regressions still run.'
+  fi
+
+  if [[ "${major}" == "17" ]]; then
+    run_ci_selection \
+      step \
+      "Release upgrade path: actual v1.4 tag to v1.5"
+  fi
+
+  run_ci_selection \
+    range \
+    "Upgrade path: discovered full chain" \
+    "Schema equivalence: fresh dev install vs full upgrade path"
+}
+
+run_degraded_no_cron() {
+  assert_extension_state f t
+  install_fresh
+  psql_gate --file="${REPO_ROOT}/devel/tests/degraded_no_cron.sql"
+}
+
+run_degraded_no_pgss() {
+  assert_extension_state t f
+  install_fresh
+  psql_gate --file="${REPO_ROOT}/devel/tests/degraded_no_pgss.sql"
+}
+
+run_degraded_neither() {
+  assert_extension_state f f
+  install_fresh
+  psql_gate --file="${REPO_ROOT}/devel/tests/degraded_no_pgss.sql"
+
+  # Preserve the CI tests' fresh-install isolation between degraded bodies.
+  uninstall_if_present
+  install_fresh
+  assert_extension_state f f
+  psql_gate --file="${REPO_ROOT}/devel/tests/degraded_no_cron.sql"
+}
+
+run_cron_path() {
+  assert_extension_state t t
+  install_fresh
+  run_ci_selection \
+    step \
+    "Verify pg_cron wiring" \
+    "Test start/stop" \
+    "H-CI-3: end-to-end pg_cron fires ash.take_sample (#46)" \
+    "Test all interval formats (issue #2)" \
+    "Test #61: status() works for non-superuser without cron.job access"
+}
+
+surface_configuration() {
+  local surface=$1
+
+  case "${surface}" in
+    fresh-install | upgrade-chain | cron-path)
+      printf '%s\t%s\t%s\n' "pg_cron,pg_stat_statements" t t
+      ;;
+    degraded-neither)
+      printf '%s\t%s\t%s\n' "<none>" f f
+      ;;
+    degraded-no-cron)
+      printf '%s\t%s\t%s\n' "pg_stat_statements" f t
+      ;;
+    degraded-no-pgss)
+      printf '%s\t%s\t%s\n' "pg_cron" t f
+      ;;
+    *)
+      err "no extension configuration for surface: ${surface}"
+      return 1
+      ;;
+  esac
+}
+
+execute_surface() {
+  local major=$1
+  local surface=$2
+  local expected_cron=$3
+  local expected_pgss=$4
+
+  create_extensions "${expected_cron}" "${expected_pgss}"
+
+  case "${surface}" in
+    fresh-install)
+      run_fresh_install
+      ;;
+    upgrade-chain)
+      run_upgrade_chain "${major}"
+      ;;
+    degraded-no-cron)
+      run_degraded_no_cron
+      ;;
+    degraded-no-pgss)
+      run_degraded_no_pgss
+      ;;
+    degraded-neither)
+      run_degraded_neither
+      ;;
+    cron-path)
+      run_cron_path
+      ;;
+  esac
+}
+
+failure_detail() {
+  local log_file=$1
+  local detail
+
+  detail="$(awk '
+    /::error::|ERROR:|FAILED|assertion failed|FATAL:/ {
+      sub(/^[[:space:]]+/, "")
+      print
+      exit
+    }
+  ' "${log_file}")"
+  if [[ -z "${detail}" ]]; then
+    detail="command failed; inspect ${log_file}"
+  fi
+  detail="${detail//$'\t'/ }"
+  detail="${detail//$'\r'/}"
+  printf '%.500s\n' "${detail}"
+}
+
+append_result() {
+  local major=$1
+  local surface=$2
+  local result=$3
+  local detail=$4
+  local log_file=$5
+
+  printf '%s\t%s\t%s\t%s\t%s\n' \
+    "${major}" \
+    "${surface}" \
+    "${result}" \
+    "${detail}" \
+    "${log_file}" >>"${summary_file}"
+}
+
+remove_owned_container() {
+  local id=$1
+  local owned_id
+  local -a remaining=()
+
+  if ! docker rm --force --volumes "${id}" >/dev/null 2>&1; then
+    err "could not tear down owned container ${id}"
+    return 1
+  fi
+  for owned_id in "${owned_containers[@]}"; do
+    if [[ "${owned_id}" != "${id}" ]]; then
+      remaining+=("${owned_id}")
+    fi
+  done
+  owned_containers=("${remaining[@]}")
+  if [[ "${container_id}" == "${id}" ]]; then
+    container_id=""
+  fi
+}
+
+run_surface() {
+  local major=$1
+  local surface=$2
+  local safe_major
+  local safe_surface
+  local log_file
+  local exit_code
+  local detail
+  local configuration
+  local preload
+  local expected_cron
+  local expected_pgss
+
+  safe_major="$(safe_component "${major}")"
+  safe_surface="$(safe_component "${surface}")"
+  surface_temp_dir="${output_dir}/tmp_${safe_major}_${safe_surface}"
+  mkdir -p "${surface_temp_dir}"
+  log_file="${output_dir}/${safe_major}_${safe_surface}.log"
+  container_name="pgash_gate_${safe_major}_${safe_surface}_$$_${RANDOM}"
+  container_id=""
+  image_name="${IMAGE_REPOSITORY}:${major}"
+  configuration="$(surface_configuration "${surface}")"
+  IFS=$'\t' read -r preload expected_cron expected_pgss <<<"${configuration}"
+  if [[ "${preload}" == "<none>" ]]; then
+    preload=""
+  fi
+
+  printf 'RUN  PostgreSQL %-7s %s\n' "${major}" "${surface}"
+  set +e
+  start_container \
+    "${major}" "${surface}" "${preload}" >"${log_file}" 2>&1
+  exit_code=$?
+  set -e
+
+  if ((exit_code == 0)); then
+    set +e
+    (
+      trap - EXIT INT TERM
+      set -Eeuo pipefail
+      execute_surface \
+        "${major}" "${surface}" "${expected_cron}" "${expected_pgss}"
+    ) >>"${log_file}" 2>&1
+    exit_code=$?
+    set -e
+  fi
+
+  if ((exit_code != 0)) && [[ -n "${container_id}" ]]; then
+    docker logs "${container_id}" >>"${log_file}" 2>&1 || true
+  fi
+  if [[ -n "${container_id}" ]]; then
+    if ! remove_owned_container "${container_id}"; then
+      printf 'ERROR: container teardown failed for %s\n' \
+        "${container_id}" >>"${log_file}"
+      exit_code=1
+    fi
+  fi
+
+  if ((exit_code == 0)); then
+    append_result \
+      "${major}" "${surface}" PASS "all assertions passed" "${log_file}"
+    printf 'PASS PostgreSQL %-7s %s\n' "${major}" "${surface}"
+  else
+    detail="$(failure_detail "${log_file}")"
+    append_result "${major}" "${surface}" FAIL "${detail}" "${log_file}"
+    err "FAIL PostgreSQL ${major} ${surface}: ${detail} (log: ${log_file})"
+    any_failure=1
+  fi
+}
+
+prepare_output() {
+  local requested_dir=${RELEASE_GATE_OUTPUT_DIR:-}
+  local requested_summary=${RELEASE_GATE_SUMMARY:-}
+
+  if [[ -n "${requested_dir}" ]]; then
+    output_dir="${requested_dir}"
+    mkdir -p "${output_dir}"
+    output_dir="$(cd "${output_dir}" && pwd -P)"
+  else
+    output_dir="$(mktemp -d /tmp/pg_ash-release-gate.XXXXXX)"
+  fi
+  if [[ ! "${output_dir}" =~ ^/[a-zA-Z0-9_./-]+$ ]]; then
+    err "release-gate output path contains unsupported shell characters: ${output_dir}"
+    return 2
+  fi
+
+  if [[ -n "${requested_summary}" ]]; then
+    summary_file="${requested_summary}"
+    mkdir -p "$(dirname "${summary_file}")"
+  else
+    summary_file="${output_dir}/results.tsv"
+  fi
+  printf 'major\tsurface\tresult\tdetail\tlog\n' >"${summary_file}"
+}
+
+build_image() {
+  local major=$1
+  local build_log
+  build_log="${output_dir}/build_$(safe_component "${major}").log"
+
+  if [[ "${RELEASE_GATE_PULL:-1}" == "1" ]]; then
+    if ! docker pull "postgres:${major}" >"${build_log}" 2>&1; then
+      err "docker pull failed for postgres:${major}"
+      return 1
+    fi
+  elif [[ "${RELEASE_GATE_PULL}" != "0" ]]; then
+    err "RELEASE_GATE_PULL must be 0 or 1"
+    return 1
+  fi
+
+  if ! docker build \
+    --build-arg="POSTGRES_TAG=${major}" \
+    --tag="${IMAGE_REPOSITORY}:${major}" \
+    "${REPO_ROOT}/devel/docker" >>"${build_log}" 2>&1; then
+    err "docker build failed for ${IMAGE_REPOSITORY}:${major}"
+    return 1
+  fi
+}
+
+print_human_table() {
+  printf '\n%-10s  %-21s  %-6s  %s\n' \
+    "PG major" "surface" "result" "detail"
+  printf '%-10s  %-21s  %-6s  %s\n' \
+    "----------" "---------------------" "------" "------"
+  awk -F'\t' '
+    NR > 1 {
+      printf "%-10s  %-21s  %-6s  %s\n", $1, $2, $3, $4
+    }
+  ' "${summary_file}"
+  printf '\nMachine-readable TSV: %s\n' "${summary_file}"
+  printf 'Logs: %s\n' "${output_dir}"
+}
+
+mark_build_failures() {
+  local major=$1
+  shift
+  local surface
+  local build_log
+  build_log="${output_dir}/build_$(safe_component "${major}").log"
+
+  for surface in "$@"; do
+    append_result \
+      "${major}" \
+      "${surface}" \
+      FAIL \
+      "pg_cron image build failed" \
+      "${build_log}"
+  done
+  any_failure=1
+}
+
+run_major() {
+  local major=$1
+  local selector=$2
+  local surface
+  local -a selected_surfaces=()
+
+  prepare_output
+  if [[ "${selector}" == "all" ]]; then
+    selected_surfaces=("${SURFACES[@]}")
+  else
+    selected_surfaces=("${selector}")
+  fi
+
+  if ! build_image "${major}"; then
+    err "could not build pg_cron image for PostgreSQL ${major}"
+    mark_build_failures "${major}" "${selected_surfaces[@]}"
+    print_human_table
+    return 1
+  fi
+
+  for surface in "${selected_surfaces[@]}"; do
+    run_surface "${major}" "${surface}"
+  done
+
+  print_human_table
+  return "${any_failure}"
+}
+
+wait_for_worker() {
+  local pid=$1
+  local worker_pid
+  local exit_code=0
+  local -a remaining=()
+
+  if ! wait "${pid}"; then
+    exit_code=1
+  fi
+  for worker_pid in "${owned_workers[@]}"; do
+    if [[ "${worker_pid}" != "${pid}" ]]; then
+      remaining+=("${worker_pid}")
+    fi
+  done
+  owned_workers=("${remaining[@]}")
+  if ((exit_code != 0)); then
+    return "${exit_code}"
+  fi
+}
+
+run_all_majors() {
+  local selector=$1
+  local majors_text=${PG_MAJORS:-${DEFAULT_MAJORS}}
+  local jobs=${RELEASE_GATE_JOBS:-2}
+  local parent_output
+  local parent_summary
+  local major
+  local safe_major
+  local child_output
+  local child_summary
+  local worker_log
+  local pid
+  local worker_failed=0
+  local header
+  local result_row
+  local row_count
+  local surface
+  local worker_major
+  local major_problem
+  local expected_failure
+  local -a majors=()
+  local -a active_pids=()
+  local -a expected_surfaces=()
+  local -a result_fields=()
+  local -a validated_majors=()
+  local -A worker_major_by_pid=()
+  local -A worker_failed_by_major=()
+  local -A result_rows=()
+  local -A result_valid=()
+
+  IFS=$' \t\n' read -r -a majors <<<"${majors_text}"
+  if ((${#majors[@]} == 0)); then
+    err "PG_MAJORS did not contain any majors"
+    return 2
+  fi
+  if [[ ! "${jobs}" =~ ^[1-9][0-9]*$ ]]; then
+    err "RELEASE_GATE_JOBS must be a positive integer"
+    return 2
+  fi
+  for major in "${majors[@]}"; do
+    validate_major "${major}"
+    if contains_value "${major}" "${validated_majors[@]}"; then
+      err "PG_MAJORS contains a duplicate major: ${major}"
+      return 2
+    fi
+    validated_majors+=("${major}")
+  done
+  if [[ "${selector}" == "all" ]]; then
+    expected_surfaces=("${SURFACES[@]}")
+  else
+    expected_surfaces=("${selector}")
+  fi
+
+  prepare_output
+  parent_output="${output_dir}"
+  parent_summary="${summary_file}"
+
+  for major in "${majors[@]}"; do
+    while ((${#active_pids[@]} >= jobs)); do
+      pid="${active_pids[0]}"
+      worker_major="${worker_major_by_pid[${pid}]}"
+      if ! wait_for_worker "${pid}"; then
+        worker_failed=1
+        worker_failed_by_major["${worker_major}"]=1
+      fi
+      active_pids=("${active_pids[@]:1}")
+    done
+
+    safe_major="$(safe_component "${major}")"
+    child_output="${parent_output}/pg_${safe_major}"
+    child_summary="${parent_output}/pg_${safe_major}.tsv"
+    RELEASE_GATE_OUTPUT_DIR="${child_output}" \
+      RELEASE_GATE_SUMMARY="${child_summary}" \
+      "${BASH_SOURCE[0]}" "${major}" "${selector}" \
+      >"${parent_output}/worker_${safe_major}.log" 2>&1 &
+    pid=$!
+    active_pids+=("${pid}")
+    owned_workers+=("${pid}")
+    worker_major_by_pid["${pid}"]="${major}"
+    worker_failed_by_major["${major}"]=0
+    printf 'LAUNCH PostgreSQL %-7s worker pid=%s\n' "${major}" "${pid}"
+  done
+
+  for pid in "${active_pids[@]}"; do
+    worker_major="${worker_major_by_pid[${pid}]}"
+    if ! wait_for_worker "${pid}"; then
+      worker_failed=1
+      worker_failed_by_major["${worker_major}"]=1
+    fi
+  done
+
+  for major in "${majors[@]}"; do
+    safe_major="$(safe_component "${major}")"
+    child_summary="${parent_output}/pg_${safe_major}.tsv"
+    worker_log="${parent_output}/worker_${safe_major}.log"
+    if [[ ! -f "${child_summary}" ]]; then
+      for surface in "${expected_surfaces[@]}"; do
+        append_result \
+          "${major}" \
+          "${surface}" \
+          FAIL \
+          "worker produced no summary" \
+          "${worker_log}"
+      done
+      worker_failed=1
+      continue
+    fi
+
+    major_problem="${worker_failed_by_major[${major}]}"
+    header=""
+    IFS= read -r header <"${child_summary}" || true
+    if [[ "${header}" != $'major\tsurface\tresult\tdetail\tlog' ]]; then
+      err "worker ${major} produced an invalid summary header"
+      worker_failed=1
+      major_problem=1
+    fi
+    row_count="$(awk 'NR > 1 { count++ } END { print count + 0 }' \
+      "${child_summary}")"
+    if [[ "${row_count}" != "${#expected_surfaces[@]}" ]]; then
+      err "worker ${major} produced ${row_count} result rows; expected ${#expected_surfaces[@]}"
+      worker_failed=1
+      major_problem=1
+    fi
+
+    result_rows=()
+    result_valid=()
+    expected_failure=0
+    for surface in "${expected_surfaces[@]}"; do
+      result_row=""
+      if [[ "${header}" == $'major\tsurface\tresult\tdetail\tlog' ]] \
+        && result_row="$(awk -F'\t' \
+          -v expected_major="${major}" \
+          -v expected_surface="${surface}" '
+            NR > 1 \
+              && $1 == expected_major \
+              && $2 == expected_surface \
+              && ($3 == "PASS" || $3 == "FAIL") \
+              && NF == 5 {
+              count++
+              row = $0
+            }
+            END {
+              if (count == 1) {
+                print row
+              } else {
+                exit 1
+              }
+            }
+          ' "${child_summary}")"; then
+        result_rows["${surface}"]="${result_row}"
+        result_valid["${surface}"]=1
+        IFS=$'\t' read -r -a result_fields <<<"${result_row}"
+        if [[ "${result_fields[2]}" == "FAIL" ]]; then
+          expected_failure=1
+        fi
+      else
+        result_valid["${surface}"]=0
+        expected_failure=1
+        worker_failed=1
+        major_problem=1
+      fi
+    done
+
+    for surface in "${expected_surfaces[@]}"; do
+      if ((major_problem != 0 && expected_failure == 0)) \
+        && [[ "${surface}" == "${expected_surfaces[0]}" ]]; then
+        append_result \
+          "${major}" \
+          "${surface}" \
+          FAIL \
+          "worker exited non-zero or produced an invalid summary" \
+          "${worker_log}"
+      elif [[ "${result_valid[${surface}]}" == "1" ]]; then
+        printf '%s\n' "${result_rows[${surface}]}" >>"${parent_summary}"
+      else
+        append_result \
+          "${major}" \
+          "${surface}" \
+          FAIL \
+          "worker summary missing or duplicated this surface" \
+          "${worker_log}"
+      fi
+    done
+  done
+
+  summary_file="${parent_summary}"
+  output_dir="${parent_output}"
+  print_human_table
+  if awk -F'\t' 'NR > 1 && $3 == "FAIL" { found=1 } END { exit !found }' \
+    "${summary_file}"; then
+    worker_failed=1
+  fi
+  return "${worker_failed}"
+}
+
+main() {
+  local target=${1:-}
+  local selector=${2:-all}
+
+  if [[ "${target}" == "--help" || "${target}" == "-h" ]]; then
+    usage
+    return 0
+  fi
+  if [[ -z "${target}" || $# -gt 2 ]]; then
+    usage >&2
+    return 2
+  fi
+
+  require_commands
+  validate_surface "${selector}"
+  [[ -f "${DOCKERFILE}" ]] || {
+    err "Dockerfile not found: ${DOCKERFILE}"
+    return 2
+  }
+  [[ -f "${CHAIN_HELPER}" && -f "${CI_STEP_HELPER}" ]] || {
+    err "release-gate helper is missing"
+    return 2
+  }
+
+  cd "${REPO_ROOT}"
+  trap cleanup EXIT
+  trap 'signal_exit 130' INT
+  trap 'signal_exit 143' TERM
+
+  if [[ "${target}" == "all" ]]; then
+    run_all_majors "${selector}"
+  else
+    validate_major "${target}"
+    run_major "${target}" "${selector}"
+  fi
+}
+
+main "$@"

--- a/devel/scripts/test_ci_step_script.py
+++ b/devel/scripts/test_ci_step_script.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Unit tests for ci_step_script.py (stdlib only)."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import ci_step_script
+
+
+SAMPLE = """\
+name: sample
+jobs:
+  docs:
+    steps:
+      - name: Not the test job
+        run: |
+          exit 99
+  test:
+    steps:
+      - uses: actions/checkout@example
+      - name: First
+        run: |
+          printf '%s\\n' first
+
+          echo done
+      - name: "Second: quoted"
+        run: |-
+          echo second
+      - name: 'Third''s step'
+        run: |+
+          echo third
+
+"""
+
+
+class WorkflowParserTests(unittest.TestCase):
+    def parse(self, text: str = SAMPLE) -> list[ci_step_script.Step]:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "workflow.yml"
+            path.write_text(text, encoding="utf-8")
+            return ci_step_script.parse_workflow(path)
+
+    def test_extracts_only_named_test_steps_and_honors_chomping(self) -> None:
+        steps = self.parse()
+        self.assertEqual(
+            [step.name for step in steps],
+            ["First", "Second: quoted", "Third's step"],
+        )
+        self.assertEqual(
+            steps[0].run,
+            "printf '%s\\n' first\n\n"
+            "echo done\n",
+        )
+        self.assertEqual(steps[1].run, "echo second")
+        self.assertEqual(steps[2].run, "echo third\n\n")
+
+    def test_duplicate_workflow_names_fail_with_locations(self) -> None:
+        text = SAMPLE.replace(
+            "      - name: 'Third''s step'",
+            "      - name: First",
+        )
+        with self.assertRaisesRegex(
+            ci_step_script.WorkflowError, "duplicate step names.*First.*lines"
+        ):
+            self.parse(text)
+
+    def test_unnamed_run_step_fails_instead_of_being_silently_omitted(self) -> None:
+        text = SAMPLE.replace(
+            "      - uses: actions/checkout@example",
+            "      - run: |\n"
+            "          echo unnamed",
+        )
+        with self.assertRaisesRegex(
+            ci_step_script.WorkflowError, "executable step.*has no name"
+        ):
+            self.parse(text)
+
+    def test_named_and_range_selection_are_strict(self) -> None:
+        steps = self.parse()
+        selected = ci_step_script.select_range(
+            steps,
+            "First",
+            "Third's step",
+            ["Second: quoted"],
+        )
+        self.assertEqual([step.name for step in selected], ["First", "Third's step"])
+
+        with self.assertRaisesRegex(ci_step_script.WorkflowError, "unknown step"):
+            ci_step_script.select_named(steps, ["missing"])
+        with self.assertRaisesRegex(ci_step_script.WorkflowError, "occurs after"):
+            ci_step_script.select_range(
+                steps, "Third's step", "First", []
+            )
+        with self.assertRaisesRegex(ci_step_script.WorkflowError, "outside"):
+            ci_step_script.select_range(
+                steps, "Second: quoted", "Third's step", ["First"]
+            )
+
+    def test_run_mode_uses_a_fresh_bash_process_for_each_step(self) -> None:
+        steps = [
+            ci_step_script.Step(
+                ordinal=1,
+                line=1,
+                name="set child environment",
+                run="export CI_STEP_MUST_NOT_LEAK=yes\n",
+            ),
+            ci_step_script.Step(
+                ordinal=2,
+                line=2,
+                name="check child environment",
+                run='test -z "${CI_STEP_MUST_NOT_LEAK:-}"\n',
+            ),
+        ]
+        args = argparse.Namespace(mode="run", env=[], cwd=None)
+        with contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(ci_step_script._emit_or_run(args, steps), 0)
+
+    def test_null_mode_preserves_exact_record_boundaries(self) -> None:
+        steps = [
+            ci_step_script.Step(
+                ordinal=1,
+                line=1,
+                name="first",
+                run="printf 'line one\\nline two\\n'\n",
+            ),
+            ci_step_script.Step(
+                ordinal=2,
+                line=2,
+                name="second",
+                run="echo done\n",
+            ),
+        ]
+        args = argparse.Namespace(mode="null", env=[], cwd=None)
+
+        class BinaryCapture(io.StringIO):
+            def __init__(self) -> None:
+                super().__init__()
+                self.buffer = io.BytesIO()
+
+        output = BinaryCapture()
+        with contextlib.redirect_stdout(output):
+            self.assertEqual(ci_step_script._emit_or_run(args, steps), 0)
+        self.assertEqual(
+            output.buffer.getvalue(),
+            b"first\0printf 'line one\\nline two\\n'\n\0"
+            b"second\0echo done\n\0",
+        )
+
+    def test_current_workflow_integration(self) -> None:
+        steps = ci_step_script.parse_workflow(ci_step_script.DEFAULT_WORKFLOW)
+        names = [step.name for step in steps]
+        self.assertGreater(len(steps), 40)
+        self.assertEqual(names[0], "Install pg_cron in container")
+        self.assertIn("Test schema and infrastructure", names)
+        self.assertIn("Degraded mode: without pg_stat_statements", names)
+        self.assertNotIn("Guard SQL release workflow", names)
+        selected = ci_step_script.select_named(
+            steps, ["Test schema and infrastructure"]
+        )[0]
+        self.assertIsNotNone(selected.run)
+        self.assertTrue((selected.run or "").startswith("psql -h localhost"))
+        self.assertIn("Schema and infrastructure tests PASSED", selected.run or "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/devel/tests/config_ordinal_assert.sql
+++ b/devel/tests/config_ordinal_assert.sql
@@ -1,0 +1,170 @@
+\set ON_ERROR_STOP on
+
+select set_config('pg_ash.expected_version', :'expected_version', false);
+
+do $$
+declare
+  v_columns text[];
+  v_config ash.config%rowtype;
+  v_default_diff text;
+  v_owner text;
+begin
+  select array_agg(attribute.attname::text order by attribute.attnum)
+  into v_columns
+  from pg_attribute as attribute
+  where
+    attribute.attrelid = 'ash.config'::regclass
+    and attribute.attnum > 0
+    and not attribute.attisdropped;
+
+  assert v_columns = array[
+    'singleton',
+    'current_slot',
+    'num_partitions',
+    'sampling_enabled',
+    'skipped_samples',
+    'missed_samples',
+    'sample_interval',
+    'rotation_period',
+    'include_bg_workers',
+    'debug_logging',
+    'encoding_version',
+    'version',
+    'rotated_at',
+    'installed_at',
+    'rollup_1m_retention_days',
+    'rollup_1h_retention_days',
+    'rollup_min_backend_seconds',
+    'last_rollup_1m_ts',
+    'last_rollup_1h_ts',
+    'insert_errors',
+    'register_wait_cap_hits'
+  ]::text[],
+    format('ash.config column order differs: %s', v_columns);
+
+  select *
+  into strict v_config
+  from ash.config
+  where singleton;
+
+  assert v_config.current_slot = 2, 'current_slot was not preserved';
+  assert not v_config.sampling_enabled, 'sampling_enabled was not preserved';
+  assert v_config.skipped_samples = 42, 'skipped_samples was not preserved';
+  assert v_config.missed_samples = 43, 'missed_samples was not preserved';
+  assert v_config.sample_interval = interval '7 seconds',
+    'sample_interval was not preserved';
+  assert v_config.rotation_period = interval '2 days',
+    'rotation_period was not preserved';
+  assert v_config.include_bg_workers, 'include_bg_workers was not preserved';
+  assert v_config.debug_logging, 'debug_logging was not preserved';
+  assert v_config.encoding_version = 1, 'encoding_version was not preserved';
+  assert v_config.version = current_setting('pg_ash.expected_version'),
+    'version was not upgraded';
+  assert v_config.rotated_at = '2026-01-02T03:04:05+00'::timestamptz,
+    'rotated_at was not preserved';
+  assert v_config.installed_at = '2025-06-07T08:09:10+00'::timestamptz,
+    'installed_at was not preserved';
+  assert v_config.rollup_1m_retention_days = 31,
+    'rollup_1m_retention_days was not preserved';
+  assert v_config.rollup_1h_retention_days = 1830,
+    'rollup_1h_retention_days was not preserved';
+  assert v_config.rollup_min_backend_seconds = 4,
+    'rollup_min_backend_seconds was not preserved';
+  assert v_config.last_rollup_1m_ts = 111,
+    'last_rollup_1m_ts was not preserved';
+  assert v_config.last_rollup_1h_ts = 222,
+    'last_rollup_1h_ts was not preserved';
+  assert v_config.insert_errors = 0, 'insert_errors default was not applied';
+  assert v_config.register_wait_cap_hits = 0,
+    'register_wait_cap_hits default was not applied';
+
+  select pg_get_userbyid(relation.relowner)
+  into v_owner
+  from pg_class as relation
+  where relation.oid = 'ash.config'::regclass;
+
+  assert v_owner = 'config_ordinal_owner',
+    format('ash.config owner changed to %s', v_owner);
+  assert has_table_privilege(
+    'config_ordinal_reader',
+    'ash.config',
+    'select with grant option'
+  ), 'table SELECT WITH GRANT OPTION was not preserved';
+  assert not has_table_privilege('public', 'ash.config', 'select'),
+    'PUBLIC SELECT on ash.config was widened';
+  assert has_column_privilege(
+    'config_ordinal_reader',
+    'ash.config',
+    'sampling_enabled',
+    'update'
+  ), 'column UPDATE was not preserved';
+  assert not has_column_privilege(
+    'config_ordinal_reader',
+    'ash.config',
+    'debug_logging',
+    'update'
+  ), 'column UPDATE widened to debug_logging';
+
+  assert exists (
+    select
+    from pg_constraint as constraint_row
+    where
+      constraint_row.conrelid = 'ash.config'::regclass
+      and constraint_row.conname = 'config_ordinal_skipped_nonnegative'
+  ), 'custom config constraint was not preserved';
+
+  assert to_regclass('ash.config_ordinal_debug_idx') is not null,
+    'custom config index was not preserved';
+
+  assert to_regclass('ash.config_ordinal_slot_uidx') is not null,
+    'standalone unique config index was not preserved';
+
+  assert exists (
+    select
+    from pg_constraint as constraint_row
+    where
+      constraint_row.conrelid = 'ash.config'::regclass
+      and constraint_row.conname = 'config_ordinal_slot_self_fk'
+      and constraint_row.contype = 'f'
+  ), 'self-referencing config FK was not preserved';
+
+  select string_agg(
+    format(
+      '%s: before=%s after=%s',
+      defaults_before.column_name,
+      defaults_before.default_expression,
+      defaults_after.default_expression
+    ),
+    '; '
+    order by defaults_before.column_name
+  )
+  into v_default_diff
+  from pg_temp.config_ordinal_defaults_before as defaults_before
+  left join (
+    select
+      attribute.attname::text as column_name,
+      pg_get_expr(
+        default_value.adbin,
+        default_value.adrelid
+      ) as default_expression
+    from pg_attribute as attribute
+    left join pg_attrdef as default_value
+      on default_value.adrelid = attribute.attrelid
+      and default_value.adnum = attribute.attnum
+    where
+      attribute.attrelid = 'ash.config'::regclass
+      and attribute.attnum > 0
+      and not attribute.attisdropped
+  ) as defaults_after
+    using (column_name)
+  where
+    defaults_before.column_name <> 'version'
+    and defaults_before.default_expression
+      is distinct from defaults_after.default_expression;
+
+  assert v_default_diff is null,
+    format('ash.config defaults changed: %s', v_default_diff);
+
+  raise notice
+    'ash.config canonical ordinals, row, defaults, constraints, indexes, and ACLs PASSED';
+end $$;

--- a/devel/tests/config_ordinal_setup.sql
+++ b/devel/tests/config_ordinal_setup.sql
@@ -1,0 +1,78 @@
+\set ON_ERROR_STOP on
+
+create role config_ordinal_owner nologin;
+create role config_ordinal_reader nologin;
+
+do $$
+declare
+  v_num_partitions_attnum smallint;
+begin
+  select attribute.attnum
+  into v_num_partitions_attnum
+  from pg_attribute as attribute
+  where
+    attribute.attrelid = 'ash.config'::regclass
+    and attribute.attname = 'num_partitions'
+    and not attribute.attisdropped;
+
+  assert v_num_partitions_attnum <> 3,
+    'upgrade fixture unexpectedly already has canonical config ordinals';
+end $$;
+
+update ash.config
+set
+  current_slot = 2,
+  sampling_enabled = false,
+  skipped_samples = 42,
+  missed_samples = 43,
+  sample_interval = interval '7 seconds',
+  rotation_period = interval '2 days',
+  include_bg_workers = true,
+  debug_logging = true,
+  rotated_at = '2026-01-02T03:04:05+00'::timestamptz,
+  installed_at = '2025-06-07T08:09:10+00'::timestamptz,
+  rollup_1m_retention_days = 31,
+  rollup_1h_retention_days = 1830,
+  rollup_min_backend_seconds = 4,
+  last_rollup_1m_ts = 111,
+  last_rollup_1h_ts = 222
+where singleton;
+
+alter table ash.config owner to config_ordinal_owner;
+grant select on table ash.config to config_ordinal_reader with grant option;
+grant update (sampling_enabled) on table ash.config to config_ordinal_reader;
+
+alter table ash.config
+  add constraint config_ordinal_skipped_nonnegative
+  check (skipped_samples >= 0);
+
+create index config_ordinal_debug_idx
+on ash.config (debug_logging)
+where debug_logging;
+
+/*
+ * PostgreSQL permits a foreign key to target a standalone non-partial unique
+ * index. This exercises the replay order: the index must precede the FK.
+ */
+create unique index config_ordinal_slot_uidx
+on ash.config (current_slot);
+
+alter table ash.config
+  add constraint config_ordinal_slot_self_fk
+  foreign key (current_slot)
+  references ash.config (current_slot);
+
+create temporary table config_ordinal_defaults_before
+on commit preserve rows
+as
+select
+  attribute.attname::text as column_name,
+  pg_get_expr(default_value.adbin, default_value.adrelid) as default_expression
+from pg_attribute as attribute
+left join pg_attrdef as default_value
+  on default_value.adrelid = attribute.attrelid
+  and default_value.adnum = attribute.attnum
+where
+  attribute.attrelid = 'ash.config'::regclass
+  and attribute.attnum > 0
+  and not attribute.attisdropped;

--- a/devel/tests/cron_path.sql
+++ b/devel/tests/cron_path.sql
@@ -1,0 +1,28 @@
+-- Clean slate: stop any prior sampler, truncate raw partitions
+-- so the post-baseline count is unambiguous.
+select ash.stop();
+truncate ash.sample_0, ash.sample_1, ash.sample_2;
+
+-- Capture pre-start baseline (should be 0 across all slots).
+do $$
+declare
+  v_baseline bigint;
+begin
+  select count(*) into v_baseline from ash.sample;
+  assert v_baseline = 0,
+    format('expected 0 samples after truncate, got %s', v_baseline);
+end $$;
+
+-- Schedule sampling at 1 Hz via pg_cron.
+select ash.start('1 second');
+
+-- Sanity: cron.job has the ash row.
+do $$
+declare
+  v_jobs int;
+begin
+  select count(*) into v_jobs
+  from cron.job where jobname like 'ash_%';
+  assert v_jobs >= 1,
+    format('expected ash_* job(s) in cron.job, got %s', v_jobs);
+end $$;

--- a/devel/tests/degraded_no_cron.sql
+++ b/devel/tests/degraded_no_cron.sql
@@ -1,0 +1,40 @@
+do $$
+declare
+  v_rec record;
+  v_status_val text;
+begin
+  -- start() should work without pg_cron (no error, prints hints)
+  select status into v_status_val
+  from ash.start('1 second')
+  where job_type = 'sampler';
+  assert v_status_val like '%schedule externally%',
+    'start() without pg_cron should say schedule externally, got: ' || v_status_val;
+
+  -- stop() should work without pg_cron
+  select status into v_status_val
+  from ash.stop()
+  limit 1;
+  assert v_status_val like '%external scheduler%',
+    'stop() without pg_cron should mention external scheduler, got: ' || v_status_val;
+
+  -- status() should show pg_cron_available = no
+  select value into v_status_val
+  from ash.status()
+  where metric = 'pg_cron_available';
+  assert v_status_val like '%no%',
+    'status() should show pg_cron not available, got: ' || v_status_val;
+
+  -- take_sample() should work without pg_cron
+  perform ash.take_sample();
+
+  -- All 2.0 reader functions should work
+  perform ash.periods();
+  perform * from ash.top('wait_event', now() - interval '1 hour', now());
+  perform * from ash.samples(now() - interval '1 hour', now());
+  perform * from ash.chart(now() - interval '1 hour', now());
+
+  raise notice 'All degraded-mode (no pg_cron) tests PASSED';
+end;
+$$;
+
+select ash.uninstall('yes');

--- a/devel/tests/degraded_no_pgss.sql
+++ b/devel/tests/degraded_no_pgss.sql
@@ -1,0 +1,63 @@
+-- Degraded mode: pg_ash freshly installed WITHOUT pg_stat_statements.
+-- Every 2.0 reader must work; query_text degrades to NULL and is never spoofed
+-- by a user-created public.pg_stat_statements relation (#87).
+insert into ash.wait_event_map (state, type, event) values
+  ('active', 'CPU*', 'CPU*') on conflict do nothing;
+insert into ash.query_map_0 (query_id) values (999999) on conflict do nothing;
+
+do $$
+declare
+  v_cpu smallint; v_q1 int4; v_ts int4; v_from timestamptz;
+  n int; tcnt int; j jsonb;
+begin
+  select id into v_cpu from ash.wait_event_map where type = 'CPU*';
+  select id into v_q1 from ash.query_map_0 where query_id = 999999;
+  -- Minute-aligned 3 minutes back so a window from here reads raw.
+  v_ts := (ash.ts_from_timestamptz(date_trunc('minute', now() - interval '3 minutes')) / 60) * 60;
+  v_from := ash.ts_to_timestamptz(v_ts);
+  insert into ash.sample (sample_ts, datid, active_count, data, slot)
+    values (v_ts, 1, 1, array[-v_cpu, 1, v_q1]::integer[], 0);
+  perform ash.rollup_minute();
+
+  -- Every reader runs without pgss; query_text is NULL, no error, no WARNING.
+  perform ash.periods();
+  perform * from ash.aas(v_from, now());
+  perform * from ash.timeline(v_from, now());
+  perform * from ash.compare(v_from, now(), v_from, now());
+  perform * from ash.summary(v_from, now());
+  perform * from ash.chart(v_from, now());
+  assert (select query_text from ash.top('query_id', v_from, now()) limit 1) is null,
+    'top query_text should be NULL without pgss';
+  assert (select query_text from ash.samples(v_from, now()) limit 1) is null,
+    'samples query_text should be NULL without pgss';
+
+  -- report still produces query ids (they come from samples, not pgss).
+  j := ash.report(v_from, now());
+  assert j is not null, 'report should work without pgss';
+  assert j->'top_queryids_worst1m' ? 'total', 'report top_queryids total should be present';
+
+  perform ash.take_sample();
+  perform ash.status();
+  perform ash.set_debug_logging();
+
+  -- #87: a user-made public.pg_stat_statements must NOT be trusted as the real
+  -- extension — no row fan-out, no spoofed query_text.
+  create table public.pg_stat_statements (
+    queryid bigint, query text, calls bigint,
+    total_exec_time double precision, mean_exec_time double precision, dbid oid);
+  insert into public.pg_stat_statements values
+    (999999, 'select same from user_a', 10, 100.0, 10.0, 1::oid),
+    (999999, 'select same from user_b', 20, 400.0, 20.0, 2::oid);
+
+  select count(*), count(query_text) into n, tcnt
+    from ash.top('query_id', v_from, now()) where key = '999999';
+  assert n = 1 and tcnt = 0,
+    format('top must ignore spoofed pg_stat_statements, got rows=%s text_rows=%s', n, tcnt);
+  select count(*), count(query_text) into n, tcnt
+    from ash.samples(v_from, now()) where query_id = 999999;
+  assert n = 1 and tcnt = 0,
+    format('samples must ignore spoofed pg_stat_statements, got rows=%s text_rows=%s', n, tcnt);
+
+  drop table public.pg_stat_statements;
+  raise notice 'All degraded-mode (no pgss) 2.0 reader tests PASSED';
+end $$;

--- a/devel/tests/schema_snapshot.sql
+++ b/devel/tests/schema_snapshot.sql
@@ -1,0 +1,58 @@
+\pset tuples_only on
+\pset format unaligned
+select 'FUNC', p.proname,
+       pg_get_function_identity_arguments(p.oid),
+       pg_get_function_result(p.oid),
+       md5(p.prosrc)
+from pg_proc p
+join pg_namespace n on n.oid = p.pronamespace
+where n.nspname = 'ash'
+order by p.proname, pg_get_function_identity_arguments(p.oid);
+
+select 'COL', c.relname, a.attnum, a.attname,
+       pg_catalog.format_type(a.atttypid, a.atttypmod),
+       a.attnotnull,
+       pg_get_expr(d.adbin, d.adrelid)
+from pg_class c
+join pg_namespace n on n.oid = c.relnamespace
+join pg_attribute a on a.attrelid = c.oid
+left join pg_attrdef d on d.adrelid = a.attrelid and d.adnum = a.attnum
+where n.nspname = 'ash' and c.relkind in ('r','p') and a.attnum > 0 and not a.attisdropped
+order by c.relname, a.attnum;
+
+select 'IDX', c.relname, pg_get_indexdef(i.indexrelid)
+from pg_index i
+join pg_class c on c.oid = i.indexrelid
+join pg_namespace n on n.oid = c.relnamespace
+where n.nspname = 'ash'
+order by c.relname;
+
+select 'VIEW', viewname, md5(definition)
+from pg_views
+where schemaname = 'ash'
+order by viewname;
+
+-- Issue #66: include CHECK / NOT NULL / PK / UNIQUE / FK constraints.
+-- Covers parent partitioned tables AND their partitions (relkind r,p).
+-- pg_get_constraintdef gives a stable canonical text form, so any
+-- divergence (e.g. sample_data_check `>= 2` vs `>= 3` from #49)
+-- surfaces here.
+select 'CON', c.relname, con.conname, pg_get_constraintdef(con.oid)
+from pg_constraint con
+join pg_class c on c.oid = con.conrelid
+join pg_namespace n on n.oid = c.relnamespace
+where n.nspname = 'ash' and c.relkind in ('r','p')
+order by c.relname, con.conname;
+
+-- Issue #107: privilege state must be equivalent too. proacl is
+-- NULL until the first GRANT/REVOKE touches a function; the
+-- installer's REVOKE-from-PUBLIC hardening always runs, so a fresh
+-- install and the full upgrade chain must converge to identical
+-- explicit function ACLs.
+select 'FACL', p.proname,
+       pg_get_function_identity_arguments(p.oid),
+       coalesce(p.proacl::text, '<default>')
+from pg_proc p
+join pg_namespace n on n.oid = p.pronamespace
+where n.nspname = 'ash'
+order by p.proname, pg_get_function_identity_arguments(p.oid);

--- a/sql/migrations/ash-1.5-to-2.0.sql
+++ b/sql/migrations/ash-1.5-to-2.0.sql
@@ -22,15 +22,852 @@
  *   * grants the default reader bundle to pg_monitor (best-effort, new in
  *     2.0 — see the block at the end of the installer; opt out afterwards
  *     with `select ash.revoke_reader('pg_monitor')`), and
- *   * stamps ash.config.version = '2.0-beta1' (and the column default).
+ *   * stamps ash.config.version = '2.0-beta1' (and the column default), and
+ *   * normalizes ash.config's physical column order to match a fresh 2.0
+ *     install while preserving its singleton row and catalog properties.
  *
  * Sampling, storage, rollups, and admin/lifecycle functions are unchanged.
  * Re-apply-safe: the installer is idempotent (CREATE OR REPLACE / IF NOT
- * EXISTS plus the deterministic drop block), so running this script again is
- * a no-op.
+ * EXISTS plus the deterministic drop block), and the config normalization
+ * exits without replacing the table once the canonical order is present.
  */
 
 \set ON_ERROR_STOP on
 begin;
 \ir ../ash-install.sql
+set local search_path = pg_catalog, pg_temp;
+set local default_tablespace = '';
+
+/*
+ * v1.1 added fields to ash.config after the original columns, and subsequent
+ * upgrades kept appending fields. The values and definitions converged by
+ * 2.0, but the physical attnum order did not. Normalize the upgraded table to
+ * the fresh-install order so row types, SELECT * consumers, and schema
+ * snapshots agree.
+ *
+ * The swap is atomic inside this migration transaction. ACCESS EXCLUSIVE
+ * serializes it with samplers and readers. DROP RESTRICT is deliberate:
+ * an unexpected external dependency aborts and rolls back the migration
+ * instead of being destroyed. Shipped pg_ash functions use string-bodied SQL
+ * or PL/pgSQL and do not depend on ash.config's relation OID.
+ *
+ * Effective grants and grant options are preserved. Historical grantor OIDs
+ * are not replayed because doing so would require assuming arbitrary roles;
+ * grants are replayed by the migration owner instead.
+ */
+do $config_ordinal_normalization$
+declare
+  v_canonical_columns constant text[] := array[
+    'singleton',
+    'current_slot',
+    'num_partitions',
+    'sampling_enabled',
+    'skipped_samples',
+    'missed_samples',
+    'sample_interval',
+    'rotation_period',
+    'include_bg_workers',
+    'debug_logging',
+    'encoding_version',
+    'version',
+    'rotated_at',
+    'installed_at',
+    'rollup_1m_retention_days',
+    'rollup_1h_retention_days',
+    'rollup_min_backend_seconds',
+    'last_rollup_1m_ts',
+    'last_rollup_1h_ts',
+    'insert_errors',
+    'register_wait_cap_hits'
+  ]::text[];
+  v_canonical_types constant text[] := array[
+    'boolean',
+    'smallint',
+    'smallint',
+    'boolean',
+    'integer',
+    'bigint',
+    'interval',
+    'interval',
+    'boolean',
+    'boolean',
+    'smallint',
+    'text',
+    'timestamp with time zone',
+    'timestamp with time zone',
+    'smallint',
+    'smallint',
+    'smallint',
+    'integer',
+    'integer',
+    'bigint',
+    'bigint'
+  ]::text[];
+  v_canonical_not_null constant bool[] := array[
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    true,
+    false,
+    false,
+    true,
+    true
+  ]::bool[];
+  v_actual_columns text[];
+  v_actual_columns_sorted text[];
+  v_actual_types text[];
+  v_actual_not_null bool[];
+  v_canonical_columns_sorted text[];
+  v_live_column_count int;
+  v_min_attnum int;
+  v_max_attnum int;
+  v_has_dropped_columns bool;
+  v_relation_oid oid;
+  v_heap_am_oid oid;
+  v_owner_oid oid;
+  v_owner_name text;
+  v_has_not_null_constraints bool;
+  v_row_count bigint;
+  v_singleton_count bigint;
+  v_relation record;
+  v_default record;
+  v_constraint record;
+  v_index record;
+  v_acl record;
+  v_comment record;
+  v_grantee_sql text;
+  v_grant_option_sql text;
+begin
+  lock table ash.config in access exclusive mode;
+  v_relation_oid := 'ash.config'::regclass;
+
+  select
+    array_agg(
+      attribute.attname::text
+      order by attribute.attnum
+    ),
+    array_agg(
+      attribute.attname::text
+      order by attribute.attname
+    ),
+    count(*)::int,
+    min(attribute.attnum)::int,
+    max(attribute.attnum)::int
+  into
+    v_actual_columns,
+    v_actual_columns_sorted,
+    v_live_column_count,
+    v_min_attnum,
+    v_max_attnum
+  from pg_catalog.pg_attribute as attribute
+  where
+    attribute.attrelid = v_relation_oid
+    and attribute.attnum > 0
+    and not attribute.attisdropped;
+
+  select array_agg(column_name order by column_name)
+  into v_canonical_columns_sorted
+  from unnest(v_canonical_columns) as canonical(column_name);
+
+  select exists (
+    select
+    from pg_catalog.pg_attribute as attribute
+    where
+      attribute.attrelid = v_relation_oid
+      and attribute.attnum > 0
+      and attribute.attisdropped
+  )
+  into v_has_dropped_columns;
+
+  if v_actual_columns_sorted is distinct from v_canonical_columns_sorted then
+    raise exception
+      'cannot normalize ash.config: expected columns %, found %',
+      v_canonical_columns,
+      v_actual_columns;
+  end if;
+
+  if v_actual_columns = v_canonical_columns
+     and v_live_column_count = cardinality(v_canonical_columns)
+     and v_min_attnum = 1
+     and v_max_attnum = cardinality(v_canonical_columns)
+     and not v_has_dropped_columns then
+    raise notice 'ash.config column order is already canonical';
+    return;
+  end if;
+
+  select
+    array_agg(
+      pg_catalog.format_type(
+        attribute.atttypid,
+        attribute.atttypmod
+      )
+      order by canonical.ordinality
+    ),
+    array_agg(
+      attribute.attnotnull
+      order by canonical.ordinality
+    )
+  into
+    v_actual_types,
+    v_actual_not_null
+  from unnest(v_canonical_columns)
+    with ordinality as canonical(column_name, ordinality)
+  inner join pg_catalog.pg_attribute as attribute
+    on attribute.attrelid = v_relation_oid
+    and attribute.attname = canonical.column_name
+    and attribute.attnum > 0
+    and not attribute.attisdropped;
+
+  if v_actual_types is distinct from v_canonical_types
+     or v_actual_not_null is distinct from v_canonical_not_null then
+    raise exception
+      'cannot normalize ash.config: unsupported column definitions (types %, not-null %)',
+      v_actual_types,
+      v_actual_not_null;
+  end if;
+
+  select
+    count(*),
+    count(*) filter (where singleton)
+  into
+    v_row_count,
+    v_singleton_count
+  from ash.config;
+
+  if v_row_count <> 1 or v_singleton_count <> 1 then
+    raise exception
+      'cannot normalize ash.config: expected one singleton row, found % row(s), % singleton',
+      v_row_count,
+      v_singleton_count;
+  end if;
+
+  if pg_catalog.to_regclass('ash.config_ordinal_legacy') is not null then
+    raise exception
+      'cannot normalize ash.config: ash.config_ordinal_legacy already exists';
+  end if;
+
+  select
+    relation.relkind,
+    relation.relpersistence,
+    relation.relispartition,
+    relation.relrowsecurity,
+    relation.relforcerowsecurity,
+    relation.relreplident,
+    relation.reltablespace,
+    relation.reloptions,
+    relation.reloftype,
+    relation.relam,
+    relation.relowner
+  into strict v_relation
+  from pg_catalog.pg_class as relation
+  where relation.oid = v_relation_oid;
+
+  select access_method.oid
+  into strict v_heap_am_oid
+  from pg_catalog.pg_am as access_method
+  where access_method.amname = 'heap';
+
+  if v_relation.relkind <> 'r'
+     or v_relation.relpersistence <> 'p'
+     or v_relation.relispartition
+     or v_relation.relrowsecurity
+     or v_relation.relforcerowsecurity
+     or v_relation.relreplident <> 'd'
+     or v_relation.reltablespace <> 0
+     or v_relation.reloptions is not null
+     or v_relation.reloftype <> 0
+     or v_relation.relam <> v_heap_am_oid then
+    raise exception
+      'cannot normalize ash.config: unsupported table storage, security, or replication properties';
+  end if;
+
+  if exists (
+    select
+    from pg_catalog.pg_attribute as attribute
+    inner join pg_catalog.pg_type as data_type
+      on data_type.oid = attribute.atttypid
+    where
+      attribute.attrelid = v_relation_oid
+      and attribute.attnum > 0
+      and not attribute.attisdropped
+      and (
+        attribute.attidentity <> ''
+        or attribute.attgenerated <> ''
+        or attribute.attstattarget <> -1
+        or attribute.attstorage <> data_type.typstorage
+        or attribute.attcompression <> ''
+        or attribute.attoptions is not null
+        or (
+          data_type.typcollation <> 0
+          and attribute.attcollation <> data_type.typcollation
+        )
+      )
+  ) then
+    raise exception
+      'cannot normalize ash.config: unsupported custom column storage properties';
+  end if;
+
+  if exists (
+    select
+    from pg_catalog.pg_trigger as trigger_row
+    where
+      trigger_row.tgrelid = v_relation_oid
+      and not trigger_row.tgisinternal
+  ) then
+    raise exception 'cannot normalize ash.config: custom triggers are present';
+  end if;
+
+  if exists (
+    select
+    from pg_catalog.pg_policy as policy
+    where policy.polrelid = v_relation_oid
+  ) then
+    raise exception 'cannot normalize ash.config: row security policies are present';
+  end if;
+
+  if exists (
+    select
+    from pg_catalog.pg_rewrite as rule
+    where rule.ev_class = v_relation_oid
+  ) then
+    raise exception 'cannot normalize ash.config: custom rules are present';
+  end if;
+
+  if exists (
+    select
+    from pg_catalog.pg_publication_rel as publication_relation
+    where publication_relation.prrelid = v_relation_oid
+  ) then
+    raise exception 'cannot normalize ash.config: publication membership is present';
+  end if;
+
+  if exists (
+    select
+    from pg_catalog.pg_statistic_ext as statistic
+    where statistic.stxrelid = v_relation_oid
+  ) then
+    raise exception 'cannot normalize ash.config: extended statistics are present';
+  end if;
+
+  if exists (
+    select
+    from pg_catalog.pg_seclabel as security_label
+    where
+      security_label.classoid = 'pg_class'::regclass
+      and security_label.objoid = v_relation_oid
+  ) then
+    raise exception 'cannot normalize ash.config: security labels are present';
+  end if;
+
+  if exists (
+    select
+    from pg_catalog.pg_inherits as inheritance
+    where
+      inheritance.inhrelid = v_relation_oid
+      or inheritance.inhparent = v_relation_oid
+  ) then
+    raise exception 'cannot normalize ash.config: table inheritance is present';
+  end if;
+
+  if exists (
+    select
+    from pg_catalog.pg_constraint as constraint_row
+    where
+      constraint_row.confrelid = v_relation_oid
+      and constraint_row.conrelid <> v_relation_oid
+  ) then
+    raise exception
+      'cannot normalize ash.config: another table has a foreign key to it';
+  end if;
+
+  if exists (
+    select
+    from pg_catalog.pg_index as index_row
+    where
+      index_row.indrelid = v_relation_oid
+      and (
+        not index_row.indisvalid
+        or not index_row.indisready
+        or not index_row.indislive
+      )
+  ) then
+    raise exception 'cannot normalize ash.config: an invalid index is present';
+  end if;
+
+  v_owner_oid := v_relation.relowner;
+
+  create temporary table ash_config_migration_defaults
+  on commit drop
+  as
+  select
+    attribute.attname::text as column_name,
+    attribute.attnotnull as is_not_null,
+    pg_catalog.pg_get_expr(
+      default_value.adbin,
+      default_value.adrelid
+    ) as default_expression
+  from pg_catalog.pg_attribute as attribute
+  left join pg_catalog.pg_attrdef as default_value
+    on default_value.adrelid = attribute.attrelid
+    and default_value.adnum = attribute.attnum
+  where
+    attribute.attrelid = v_relation_oid
+    and attribute.attnum > 0
+    and not attribute.attisdropped;
+
+  create temporary table ash_config_migration_constraints
+  on commit drop
+  as
+  select
+    constraint_row.conname::text as constraint_name,
+    constraint_row.contype as constraint_type,
+    pg_catalog.pg_get_constraintdef(
+      constraint_row.oid,
+      false
+    ) as constraint_definition,
+    pg_catalog.obj_description(
+      constraint_row.oid,
+      'pg_constraint'
+    ) as constraint_comment
+  from pg_catalog.pg_constraint as constraint_row
+  where
+    constraint_row.conrelid = v_relation_oid
+  order by constraint_row.conname;
+
+  select exists (
+    select
+    from ash_config_migration_constraints as constraint_row
+    where constraint_row.constraint_type = 'n'
+  )
+  into v_has_not_null_constraints;
+
+  create temporary table ash_config_migration_indexes
+  on commit drop
+  as
+  select
+    index_relation.relname::text as index_name,
+    exists (
+      select
+      from pg_catalog.pg_constraint as constraint_row
+      where
+        constraint_row.conindid = index_row.indexrelid
+        and constraint_row.contype in ('p', 'u', 'x')
+    ) as is_constraint_index,
+    index_row.indisclustered as is_clustered,
+    pg_catalog.pg_get_indexdef(index_row.indexrelid) as index_definition,
+    pg_catalog.obj_description(
+      index_row.indexrelid,
+      'pg_class'
+    ) as index_comment
+  from pg_catalog.pg_index as index_row
+  inner join pg_catalog.pg_class as index_relation
+    on index_relation.oid = index_row.indexrelid
+  where
+    index_row.indrelid = v_relation_oid
+  order by index_relation.relname;
+
+  create temporary table ash_config_migration_table_acl
+  on commit drop
+  as
+  select
+    acl.grantee,
+    acl.privilege_type,
+    acl.is_grantable
+  from pg_catalog.pg_class as relation
+  cross join lateral pg_catalog.aclexplode(relation.relacl) as acl
+  where relation.oid = v_relation_oid;
+
+  create temporary table ash_config_migration_column_acl
+  on commit drop
+  as
+  select
+    attribute.attname::text as column_name,
+    acl.grantee,
+    acl.privilege_type,
+    acl.is_grantable
+  from pg_catalog.pg_attribute as attribute
+  cross join lateral pg_catalog.aclexplode(attribute.attacl) as acl
+  where
+    attribute.attrelid = v_relation_oid
+    and attribute.attnum > 0
+    and not attribute.attisdropped;
+
+  create temporary table ash_config_migration_comments
+  on commit drop
+  as
+  select
+    null::text as column_name,
+    pg_catalog.obj_description(
+      v_relation_oid,
+      'pg_class'
+    ) as object_comment
+  union all
+  select
+    attribute.attname::text as column_name,
+    pg_catalog.col_description(
+      v_relation_oid,
+      attribute.attnum
+    ) as object_comment
+  from pg_catalog.pg_attribute as attribute
+  where
+    attribute.attrelid = v_relation_oid
+    and attribute.attnum > 0
+    and not attribute.attisdropped;
+
+  alter table ash.config rename to config_ordinal_legacy;
+
+  create table ash.config (
+    singleton                  bool,
+    current_slot               smallint,
+    num_partitions             smallint,
+    sampling_enabled           bool,
+    skipped_samples            int4,
+    missed_samples             bigint,
+    sample_interval            interval,
+    rotation_period            interval,
+    include_bg_workers         bool,
+    debug_logging              bool,
+    encoding_version           smallint,
+    version                    text,
+    rotated_at                 timestamptz,
+    installed_at               timestamptz,
+    rollup_1m_retention_days   smallint,
+    rollup_1h_retention_days   smallint,
+    rollup_min_backend_seconds smallint,
+    last_rollup_1m_ts          int4,
+    last_rollup_1h_ts          int4,
+    insert_errors              bigint,
+    register_wait_cap_hits     bigint
+  ) using heap;
+
+  insert into ash.config (
+    singleton,
+    current_slot,
+    num_partitions,
+    sampling_enabled,
+    skipped_samples,
+    missed_samples,
+    sample_interval,
+    rotation_period,
+    include_bg_workers,
+    debug_logging,
+    encoding_version,
+    version,
+    rotated_at,
+    installed_at,
+    rollup_1m_retention_days,
+    rollup_1h_retention_days,
+    rollup_min_backend_seconds,
+    last_rollup_1m_ts,
+    last_rollup_1h_ts,
+    insert_errors,
+    register_wait_cap_hits
+  )
+  select
+    singleton,
+    current_slot,
+    num_partitions,
+    sampling_enabled,
+    skipped_samples,
+    missed_samples,
+    sample_interval,
+    rotation_period,
+    include_bg_workers,
+    debug_logging,
+    encoding_version,
+    version,
+    rotated_at,
+    installed_at,
+    rollup_1m_retention_days,
+    rollup_1h_retention_days,
+    rollup_min_backend_seconds,
+    last_rollup_1m_ts,
+    last_rollup_1h_ts,
+    insert_errors,
+    register_wait_cap_hits
+  from ash.config_ordinal_legacy;
+
+  drop table ash.config_ordinal_legacy restrict;
+
+  v_owner_name := pg_catalog.pg_get_userbyid(v_owner_oid);
+  execute format(
+    'alter table ash.config owner to %I',
+    v_owner_name
+  );
+
+  for v_default in
+    select
+      column_name,
+      is_not_null,
+      default_expression
+    from ash_config_migration_defaults
+    order by column_name
+  loop
+    if v_default.default_expression is not null then
+      execute format(
+        'alter table ash.config alter column %I set default %s',
+        v_default.column_name,
+        v_default.default_expression
+      );
+    end if;
+  end loop;
+
+  /*
+   * PostgreSQL 18 exposes NOT NULL declarations as named pg_constraint rows,
+   * so the general constraint replay below preserves their exact names.
+   * Earlier majors represent them only in pg_attribute.
+   */
+  if not v_has_not_null_constraints then
+    for v_default in
+      select column_name
+      from ash_config_migration_defaults
+      where is_not_null
+      order by column_name
+    loop
+      execute format(
+        'alter table ash.config alter column %I set not null',
+        v_default.column_name
+      );
+    end loop;
+  end if;
+
+  /*
+   * Standalone unique indexes can be valid foreign-key targets. Recreate
+   * them before constraints so a custom self-referencing FK can bind to one.
+   */
+  for v_index in
+    select
+      index_name,
+      index_definition
+    from ash_config_migration_indexes
+    where not is_constraint_index
+    order by index_name
+  loop
+    execute v_index.index_definition;
+  end loop;
+
+  for v_constraint in
+    select
+      constraint_name,
+      constraint_type,
+      constraint_definition,
+      constraint_comment
+    from ash_config_migration_constraints
+    order by
+      case
+        when constraint_type in ('p', 'u', 'x') then 1
+        when constraint_type = 'f' then 3
+        else 2
+      end,
+      constraint_name
+  loop
+    execute format(
+      'alter table ash.config add constraint %I %s',
+      v_constraint.constraint_name,
+      v_constraint.constraint_definition
+    );
+
+    if v_constraint.constraint_comment is not null then
+      execute format(
+        'comment on constraint %I on ash.config is %L',
+        v_constraint.constraint_name,
+        v_constraint.constraint_comment
+      );
+    end if;
+  end loop;
+
+  for v_index in
+    select
+      index_name,
+      index_comment
+    from ash_config_migration_indexes
+    where index_comment is not null
+    order by index_name
+  loop
+    execute format(
+      'comment on index ash.%I is %L',
+      v_index.index_name,
+      v_index.index_comment
+    );
+  end loop;
+
+  for v_index in
+    select index_name
+    from ash_config_migration_indexes
+    where is_clustered
+    order by index_name
+  loop
+    execute format(
+      'alter table ash.config cluster on %I',
+      v_index.index_name
+    );
+  end loop;
+
+  /*
+   * CREATE TABLE applies the migration role's current default privileges.
+   * Remove every generated non-owner grant before replaying the old ACL.
+   */
+  execute 'revoke all privileges on table ash.config from public';
+  for v_acl in
+    select distinct
+      acl.grantee,
+      case
+        when acl.grantee = 0 then null
+        else pg_catalog.pg_get_userbyid(acl.grantee)
+      end as grantee_name
+    from pg_catalog.pg_class as relation
+    cross join lateral pg_catalog.aclexplode(relation.relacl) as acl
+    where
+      relation.oid = 'ash.config'::regclass
+      and acl.grantee <> v_owner_oid
+  loop
+    if v_acl.grantee = 0 then
+      v_grantee_sql := 'public';
+    else
+      v_grantee_sql := format(
+        '%I',
+        pg_catalog.pg_get_userbyid(v_acl.grantee)
+      );
+    end if;
+
+    execute format(
+      'revoke all privileges on table ash.config from %s',
+      v_grantee_sql
+    );
+  end loop;
+
+  for v_acl in
+    select
+      grantee,
+      privilege_type,
+      is_grantable
+    from ash_config_migration_table_acl
+    order by grantee, privilege_type
+  loop
+    if v_acl.grantee = 0 then
+      v_grantee_sql := 'public';
+    else
+      v_grantee_sql := format(
+        '%I',
+        pg_catalog.pg_get_userbyid(v_acl.grantee)
+      );
+    end if;
+
+    if v_acl.is_grantable then
+      v_grant_option_sql := ' with grant option';
+    else
+      v_grant_option_sql := '';
+    end if;
+
+    execute format(
+      'grant %s on table ash.config to %s%s',
+      v_acl.privilege_type,
+      v_grantee_sql,
+      v_grant_option_sql
+    );
+  end loop;
+
+  for v_acl in
+    select
+      column_name,
+      grantee,
+      privilege_type,
+      is_grantable
+    from ash_config_migration_column_acl
+    order by column_name, grantee, privilege_type
+  loop
+    if v_acl.grantee = 0 then
+      v_grantee_sql := 'public';
+    else
+      v_grantee_sql := format(
+        '%I',
+        pg_catalog.pg_get_userbyid(v_acl.grantee)
+      );
+    end if;
+
+    if v_acl.is_grantable then
+      v_grant_option_sql := ' with grant option';
+    else
+      v_grant_option_sql := '';
+    end if;
+
+    execute format(
+      'grant %s (%I) on table ash.config to %s%s',
+      v_acl.privilege_type,
+      v_acl.column_name,
+      v_grantee_sql,
+      v_grant_option_sql
+    );
+  end loop;
+
+  for v_comment in
+    select
+      column_name,
+      object_comment
+    from ash_config_migration_comments
+    where object_comment is not null
+    order by column_name nulls first
+  loop
+    if v_comment.column_name is null then
+      execute format(
+        'comment on table ash.config is %L',
+        v_comment.object_comment
+      );
+    else
+      execute format(
+        'comment on column ash.config.%I is %L',
+        v_comment.column_name,
+        v_comment.object_comment
+      );
+    end if;
+  end loop;
+
+  select
+    array_agg(
+      attribute.attname::text
+      order by attribute.attnum
+    )
+  into v_actual_columns
+  from pg_catalog.pg_attribute as attribute
+  where
+    attribute.attrelid = 'ash.config'::regclass
+    and attribute.attnum > 0
+    and not attribute.attisdropped;
+
+  if v_actual_columns is distinct from v_canonical_columns then
+    raise exception
+      'ash.config normalization produced unexpected columns: %',
+      v_actual_columns;
+  end if;
+
+  select
+    count(*),
+    count(*) filter (where singleton)
+  into
+    v_row_count,
+    v_singleton_count
+  from ash.config;
+
+  if v_row_count <> 1 or v_singleton_count <> 1 then
+    raise exception
+      'ash.config normalization lost the singleton row';
+  end if;
+
+  raise notice
+    'ash.config normalized to canonical column order with row and catalog properties preserved';
+end
+$config_ordinal_normalization$;
 commit;


### PR DESCRIPTION
## Summary

- adds repeatable Docker release-gate images and a safe local runner for PostgreSQL 14, 15, 16, 17, 18, and 19beta2;
- reuses the workflow's SQL assertions through shared test files, including previously missing degraded-mode coverage and real pg_cron scheduling/firing;
- closes the schema-equivalence blind spot by snapshotting columns in physical `attnum` order;
- fixes the resulting upgrade finding in the editable `ash-1.5-to-2.0.sql` migration: `ash.config` had fresh-vs-upgraded column ordinals that diverged beginning with v1.1;
- rebased onto current `main`, including #159, #145, #154, #151, #149, #133, and #127.

Relates to #160.

## `ash.config` red/green

The new ordinal-aware upgrade assertion was red before the migration fix on PostgreSQL 14 (and the same divergence affected every supported major):

```text
ash.config column order differs: {singleton,current_slot,sample_interval,rotation_period,include_bg_workers,encoding_version,rotated_at,installed_at,version,debug_logging,num_partitions,sampling_enabled,skipped_samples,missed_samples,rollup_1m_retention_days,rollup_1h_retention_days,rollup_min_backend_seconds,last_rollup_1m_ts,last_rollup_1h_ts,insert_errors,register_wait_cap_hits}
```

No allowlist was added. The final migration takes an `ACCESS EXCLUSIVE` lock, validates the exact expected columns/types/nullability and supported catalog properties, snapshots the singleton row plus defaults, constraints, indexes, owner, effective table/column ACLs, and comments, then performs an atomic rename/create/copy/`DROP RESTRICT`/replay. Unsupported dependencies or properties abort and roll back. A canonical table is a no-op on reapplication and retains its OID.

The regression seeds non-default data, custom defaults/ACL state, a check constraint, a partial index, and a standalone-UNIQUE/self-FK pair. It verifies preservation and applies the migration twice.

## Release-gate matrix

Command used on rebased HEAD:

```bash
PG_MAJORS="14 15 16 17 18 19beta2" \
RELEASE_GATE_JOBS=2 \
RELEASE_GATE_PULL=0 \
RELEASE_GATE_OUTPUT_DIR=/tmp/pg_ash-release-gate-postrebase-final3-20260727 \
devel/scripts/release_gate.sh all
```

| Surface | PG14 | PG15 | PG16 | PG17 | PG18 | PG19beta2 |
|---|---:|---:|---:|---:|---:|---:|
| fresh-install | PASS | PASS | PASS | PASS | PASS | PASS |
| upgrade-chain | PASS | PASS | PASS | PASS | PASS | PASS |
| degraded-no-cron | PASS | PASS | PASS | PASS | PASS | PASS |
| degraded-no-pgss | PASS | PASS | PASS | PASS | PASS | PASS |
| degraded-neither | PASS | PASS | PASS | PASS | PASS | PASS |
| cron-path | PASS | PASS | PASS | PASS | PASS | PASS |

Result: **36/36 PASS**. The cron surface confirmed actual pg_cron job firing on every major, including `postgres:19beta2` (there is no `postgres:19` image yet).

## Additional validation

- `actionlint` 1.7.7: PASS
- `shellcheck` 0.10.0: PASS
- `hadolint` 2.12.0: PASS
- workflow YAML and six-major matrix parse: PASS
- release-gate helper unit tests: 7/7 PASS
- `bash -n devel/scripts/release_gate.sh`: PASS
- `git diff --check`: PASS
- disposable release-gate containers after run: 0
- unrelated `finance-control-*` containers remained running and untouched: 5

This PR is intentionally left as a draft.