### PR TITLE
release: fix raw retention boundary

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3060,7 +3060,7 @@ jobs:
           -- --- raw-retention exception (tie drill before raw retention) ----------------
           update ash.config
           set num_partitions = 3,
-              rotation_period = interval '30 minutes',
+              rotation_period = interval '1 day',
               rotated_at = date_trunc('minute', now())
           where singleton;
 
@@ -3070,7 +3070,8 @@ jobs:
             select base_ts into v_base from t2anchor;
             begin
               perform * from ash.top('query_id',
-                ash.ts_to_timestamptz(v_base - 3600), ash.ts_to_timestamptz(v_base - 3000),
+                ash.ts_to_timestamptz(v_base - 172800),
+                ash.ts_to_timestamptz(v_base - 172200),
                 wait_event => 'DataFileRead');
               raise exception 'expected raw-retention exception, none raised';
             exception when others then
@@ -6563,7 +6564,7 @@ jobs:
             v_slots smallint[];
           begin
             update ash.config
-            set rotation_period = interval '30 minutes',
+            set rotation_period = interval '1 day',
                 rotated_at = v_end
             where singleton;
             select ash._register_wait('active','CPU*','CPU*') into v_cpu;
@@ -6582,8 +6583,9 @@ jobs:
                            else array[v_cpu, 60]::int4[] end,
                       case when i = 5 then array[424242::bigint, 540]::int8[] else '{}'::int8[] end);
             end loop;
-            -- raw samples for the last 30 minutes ONLY (raw retention starts at
-            -- v_end-30min); worst minute carries the 424242 tie.
+            -- Raw samples cover the last 30 minutes only (physical coverage);
+            -- the logical planning boundary is v_end-1day. The worst minute
+            -- carries the 424242 tie.
             for i in 1..30 loop
               insert into ash.sample (sample_ts, datid, active_count, data, slot)
               values (ash.ts_from_timestamptz(v_end - (i || ' minutes')::interval), v_dp,
@@ -6610,8 +6612,10 @@ jobs:
             assert (j->'coverage'->>'minutes_with_data')::int = 120, 'coverage.minutes_with_data 120';
             assert (j->'coverage'->>'from')::timestamptz = v_end - interval '2 hours', 'coverage.from';
             assert (j->'coverage'->>'to')::timestamptz = v_end, 'coverage.to';
-            assert (j->'coverage'->>'raw_retention_start')::timestamptz = v_end - interval '30 minutes',
-              'coverage.raw_retention_start -30min, got ' || (j->'coverage'->>'raw_retention_start');
+            assert (j->'coverage'->>'raw_retention_start')::timestamptz
+                = v_end - interval '1 day',
+              'coverage.raw_retention_start -1day, got '
+                || (j->'coverage'->>'raw_retention_start');
 
             -- window whose extremes all predate raw retention: aas_* still present,
             -- attribution keys absent, availability flag false, never raises.
@@ -6628,8 +6632,8 @@ jobs:
             -- entirely past raw retention: unrecoverable, no "narrow" advice.
             v_raised := false;
             begin
-              perform * from ash.top('query_id', v_end - interval '2 hours',
-                                     v_end - interval '1 hour', wait_event => 'DataFileRead');
+              perform * from ash.top('query_id', v_end - interval '2 days',
+                                     v_end - interval '1 day', wait_event => 'DataFileRead');
               raise exception 'entirely-past tie drill should have raised';
             exception when others then
               if sqlerrm like '%entirely outside raw retention%'
@@ -6643,24 +6647,27 @@ jobs:
             -- the message must (a) echo the un-floored start the USER passed and
             -- (b) advise the logical, minute-aligned retention boundary.
             insert into ash.sample (sample_ts, datid, active_count, data, slot)
-            values (ash.ts_from_timestamptz(v_end - interval '40 minutes' + interval '37 seconds'),
+            values (ash.ts_from_timestamptz(
+                      v_end - interval '1 day 40 minutes' + interval '37 seconds'
+                    ),
                     v_dp, 1, array[-v_cpu, 1, 0]::integer[], 0);
             v_raw := ash._raw_retention_start();
-            assert v_raw = v_end - interval '40 minutes',
+            assert v_raw = v_end - interval '1 day 40 minutes',
               'logical boundary must preserve delayed-rotation evidence, got '
                 || v_raw;
             v_oldest := ash._raw_oldest_sample();
-            assert v_oldest = v_end - interval '40 minutes' + interval '37 seconds',
+            assert v_oldest
+                = v_end - interval '1 day 40 minutes' + interval '37 seconds',
               'physical oldest raw sample mismatch: ' || v_oldest;
             v_slots := ash._active_slots_for_at(
-              v_end - interval '40 minutes',
-              v_end - interval '39 minutes'
+              v_end - interval '1 day 40 minutes',
+              v_end - interval '1 day 39 minutes'
             );
             assert v_slots = array[0, 2]::smallint[],
               'absolute range guard discarded delayed-rotation evidence: '
                 || v_slots::text;
             v_bound := v_raw;
-            v_passed := v_end - interval '2 hours' + interval '23 seconds';  -- mid-minute passed start
+            v_passed := v_end - interval '2 days' + interval '23 seconds';
             v_raised := false;
             begin
               perform * from ash.aas(v_passed, v_end,
@@ -6711,7 +6718,9 @@ jobs:
             );
             -- restore pre-test raw retention so downstream assertions see original state
             delete from ash.sample
-              where sample_ts = ash.ts_from_timestamptz(v_end - interval '40 minutes' + interval '37 seconds');
+              where sample_ts = ash.ts_from_timestamptz(
+                v_end - interval '1 day 40 minutes' + interval '37 seconds'
+              );
             raise notice 'retention error split PASSED (logical boundary + down-rounded helper hint)';
 
             -- ---- compare coverage honesty ----

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6560,6 +6560,7 @@ jobs:
             j jsonb; r record; n int; v_raised boolean;
             v_raw timestamptz; v_oldest timestamptz; v_bound timestamptz;
             v_passed timestamptz; v_msg text; v_mid_msg text;
+            v_slots smallint[];
           begin
             update ash.config
             set rotation_period = interval '30 minutes',
@@ -6645,11 +6646,19 @@ jobs:
             values (ash.ts_from_timestamptz(v_end - interval '40 minutes' + interval '37 seconds'),
                     v_dp, 1, array[-v_cpu, 1, 0]::integer[], 0);
             v_raw := ash._raw_retention_start();
-            assert v_raw = v_end - interval '30 minutes',
-              'logical raw retention boundary must stay at -30min, got ' || v_raw;
+            assert v_raw = v_end - interval '40 minutes',
+              'logical boundary must preserve delayed-rotation evidence, got '
+                || v_raw;
             v_oldest := ash._raw_oldest_sample();
             assert v_oldest = v_end - interval '40 minutes' + interval '37 seconds',
               'physical oldest raw sample mismatch: ' || v_oldest;
+            v_slots := ash._active_slots_for_at(
+              v_end - interval '40 minutes',
+              v_end - interval '39 minutes'
+            );
+            assert v_slots = array[0, 2]::smallint[],
+              'absolute range guard discarded delayed-rotation evidence: '
+                || v_slots::text;
             v_bound := v_raw;
             v_passed := v_end - interval '2 hours' + interval '23 seconds';  -- mid-minute passed start
             v_raised := false;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6547,8 +6547,13 @@ jobs:
             v_cpu smallint; v_io smallint; v_q1 int4; v_dp oid;
             v_end timestamptz := date_trunc('hour', now());
             j jsonb; r record; n int; v_raised boolean;
-            v_raw timestamptz; v_bound timestamptz; v_passed timestamptz; v_msg text;
+            v_raw timestamptz; v_oldest timestamptz; v_bound timestamptz;
+            v_passed timestamptz; v_msg text; v_mid_msg text;
           begin
+            update ash.config
+            set rotation_period = interval '30 minutes',
+                rotated_at = v_end
+            where singleton;
             select ash._register_wait('active','CPU*','CPU*') into v_cpu;
             select ash._register_wait('active','IO','DataFileRead') into v_io;
             insert into ash.query_map_0 (query_id) values (424242);
@@ -6622,20 +6627,19 @@ jobs:
               else raise; end if;
             end;
             assert v_raised, 'entirely-past retention error mismatch';
-            -- partial overlap (window END inside raw retention, START before it):
+            -- Partial overlap (window END inside raw retention, START before it):
             -- the message must (a) echo the un-floored start the USER passed and
-            -- (b) advise a minute-aligned boundary that, once passed, actually
-            -- clears the guard. Readers floor since to the minute before the
-            -- guard runs, so a mid-minute raw_retention_start otherwise loops:
-            -- narrowing to exactly raw_start re-floors below it and re-raises.
-            -- Give raw retention a mid-minute start with one earlier sample.
+            -- (b) advise the logical, minute-aligned retention boundary.
             insert into ash.sample (sample_ts, datid, active_count, data, slot)
             values (ash.ts_from_timestamptz(v_end - interval '40 minutes' + interval '37 seconds'),
                     v_dp, 1, array[-v_cpu, 1, 0]::integer[], 0);
             v_raw := ash._raw_retention_start();
-            assert date_trunc('minute', v_raw) <> v_raw,
-              'test setup: raw_retention_start must be mid-minute, got ' || v_raw;
-            v_bound := date_trunc('minute', v_raw) + interval '1 minute';
+            assert v_raw = v_end - interval '30 minutes',
+              'logical raw retention boundary must stay at -30min, got ' || v_raw;
+            v_oldest := ash._raw_oldest_sample();
+            assert v_oldest = v_end - interval '40 minutes' + interval '37 seconds',
+              'physical oldest raw sample mismatch: ' || v_oldest;
+            v_bound := v_raw;
             v_passed := v_end - interval '2 hours' + interval '23 seconds';  -- mid-minute passed start
             v_raised := false;
             begin
@@ -6649,23 +6653,46 @@ jobs:
             -- (a) echoes the un-floored start the user actually passed (not floored v_start_ts)
             assert v_msg like '%' || v_passed::text || '%',
               'message must echo the user''s passed start ' || v_passed || ', got: ' || v_msg;
-            -- (b) advises a minute-aligned boundary >= raw_start (followable, not a loop)
+            -- (b) advises the logical boundary, rounded down to its minute.
             assert v_msg like '%start at or after ' || v_bound::text || '%',
               'hint must print minute-aligned boundary ' || v_bound || ', got: ' || v_msg;
-            -- passing exactly that boundary now SUCCEEDS (the advice is actionable)
+            -- Passing exactly the status/guard boundary succeeds.
             select count(*) into n from ash.top('query_id', v_bound, v_end,
                                                 wait_event => 'DataFileRead');
             assert n = 1, 'following the hint boundary must return the 424242 row, got ' || n;
-            -- and passing raw_start itself re-floors below it and still raises (the loop we fixed)
+            -- Defensive helper contract: if a mid-minute boundary is supplied,
+            -- floor both sides and advise DOWN, preserving its partial minute.
             v_raised := false;
             begin
-              perform * from ash.aas(v_raw, v_end, wait_event => 'DataFileRead', query_id => 424242);
-            exception when others then v_raised := true; end;
-            assert v_raised, 'passing a mid-minute raw_start re-floors below it and still raises';
+              perform ash._raise_tie_retention(
+                v_oldest,
+                ash.ts_from_timestamptz(v_passed) / 60 * 60,
+                ash.ts_from_timestamptz(v_end),
+                v_passed
+              );
+              raise exception 'mid-minute helper guard should have raised';
+            exception when others then
+              if sqlerrm like '%Narrow the window%' then
+                v_raised := true;
+                v_mid_msg := sqlerrm;
+              else
+                raise;
+              end if;
+            end;
+            assert v_raised, 'mid-minute helper retention error mismatch';
+            assert v_mid_msg like '%start at or after '
+              || date_trunc('minute', v_oldest)::text || '%',
+              'mid-minute helper hint must round down, got: ' || v_mid_msg;
+            perform ash._raise_tie_retention(
+              v_oldest,
+              ash.ts_from_timestamptz(date_trunc('minute', v_oldest)),
+              ash.ts_from_timestamptz(v_end),
+              date_trunc('minute', v_oldest)
+            );
             -- restore pre-test raw retention so downstream assertions see original state
             delete from ash.sample
               where sample_ts = ash.ts_from_timestamptz(v_end - interval '40 minutes' + interval '37 seconds');
-            raise notice 'retention error split PASSED (mid-minute hint is followable, echoes passed start)';
+            raise notice 'retention error split PASSED (logical boundary + down-rounded helper hint)';
 
             -- ---- compare coverage honesty ----
             -- window 1 uncovered (4..3h back): NULL columns + NULL delta, overall mode.
@@ -6767,15 +6794,19 @@ jobs:
               date_trunc('minute', now()) - interval '2 days');
             v_recent_ts int4 := ash.ts_from_timestamptz(
               date_trunc('minute', now()) - interval '10 minutes');
+            v_oldest timestamptz;
             v_start timestamptz;
             v_status_start timestamptz;
+            v_expected_start timestamptz := date_trunc('minute', now())
+              - interval '1 day';
             v_slots smallint[];
             v_raised boolean := false;
           begin
             truncate ash.sample_0, ash.sample_1, ash.sample_2;
             update ash.config
             set current_slot = 0, num_partitions = 3,
-                rotation_period = interval '1 day'
+                rotation_period = interval '1 day',
+                rotated_at = date_trunc('minute', now())
             where singleton;
             select ash._register_wait('active', 'CPU*', 'CPU*') into v_wait;
 
@@ -6790,13 +6821,16 @@ jobs:
             v_slots := ash._active_slots();
             assert v_slots = array[0, 2]::smallint[],
               'retained slot set should be {0,2}, got ' || v_slots::text;
+            v_oldest := ash._raw_oldest_sample();
+            assert v_oldest = ash.ts_to_timestamptz(v_recent_ts),
+              'oldest raw sample used excluded slot 1: ' || v_oldest::text;
             v_start := ash._raw_retention_start();
-            assert v_start = ash.ts_to_timestamptz(v_recent_ts),
-              'raw retention start used excluded slot 1: ' || v_start::text;
+            assert v_start = v_expected_start,
+              'logical raw retention start mismatch: ' || v_start::text;
             select value::timestamptz into v_status_start
             from ash.status() where metric = 'raw_retention_start';
             assert v_status_start = v_start,
-              'status raw_retention_start disagrees with retained slots';
+              'status raw_retention_start disagrees with logical boundary';
 
             begin
               perform * from ash.aas(
@@ -6817,6 +6851,242 @@ jobs:
             truncate ash.sample_0, ash.sample_1, ash.sample_2;
             raise notice 'raw retention excludes the oldest ring slot PASSED';
           end $$;
+
+          -- B3 / #163: a fresh default-interval install has only a partial first
+          -- minute. The documented five-minute tie drill must still read it,
+          -- status must return a reusable logical boundary, and remediation must
+          -- round down so it does not discard that partial minute.
+          begin;
+
+          update ash.config
+          set current_slot = 0,
+              num_partitions = 3,
+              sample_interval = interval '1 second',
+              rotation_period = interval '1 day',
+              rotated_at = date_trunc('minute', now())
+                - interval '1 minute' + interval '50 seconds'
+          where singleton;
+          truncate ash.sample_0, ash.sample_1, ash.sample_2;
+          truncate ash.query_map_0, ash.query_map_1, ash.query_map_2;
+          alter table ash.query_map_0 alter column id restart;
+
+          create temp table b3_anchor (
+            anchor timestamptz primary key
+          ) on commit drop;
+          insert into b3_anchor values (date_trunc('minute', now()));
+
+          do $$
+          declare
+            v_anchor timestamptz := (select anchor from b3_anchor);
+            v_wait smallint;
+            v_map_id int4;
+            v_datid oid;
+            v_setup text[];
+          begin
+            select ash._register_wait('active', 'Lock', 'tuple') into v_wait;
+            insert into ash.query_map_0 (query_id)
+            values (8231004856741017)
+            returning id into v_map_id;
+            select oid into v_datid
+            from pg_database
+            where datname = current_database();
+
+            insert into ash.sample (
+              sample_ts, datid, active_count, data, slot
+            )
+            select
+              ash.ts_from_timestamptz(
+                v_anchor - interval '1 minute'
+                + (sample_offset || ' seconds')::interval
+              ),
+              v_datid,
+              1,
+              array[-v_wait, 1, v_map_id]::int4[],
+              0
+            from generate_series(51, 58) as sample_offset;
+
+            select array[
+              count(*)::text,
+              min(ash.ts_to_timestamptz(sample_ts))::text,
+              max(ash.ts_to_timestamptz(sample_ts))::text,
+              (min(sample_ts) % 60)::text
+            ]
+            into v_setup
+            from ash.sample;
+            assert v_setup = array[
+              '8',
+              (v_anchor - interval '1 minute' + interval '51 seconds')::text,
+              (v_anchor - interval '1 minute' + interval '58 seconds')::text,
+              '51'
+            ], 'B3 fixture mismatch: ' || v_setup::text;
+
+            select array[
+              count(*)::text,
+              min(key),
+              min(source),
+              min(backend_seconds)::text
+            ]
+            into v_setup
+            from ash.top(
+              'wait_event',
+              since => now() - interval '5 minutes'
+            );
+            assert v_setup = array['1', 'Lock:tuple', 'raw', '8.00'],
+              'B3 untied control mismatch: ' || v_setup::text;
+          end
+          $$;
+
+          -- RED 1: README.md's flagship drill, copied verbatim.
+          do $$
+          declare
+            v_got text[];
+          begin
+            begin
+              select array[
+                count(*)::text,
+                min(key),
+                min(source),
+                min(avg_aas)::text,
+                min(peak_aas)::text,
+                min(p99_aas)::text,
+                min(backend_seconds)::text,
+                min(pct)::text
+              ]
+              into v_got
+              from ash.top(
+                'query_id',
+                since => now() - interval '5 minutes',
+                wait_event => 'Lock:tuple',
+                order_by => 'peak',
+                n => 5
+              );
+            exception when others then
+              v_got := array['ERROR', sqlerrm];
+            end;
+
+            assert v_got = array[
+              '1', '8231004856741017', 'raw', '0.03',
+              '0.13', '0.13', '8.00', '100.00'
+            ], 'B3 README drill mismatch: ' || v_got::text;
+          end
+          $$;
+
+          -- RED 2: status.raw_retention_start must be directly reusable.
+          do $$
+          declare
+            v_anchor timestamptz := (select anchor from b3_anchor);
+            v_status_start timestamptz;
+            v_result text[];
+            v_got text[];
+          begin
+            select value::timestamptz into v_status_start
+            from ash.status()
+            where metric = 'raw_retention_start';
+
+            begin
+              select array[
+                count(*)::text,
+                min(key),
+                min(source),
+                min(avg_aas)::text,
+                min(peak_aas)::text,
+                min(p99_aas)::text,
+                min(backend_seconds)::text,
+                min(pct)::text
+              ]
+              into v_result
+              from ash.top(
+                'query_id',
+                since => (
+                  select value::timestamptz
+                  from ash.status()
+                  where metric = 'raw_retention_start'
+                ),
+                wait_event => 'Lock:tuple'
+              );
+            exception when others then
+              v_result := array['ERROR', sqlerrm];
+            end;
+            v_got := array[v_status_start::text] || v_result;
+
+            assert v_got = array[
+              (v_anchor - interval '1 day' - interval '1 minute')::text,
+              '1', '8231004856741017', 'raw', '0.00',
+              '0.13', '0.13', '8.00', '100.00'
+            ], 'B3 status boundary mismatch: ' || v_got::text;
+          end
+          $$;
+
+          -- RED 3: the guard's printed boundary must round down, and following
+          -- that exact advice must preserve all eight partial-minute samples.
+          do $$
+          declare
+            v_anchor timestamptz := (select anchor from b3_anchor);
+            v_raw_start timestamptz :=
+              (select min(ash.ts_to_timestamptz(sample_ts)) from ash.sample);
+            v_passed timestamptz := v_anchor - interval '5 minutes'
+              + interval '23 seconds';
+            v_message text;
+            v_advised timestamptz;
+            v_direction text;
+            v_result text[];
+            v_got text[];
+          begin
+            begin
+              perform ash._raise_tie_retention(
+                v_raw_start,
+                ash.ts_from_timestamptz(v_passed) / 60 * 60,
+                ash.ts_from_timestamptz(v_anchor),
+                v_passed
+              );
+              raise exception 'B3 guard should have raised for partial overlap';
+            exception when others then
+              if sqlerrm like '%Narrow the window%' then
+                v_message := sqlerrm;
+              else
+                raise;
+              end if;
+            end;
+
+            v_advised := split_part(
+              split_part(v_message, 'start at or after ', 2),
+              ' (the window end',
+              1
+            )::timestamptz;
+            v_direction := case
+              when v_advised = date_trunc('minute', v_raw_start) then 'down'
+              when v_advised = date_trunc('minute', v_raw_start)
+                + interval '1 minute' then 'up'
+              else 'other'
+            end;
+
+            select array[
+              count(*)::text,
+              min(key),
+              min(source),
+              min(avg_aas)::text,
+              min(peak_aas)::text,
+              min(p99_aas)::text,
+              min(backend_seconds)::text,
+              min(pct)::text
+            ]
+            into v_result
+            from ash.top(
+              'query_id',
+              since => v_advised,
+              until => v_anchor,
+              wait_event => 'Lock:tuple'
+            );
+            v_got := array[v_direction] || v_result;
+
+            assert v_got = array[
+              'down', '1', '8231004856741017', 'raw', '0.13',
+              '0.13', '0.13', '8.00', '100.00'
+            ], 'B3 down-rounded advice mismatch: ' || v_got::text;
+          end
+          $$;
+
+          rollback;
           EOF
 
       - name: "Test v1.4: status output and admin catalog contracts"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3058,6 +3058,12 @@ jobs:
           end $$;
 
           -- --- raw-retention exception (tie drill before raw retention) ----------------
+          update ash.config
+          set num_partitions = 3,
+              rotation_period = interval '30 minutes',
+              rotated_at = date_trunc('minute', now())
+          where singleton;
+
           do $$
           declare v_base int4; v_raised boolean := false;
           begin
@@ -3080,6 +3086,11 @@ jobs:
             assert v_raised, 'raw-retention exception message mismatch';
             raise notice 'raw-retention exception PASSED';
           end $$;
+
+          update ash.config
+          set rotation_period = interval '1 day',
+              rotated_at = date_trunc('minute', now())
+          where singleton;
 
           -- --- ash.timeline (per-bucket series + no-data bucket) -----------------------
           do $$
@@ -6858,22 +6869,98 @@ jobs:
           -- round down so it does not discard that partial minute.
           begin;
 
+          create temp table b3_start_result (
+            result_order smallint generated always as identity,
+            job_type text,
+            job_id bigint,
+            status text
+          ) on commit drop;
           update ash.config
-          set current_slot = 0,
-              num_partitions = 3,
-              sample_interval = interval '1 second',
-              rotation_period = interval '1 day',
-              rotated_at = date_trunc('minute', now())
-                - interval '1 minute' + interval '50 seconds'
+          set sample_interval = interval '7 seconds',
+              sampling_enabled = false
           where singleton;
-          truncate ash.sample_0, ash.sample_1, ash.sample_2;
-          truncate ash.query_map_0, ash.query_map_1, ash.query_map_2;
-          alter table ash.query_map_0 alter column id restart;
+          insert into b3_start_result (job_type, job_id, status)
+          select * from ash.start();
+
+          do $$
+          declare
+            v_job_types text[];
+            v_sampler_status text;
+            v_cron_available boolean := ash._pg_cron_available();
+          begin
+            assert (select sample_interval from ash.config where singleton)
+              = interval '1 second',
+              'B3 precondition: ash.start() default did not replace 7 seconds';
+            assert (select sampling_enabled from ash.config where singleton),
+              'B3 precondition: ash.start() default did not enable sampling';
+
+            select array_agg(job_type order by result_order)
+            into v_job_types
+            from b3_start_result;
+            select status into v_sampler_status
+            from b3_start_result
+            where job_type = 'sampler';
+
+            if v_cron_available then
+              assert v_job_types = array[
+                'sampler', 'rotation', 'rollup_1m', 'rollup_1h', 'rollup_gc'
+              ], 'B3 ash.start() cron result mismatch: '
+                || v_job_types::text;
+              assert not exists (
+                select from b3_start_result
+                where job_id is null or status is null or job_type = 'error'
+              ), 'B3 ash.start() cron result was not successful';
+              assert v_sampler_status in (
+                'created',
+                'already exists — schedule updated to 1 seconds'
+              ), 'B3 ash.start() sampler status mismatch: '
+                || v_sampler_status;
+            else
+              assert v_job_types = array['sampler', 'rotation', 'rollup'],
+                'B3 ash.start() external result mismatch: '
+                  || v_job_types::text;
+              assert (
+                select array_agg(status order by result_order)
+                from b3_start_result
+              ) = array[
+                'interval set to 00:00:01 — schedule externally '
+                  '(pg_cron not available)',
+                (
+                  select format(
+                    'rotation_period is %s — schedule ash.rotate() externally',
+                    rotation_period
+                  )
+                  from ash.config
+                  where singleton
+                ),
+                'schedule ash.rollup_minute() every minute, '
+                  'ash.rollup_hour() at minute 1 every hour, '
+                  'ash.rollup_cleanup() daily'
+              ], 'B3 ash.start() external statuses mismatch';
+              assert not exists (
+                select from b3_start_result
+                where job_id is not null or status is null or job_type = 'error'
+              ), 'B3 ash.start() external result was not successful';
+            end if;
+          end
+          $$;
 
           create temp table b3_anchor (
             anchor timestamptz primary key
           ) on commit drop;
           insert into b3_anchor values (date_trunc('minute', now()));
+
+          update ash.config
+          set current_slot = 0,
+              num_partitions = 3,
+              sample_interval = interval '1 second',
+              rotation_period = interval '1 day',
+              rotated_at = (select anchor from b3_anchor)
+                - interval '1 minute' + interval '59.75 seconds'
+          where singleton;
+          truncate ash.sample_0, ash.sample_1, ash.sample_2;
+          truncate ash.query_map_0, ash.query_map_1, ash.query_map_2;
+          alter table ash.query_map_0 alter column id restart;
 
           do $$
           declare
@@ -6936,12 +7023,27 @@ jobs:
           end
           $$;
 
-          -- RED 1: README.md's flagship drill, copied verbatim.
+          -- RED 1: README.md's flagship drill, copied verbatim into the
+          -- materialized result below so its error and exact row are assertable.
           do $$
           declare
             v_got text[];
           begin
             begin
+              create temp table b3_readme_result on commit drop as
+              select *
+              from ash.top(
+                'query_id',
+                since => now() - interval '5 minutes',
+                wait_event => 'Lock:tuple',
+                order_by => 'peak',
+                n => 5
+              );
+            exception when others then
+              v_got := array['ERROR', sqlerrm];
+            end;
+
+            if v_got is null then
               select array[
                 count(*)::text,
                 min(key),
@@ -6953,16 +7055,8 @@ jobs:
                 min(pct)::text
               ]
               into v_got
-              from ash.top(
-                'query_id',
-                since => now() - interval '5 minutes',
-                wait_event => 'Lock:tuple',
-                order_by => 'peak',
-                n => 5
-              );
-            exception when others then
-              v_got := array['ERROR', sqlerrm];
-            end;
+              from b3_readme_result;
+            end if;
 
             assert v_got = array[
               '1', '8231004856741017', 'raw', '0.03',

--- a/blueprints/AAS_API.md
+++ b/blueprints/AAS_API.md
@@ -311,8 +311,11 @@ key (consumers MUST treat them as optional), so a scraper reads
 `top_queryids_available` — additive and **always present** — instead of probing
 for key absence. `coverage` (also additive, always present) lets a consumer
 reconcile the payload against `ash.aas()` / `ash.top()` for the same window and
-detect degraded resolution (`minutes_with_data < minutes_expected`) or a reduced
-attribution window (`raw_retention_start` inside the window).
+detect degraded resolution (`minutes_with_data < minutes_expected`).
+`raw_retention_start` is the reusable, minute-aligned raw loss/planning
+boundary (the older of configured ring capacity and retained evidence), not
+the physical query-attribution cutoff; use `top_queryids_available` and the
+optional `top_queryids_*` keys for attribution.
 
 **Boundary:** pg_ash is **only the data source**. Consumer-side scoring —
 thresholds, health zoning, normalization against vCPU counts, display labels,
@@ -352,6 +355,8 @@ Semantics:
 - `coverage` (always present): `{from, to, source, minutes_expected,
   minutes_with_data, raw_retention_start}`. `source` is always `rollup_1m`
   (report is exclusively rollup-backed at 1-minute resolution).
+  `raw_retention_start` is the minute-aligned planning/loss boundary; it can
+  predate the oldest physical sample after a fresh install or sampler outage.
 - Never raises for missing data: classes with no samples report `0`; if
   the whole window has no coverage at all, returns `null` (consumers should
   skip ingestion for the period).

--- a/blueprints/AAS_EXAMPLES.md
+++ b/blueprints/AAS_EXAMPLES.md
@@ -401,14 +401,15 @@ select ash.report(since => '2026-07-04 00:00', until => '2026-07-05 00:00');
 ```
 
 `top_queryids_available` is **always present** (branch on it, not on key
-absence): here the worst/percentile minutes are inside raw retention even though
-the 1-day window *starts* at `2026-07-04 00:00` and `raw_retention_start` is
-`18:11` — attribution is decided per extreme minute. `coverage` lets the
-consumer reconcile this payload against `ash.aas()` / `ash.top()` for the same
-window and spot degraded resolution (`minutes_with_data < minutes_expected`).
-When the extremes themselves predate raw retention, the `top_queryids_*` objects
-are omitted and `top_queryids_available` is `false` — the `aas_*` keys still
-carry the load numbers.
+absence): attribution is decided per extreme minute. `raw_retention_start` is
+the reusable, minute-aligned planning/loss boundary, not the physical
+attribution cutoff; after a fresh install or sampler outage it can predate the
+oldest sample. `coverage` lets the consumer reconcile this payload against
+`ash.aas()` / `ash.top()` for the same window and spot degraded resolution
+(`minutes_with_data < minutes_expected`). When no extreme minute has raw
+evidence, the `top_queryids_*` objects are omitted and
+`top_queryids_available` is `false` — the `aas_*` keys still carry the load
+numbers.
 
 ---
 

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -2680,16 +2680,16 @@ $$;
 /*
  * Absolute-range counterpart to ash._active_slots_for(interval), used by
  * every _at reader (top_waits_at, samples_at, query_waits_at, etc.). Returns
- * the active slot set when the requested [since, until) range overlaps what
- * raw samples retain ((num_partitions - 2) * rotation_period back from now()),
- * and an empty array with a NOTICE when it doesn't — restoring loud-warn
+ * the active slot set when the requested [since, until) range overlaps the
+ * logical raw-retention boundary, and an empty array with a NOTICE when it
+ * doesn't — restoring loud-warn
  * symmetry with the relative readers (#69). Without this, _at readers silently
  * returned 0 rows on absurd inputs (year 1000, year 3000) thanks to
  * ts_from_timestamptz()'s int4 clamp (#63), which was a UX regression vs the
  * interval path.
  *
  * Out-of-retention conditions (each emits the NOTICE and returns {}):
- *   * until   <= now() - raw_retention (range entirely too old)
+ *   * until   <= raw_retention_start (range entirely too old)
  *   * since >  now()                  (range entirely in the future)
  *
  * Importantly, an empty range (since >= until) inside the retained window
@@ -2720,18 +2720,28 @@ declare
   v_current_slot    smallint;
   v_num_partitions  smallint;
   v_rotation_period interval;
+  v_rotated_at      timestamptz;
   v_now             timestamptz := now();
   v_raw_retention   interval;
   v_retention_start timestamptz;
   v_already         text;
 begin
-  select current_slot, num_partitions, rotation_period
-    into v_current_slot, v_num_partitions, v_rotation_period
+  select current_slot, num_partitions, rotation_period, rotated_at
+    into v_current_slot, v_num_partitions, v_rotation_period, v_rotated_at
   from ash.config
   where singleton;
 
   v_raw_retention := (v_num_partitions - 2) * v_rotation_period;
-  v_retention_start := v_now - v_raw_retention;
+  /*
+   * Use the same stable, minute-aligned planning boundary as status() and the
+   * tie guard. With no samples, keep the historical range-NOTICE behavior by
+   * deriving the same boundary directly from the ring geometry.
+  */
+  v_retention_start := ash.ts_to_timestamptz(
+    ash.ts_from_timestamptz(
+      date_trunc('minute', v_rotated_at - v_raw_retention)
+    )
+  );
 
   /*
    * Out-of-retention check. Skip when either bound is null (the reader's
@@ -2744,7 +2754,7 @@ begin
     if v_already is null or v_already = '' then
       raise notice
         'requested range [%, %) lies outside the retained window '
-        '(now - raw_retention .. now, i.e. [%, %)); only % completed '
+        '(raw_retention_start .. now, i.e. [%, %)); only % completed '
         'partition(s) plus the current partial partition are retained. '
         'Adjust the range, increase rotation_period, or rebuild with more '
         'partitions.',
@@ -3798,11 +3808,13 @@ $$;
  */
 
 /*
- * Retention-start helpers: earliest timestamp each source can answer. Null
- * when the source holds no data. Used by source auto-selection and by the
- * raw-drill retention-boundary exception.
+ * Physical raw coverage and logical raw retention are deliberately separate.
+ * The oldest sample is exact retained evidence (and follows the active slot
+ * set fixed by #128). The retention start is the minute-aligned ring boundary:
+ * it advances with rotation/rebuild, not with the timestamp of the first sample
+ * after install or an outage. Null when raw holds no data.
  */
-create or replace function ash._raw_retention_start()
+create or replace function ash._raw_oldest_sample()
 returns timestamptz
 language sql
 stable
@@ -3811,6 +3823,32 @@ as $$
   select ash.ts_to_timestamptz(min(sample_ts))
   from ash.sample
   where slot = any(ash._active_slots())
+$$;
+
+create or replace function ash._raw_retention_start()
+returns timestamptz
+language sql
+stable
+set search_path = pg_catalog, ash
+as $$
+  with raw_coverage as (
+    select ash._raw_oldest_sample() as oldest_sample
+  )
+  select case
+    when raw_coverage.oldest_sample is null then null
+    else ash.ts_to_timestamptz(
+      ash.ts_from_timestamptz(
+        date_trunc(
+          'minute',
+          config_row.rotated_at
+          - (config_row.num_partitions - 2) * config_row.rotation_period
+        )
+      )
+    )
+  end
+  from ash.config as config_row
+  cross join raw_coverage
+  where config_row.singleton
 $$;
 
 create or replace function ash._rollup_1m_retention_start()
@@ -3846,16 +3884,23 @@ language sql
 stable
 set search_path = pg_catalog, ash
 as $$
+  with raw_coverage as (
+    select ash._raw_oldest_sample() as oldest_sample
+  )
   select case
-    when ash._raw_retention_start() is not null
-         and since >= ash._raw_retention_start() then 'raw'
+    when raw_coverage.oldest_sample is not null
+         and ash.ts_from_timestamptz(date_trunc('minute', since))
+             >= ash.ts_from_timestamptz(
+                  date_trunc('minute', raw_coverage.oldest_sample)
+                ) then 'raw'
     when ash._rollup_1m_retention_start() is not null
          and since >= ash._rollup_1m_retention_start() then 'rollup_1m'
     when ash._rollup_1h_retention_start() is not null then 'rollup_1h'
     when ash._rollup_1m_retention_start() is not null then 'rollup_1m'
-    when ash._raw_retention_start() is not null then 'raw'
+    when raw_coverage.oldest_sample is not null then 'raw'
     else 'none'
   end
+  from raw_coverage
 $$;
 
 /*
@@ -3913,13 +3958,22 @@ stable
 set search_path = pg_catalog, ash
 as $$
 declare
-  v_next_boundary timestamptz;
+  v_raw_start_ts int4;
+  v_start_ts int4 := (start_ts / 60) * 60;
+  v_end_ts int4 := (end_ts / 60) * 60;
+  v_raw_boundary timestamptz;
 begin
-  if raw_start is not null
-     and ash.ts_to_timestamptz(start_ts) >= raw_start then
+  if raw_start is not null then
+    v_raw_start_ts := ash.ts_from_timestamptz(
+      date_trunc('minute', raw_start)
+    );
+    v_raw_boundary := ash.ts_to_timestamptz(v_raw_start_ts);
+  end if;
+
+  if v_raw_start_ts is not null and v_start_ts >= v_raw_start_ts then
     return;  -- raw covers the window start: the tie drill can proceed
   end if;
-  if raw_start is null or ash.ts_to_timestamptz(end_ts) <= raw_start then
+  if v_raw_start_ts is null or v_end_ts <= v_raw_start_ts then
     raise exception
       'pg_ash: this drill needs the raw wait<->query tie, but the requested '
       'window (% to %) is entirely outside raw retention (%). The tie is '
@@ -3928,25 +3982,22 @@ begin
       'query_id (e.g. ash.aas(), ash.timeline(), ash.top() with one of the '
       'two).',
       since,
-      ash.ts_to_timestamptz(end_ts),
-      coalesce('raw retention starts at ' || raw_start, 'no raw samples exist');
+      ash.ts_to_timestamptz(v_end_ts),
+      coalesce(
+        'raw retention starts at ' || v_raw_boundary,
+        'no raw samples exist'
+      );
   end if;
   /*
-   * The reader floors since to the minute BEFORE this guard runs, so a user
-   * who narrows to exactly raw_start (when it is mid-minute) re-floors below
-   * it and loops on this same error. Advise the first minute-aligned instant
-   * at or after raw retention start — a value that actually clears the guard.
+   * Compare and report the same minute-aligned boundary the reader uses. The
+   * floor preserves a partial first minute; rounding up would discard it.
    */
-  v_next_boundary := case
-    when date_trunc('minute', raw_start) = raw_start then raw_start
-    else date_trunc('minute', raw_start) + interval '1 minute'
-  end;
   raise exception
     'pg_ash: this drill needs raw samples; raw retention starts at % but the '
     'requested window starts at %. Narrow the window to start at or after % '
     '(the window end is still inside raw retention), or drill without the '
     'query/event tie.',
-    raw_start, since, v_next_boundary;
+    v_raw_boundary, since, v_raw_boundary;
 end;
 $$;
 
@@ -5498,16 +5549,23 @@ begin
    * starts right at the raw-retention boundary, but the worst/percentile
    * minutes themselves are usually well inside raw retention — dropping the
    * attribution wholesale threw away exactly the answer the report exists to
-   * give. v_raw_min is the first minute raw samples can attribute; each
+   * give. v_raw_min is based on the physical oldest sample (not the logical
+   * planning boundary) and is the first minute raw samples can attribute; each
    * extreme-minute set below is filtered to covered minutes and attributed
    * when any survive.
    * (greatest/least in ts_from_timestamptz ignore NULLs, so a missing raw
-   * retention start must be short-circuited here, not passed through.)
+   * oldest sample must be short-circuited here, not passed through.)
    */
-  v_raw_min := case
-    when ash._raw_retention_start() is null then null
-    else (ash.ts_from_timestamptz(ash._raw_retention_start()) / 60) * 60
-  end;
+  select case
+    when raw_coverage.oldest_sample is null then null
+    else ash.ts_from_timestamptz(
+      date_trunc('minute', raw_coverage.oldest_sample)
+    )
+  end
+  into v_raw_min
+  from (
+    select ash._raw_oldest_sample() as oldest_sample
+  ) as raw_coverage;
 
   -- Per-class metrics over the zero-filled per-minute AAS series.
   for v_class in
@@ -5777,8 +5835,8 @@ begin
    * Additive metadata (frozen contract: keys only ever added): the window and
    * coverage actually used, so a consumer can reconcile this payload against
    * ash.aas()/ash.top() for the same window and detect degraded resolution
-   * (minutes_with_data < minutes_expected) or a reduced attribution window
-   * (raw_retention_start inside the window).
+   * (minutes_with_data < minutes_expected). raw_retention_start is the logical
+   * planning boundary; top_queryids_available reports actual attribution.
    */
   v_result := v_result || jsonb_build_object(
     'top_queryids_available',

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -2734,12 +2734,17 @@ begin
   v_raw_retention := (v_num_partitions - 2) * v_rotation_period;
   /*
    * Use the same stable, minute-aligned planning boundary as status() and the
-   * tie guard. With no samples, keep the historical range-NOTICE behavior by
-   * deriving the same boundary directly from the ring geometry.
-  */
-  v_retention_start := ash.ts_to_timestamptz(
-    ash.ts_from_timestamptz(
-      date_trunc('minute', v_rotated_at - v_raw_retention)
+   * tie guard. Delayed rotation can leave readable evidence older than the
+   * nominal ring horizon, so never reject it: the usable boundary is the older
+   * of physical coverage and configured capacity. With no samples, retain the
+   * geometry fallback solely for the historical out-of-range NOTICE.
+   */
+  v_retention_start := coalesce(
+    ash._raw_retention_start(),
+    ash.ts_to_timestamptz(
+      ash.ts_from_timestamptz(
+        date_trunc('minute', v_rotated_at - v_raw_retention)
+      )
     )
   );
 
@@ -2935,9 +2940,10 @@ begin
   end if;
 
   /*
-   * Retention-start boundaries (2.0): the earliest timestamp each source can
-   * answer, so a caller can plan a window before querying and knows where the
-   * raw wait<->query drill stops. NULL when the source holds no data yet.
+   * Retention-start boundaries (2.0): raw_retention_start is the reusable,
+   * minute-aligned loss boundary (the older of ring capacity and retained
+   * evidence); rollup starts are their physical oldest rows. Callers can plan
+   * windows before querying. NULL when the source holds no data yet.
    */
   metric := 'raw_retention_start';
   value := coalesce(ash._raw_retention_start()::text, 'no samples'); return next;
@@ -3810,9 +3816,10 @@ $$;
 /*
  * Physical raw coverage and logical raw retention are deliberately separate.
  * The oldest sample is exact retained evidence (and follows the active slot
- * set fixed by #128). The retention start is the minute-aligned ring boundary:
- * it advances with rotation/rebuild, not with the timestamp of the first sample
- * after install or an outage. Null when raw holds no data.
+ * set fixed by #128). The retention start is a usable minute boundary: never
+ * newer than the configured ring horizon or than older evidence preserved by
+ * a delayed rotation. It therefore does not jump to the first post-install or
+ * post-outage sample. Null when raw holds no data.
  */
 create or replace function ash._raw_oldest_sample()
 returns timestamptz
@@ -3836,12 +3843,15 @@ as $$
   )
   select case
     when raw_coverage.oldest_sample is null then null
-    else ash.ts_to_timestamptz(
-      ash.ts_from_timestamptz(
-        date_trunc(
-          'minute',
-          config_row.rotated_at
-          - (config_row.num_partitions - 2) * config_row.rotation_period
+    else least(
+      date_trunc('minute', raw_coverage.oldest_sample),
+      ash.ts_to_timestamptz(
+        ash.ts_from_timestamptz(
+          date_trunc(
+            'minute',
+            config_row.rotated_at
+            - (config_row.num_partitions - 2) * config_row.rotation_period
+          )
         )
       )
     )
@@ -6198,7 +6208,7 @@ comment on function ash.samples(timestamptz, timestamptz, int, text, text, bigin
 $$Decoded raw sample rows, newest first (US-5 raw evidence) over [since, until) (default last 1 hour), up to n. Uniform filters wait_event_type/wait_event/query_id/database. Columns (sample_time, database_name, active_backends, wait_event, query_id, query_text). query_text needs pg_stat_statements AND that the caller holds pg_read_all_stats (e.g. via pg_monitor membership); it is null otherwise — a plain ash.grant_reader() role without pg_read_all_stats sees null even with pgss installed, because pgss restricts query text to the owning role. When pgss lives outside public, the caller also needs USAGE on that schema, else query_text is null. Reads ash.sample directly (raw retention only).$$;
 
 comment on function ash.report(timestamptz, timestamptz, int, int) is
-$$Machine-readable load report as one jsonb (US-8) for [since, until) (default last 1 day). Per wait class (cpu=CPU*, io=IO, ipc=IPC, lock=Lock, lwlock=LWLock; total = their sum) at 1-minute resolution: aas_avg / aas_worst1m / aas_p99 / aas_p999. Plus top_events_{worst1m,p99,p999} (keys io/ipc/lock/lwlock, entries "event(aas)") and top_queryids_{worst1m,p99,p999} (keys total+the four non-cpu classes, entries "queryid(aas)"). Query attribution is decided per extreme minute: a top_queryids key appears when raw samples still cover that class's worst/percentile minute(s), even if the window start predates raw retention (percentile sets attribute over their raw-covered minutes). top_queryids_available (boolean, always present) says whether any attribution was possible — branch on it, not on key absence. coverage {from, to, source, minutes_expected, minutes_with_data, raw_retention_start} reconciles the payload against ash.aas()/ash.top() and flags degraded resolution. vcpus (echoed, never used) and cluster_name are pass-throughs. Returns null when the window has no coverage; never raises. Payload contract is frozen per 2.0 minor line (keys only added, never renamed/removed); scoring/normalization is the consumer's job.$$;
+$$Machine-readable load report as one jsonb (US-8) for [since, until) (default last 1 day). Per wait class (cpu=CPU*, io=IO, ipc=IPC, lock=Lock, lwlock=LWLock; total = their sum) at 1-minute resolution: aas_avg / aas_worst1m / aas_p99 / aas_p999. Plus top_events_{worst1m,p99,p999} (keys io/ipc/lock/lwlock, entries "event(aas)") and top_queryids_{worst1m,p99,p999} (keys total+the four non-cpu classes, entries "queryid(aas)"). Query attribution is decided per extreme minute: a top_queryids key appears when raw samples still cover that class's worst/percentile minute(s), even if the window start predates raw retention (percentile sets attribute over their raw-covered minutes). top_queryids_available (boolean, always present) says whether any attribution was possible — branch on it, not on key absence. coverage {from, to, source, minutes_expected, minutes_with_data, raw_retention_start} reconciles the payload against ash.aas()/ash.top() and flags degraded resolution; raw_retention_start is the logical planning/loss boundary, not the physical query-attribution cutoff. vcpus (echoed, never used) and cluster_name are pass-throughs. Returns null when the window has no coverage; never raises. Payload contract is frozen per 2.0 minor line (keys only added, never renamed/removed); scoring/normalization is the consumer's job.$$;
 
 comment on function ash.chart(timestamptz, timestamptz, interval, int, int, boolean) is
 $$Human render helper: stacked ASCII per-bucket AAS chart over [since, until) (default last 1 hour). Series/legend = the window-wide top n wait events PLUS any event that is top-1 in at least one bucket (so a single-bucket spike culprit is always visible), plus Other. bucket => null auto-selects grain by span; buckets are calendar-aligned like ash.timeline(). Presentation-only (columns bucket_start, aas, detail, chart); for typed data use ash.timeline(). Enable ANSI color with color => true or "set ash.color = on".$$;
@@ -6218,7 +6228,7 @@ $$pg_ash: Active Session History for Postgres (pure SQL, no extension). Reader e
  * reader-vs-ops split is legible from \df+ alone.
  */
 comment on function ash.status() is
-$$Installation health snapshot (readable by monitoring roles): sampling state and interval, the day-granular rotation_period contract (whole days, minimum 1 day), pg_cron job status, partition slots and sizes, rollup progress/lag, retention starts (raw_retention_start, rollup_1m_retention_start, rollup_1h_retention_start — use these to plan reader windows), error counters (consecutive_rotate_failures, insert_errors, register_wait_cap_hits, missed/skipped samples), and version. Returns (metric, value) rows. Start here when pg_ash misbehaves; readers are documented on the schema: obj_description('ash'::regnamespace).$$;
+$$Installation health snapshot (readable by monitoring roles): sampling state and interval, the day-granular rotation_period contract (whole days, minimum 1 day), pg_cron job status, partition slots and sizes, rollup progress/lag, retention starts (raw_retention_start is a reusable minute-aligned planning/loss boundary; rollup_1m_retention_start and rollup_1h_retention_start are physical starts), error counters (consecutive_rotate_failures, insert_errors, register_wait_cap_hits, missed/skipped samples), and version. Returns (metric, value) rows. Start here when pg_ash misbehaves; readers are documented on the schema: obj_description('ash'::regnamespace).$$;
 
 comment on function ash.start(interval) is
 $$Admin: start sampling — schedules take_sample() at the given interval (every => ..., default 1 second; accepts 1–59 whole seconds, whole minutes, or whole hours up to 23h) plus rollup_minute()/rollup_hour()/rollup_cleanup() and a daily rotation check via pg_cron when available. rotation_period accepts whole days only (minimum 1 day); early daily checks skip until it is due. Without pg_cron, start enables sampling and prints the jobs to schedule externally. Idempotent. Inverse: ash.stop(). Check with ash.status().$$;


### PR DESCRIPTION
## Summary

- separate exact physical raw coverage (`ash._raw_oldest_sample()`) from the reusable minute-aligned planning/loss boundary (`ash._raw_retention_start()`)
- floor both sides of the wait/query tie guard and print the same down-rounded remediation boundary it accepts
- keep source selection and report query attribution tied to physical coverage while status/report coverage expose the logical boundary
- preserve still-readable evidence after delayed rotation by choosing the older of ring geometry and the physical oldest minute
- add three independent exact B3 regressions, including the README query copied verbatim after a no-argument `ash.start()` call
- clarify the logical-vs-physical report and status contracts

## Root cause

`ash._raw_retention_start()` exposed the exact first sample second. Readers query minute buckets, so status could not be fed back into `since`, and the guard rounded its advice up past the only partial minute. The same physical timestamp was also being used for source attribution and public planning even though those are different contracts.

## Verification

- all three exact failures reproduced independently on current `main` (`1fcf9e7`): README drill errors, status self-feed errors, and advice rounds up to an empty result
- PostgreSQL 17.9 fresh install and full discovered upgrade chain: pass
- exact README/default-start/status/advice B3 step: pass
- report attribution, retention split, delayed-rotation range guard, compare, and chart step: pass
- behavioral reader suite through the changed retention section: pass
- #185 cleanup/rotation regression: pass
- `grant_reader` dynamic helper closure: 41/41 current non-admin functions after #181, including direct EXECUTE/call of `ash._raw_oldest_sample()`; rebuild preserves it and revoke removes it
- workflow YAML parse and `git diff --check`: pass
- Codex review plus independent adversarial verification: approved with no blockers

## Rebase resolution

Rebased onto current `main` (`1fcf9e7`). The `ash.status()` catalog-comment conflict preserves both #185's day-granular rotation / `consecutive_rotate_failures` contract and this PR's logical-vs-physical retention contract. Two test fixtures that still used a now-invalid 30-minute `rotation_period` were converted to the deliberate one-day contract and their entirely-past/partial/delayed-evidence ranges were scaled without weakening any assertion.

## Merge sequencing

Land this retention-boundary change before rebasing sibling PRs #182 and #180. PR #181's dynamic non-admin helper enumeration is retained and verified for the new helper. Expect documentation conflicts in `blueprints/AAS_API.md` and `blueprints/AAS_EXAMPLES.md` when #182 and #186 are rebased.

Fixes #163