### PR TITLE
release: keep compacted query attribution honest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4203,6 +4203,693 @@ jobs:
           end $$;
           EOF
 
+      - name: "Issue #136: compacted query attribution stays honest"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          -- Minute threshold compaction: the NULL residual must reconcile the
+          -- query breakdown and compete for the top-N cut.
+          do $$
+          declare
+            v_ts int4 := (
+              ash.ts_from_timestamptz(
+                date_trunc('minute', now() - interval '20 minutes')
+              ) / 60
+            ) * 60;
+            v_from timestamptz;
+            v_to timestamptz;
+            v_datid oid;
+            v_wait_id smallint;
+            v_q1 int4;
+            v_q2 int4;
+            v_q3 int4;
+            v_result int;
+            v_aas record;
+            v_named record;
+            v_residual record;
+            v_top1 record;
+            v_compare_residual record;
+            v_compare_residual_rows int;
+            v_summary_value text;
+            v_rows int;
+            v_total numeric;
+            v_pct numeric;
+          begin
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.query_map_0, ash.query_map_1, ash.query_map_2
+              restart identity;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set current_slot = 0,
+                sample_interval = interval '1 second',
+                rollup_min_backend_seconds = 3,
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+
+            select oid into v_datid
+            from pg_database
+            where datname = current_database();
+            select ash._register_wait('active', 'CPU*', 'CPU*')
+              into v_wait_id;
+
+            insert into ash.query_map_0 (query_id)
+            values (111), (222), (333);
+            select id into v_q1 from ash.query_map_0 where query_id = 111;
+            select id into v_q2 from ash.query_map_0 where query_id = 222;
+            select id into v_q3 from ash.query_map_0 where query_id = 333;
+
+            -- One packed sample: 26 backend appearances. Only q111 reaches
+            -- the minute threshold; q222/q333 and the 20 uncaptured
+            -- appearances must survive as one NULL residual.
+            insert into ash.sample (
+              sample_ts, datid, active_count, data, slot
+            ) values (
+              v_ts,
+              v_datid,
+              26,
+              array[-v_wait_id, 26, v_q1, v_q1, v_q1, v_q2, v_q2, v_q3]
+                || array_fill(0, array[20]),
+              0
+            );
+
+            select ash.rollup_minute() into v_result;
+            assert v_result = 1,
+              'rollup_minute should create exactly one database row, got '
+              || v_result;
+            assert (
+              select query_counts
+              from ash.rollup_1m
+              where ts = v_ts
+            ) = array[111, 3]::int8[],
+              'fixture must exercise compacted query_counts';
+
+            v_from := ash.ts_to_timestamptz(v_ts);
+            v_to := ash.ts_to_timestamptz(v_ts + 60);
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+
+            select * into v_aas from ash.aas(v_from, v_to);
+            assert v_aas.source = 'rollup_1m'
+                   and v_aas.backend_seconds = 26.00,
+              format(
+                'fixture AAS mismatch: source=%s backend_seconds=%s',
+                v_aas.source,
+                v_aas.backend_seconds
+              );
+
+            select * into v_named
+            from ash.top('query_id', v_from, v_to, n => 100)
+            where key = '111';
+            select * into v_residual
+            from ash.top('query_id', v_from, v_to, n => 100)
+            where key is null;
+            select count(*), sum(backend_seconds), sum(pct)
+              into v_rows, v_total, v_pct
+            from ash.top('query_id', v_from, v_to, n => 100);
+
+            assert v_named.backend_seconds = 3.00
+                   and v_named.pct = 11.54,
+              format(
+                'named compacted query mismatch: seconds=%s pct=%s',
+                v_named.backend_seconds,
+                v_named.pct
+              );
+            assert v_residual.backend_seconds = 23.00
+                   and v_residual.pct = 88.46,
+              format(
+                'NULL residual mismatch: seconds=%s pct=%s',
+                v_residual.backend_seconds,
+                v_residual.pct
+              );
+            assert v_rows = 2
+                   and v_total = v_aas.backend_seconds
+                   and v_pct = 100.00,
+              format(
+                'query breakdown does not reconcile: rows=%s total=%s pct=%s',
+                v_rows,
+                v_total,
+                v_pct
+              );
+
+            select * into v_top1
+            from ash.top('query_id', v_from, v_to, n => 1);
+            assert v_top1.key is null
+                   and v_top1.source = 'rollup_1m'
+                   and v_top1.backend_seconds = 23.00
+                   and v_top1.pct = 88.46,
+              format(
+                'residual top-N mismatch: key=%s source=%s seconds=%s pct=%s',
+                coalesce(v_top1.key, '<NULL>'),
+                v_top1.source,
+                v_top1.backend_seconds,
+                v_top1.pct
+              );
+
+            select count(*), max(avg_delta)
+              into v_compare_residual_rows, v_pct
+            from ash.compare(
+              v_from,
+              v_to,
+              v_from,
+              v_to,
+              dimension => 'query_id',
+              n => 100
+            )
+            where key is null;
+            select * into v_compare_residual
+            from ash.compare(
+              v_from,
+              v_to,
+              v_from,
+              v_to,
+              dimension => 'query_id',
+              n => 100
+            )
+            where key is null;
+            assert v_compare_residual_rows = 1
+                   and v_pct = 0.00
+                   and v_compare_residual.source_1 = 'rollup_1m'
+                   and v_compare_residual.source_2 = 'rollup_1m'
+                   and v_compare_residual.pct_1 = 88.46
+                   and v_compare_residual.pct_2 = 88.46,
+              format(
+                'compare NULL residual mismatch: rows=%s source=%s/%s delta=%s pct=%s/%s',
+                v_compare_residual_rows,
+                v_compare_residual.source_1,
+                v_compare_residual.source_2,
+                v_pct,
+                v_compare_residual.pct_1,
+                v_compare_residual.pct_2
+              );
+
+            select value into v_summary_value
+            from ash.summary(v_from, v_to)
+            where metric = 'top_query_1';
+            assert v_summary_value
+                     = '(other / unattributed) (avg_aas 0.38, 88.46%)',
+              'summary residual label/value mismatch: '
+              || coalesce(v_summary_value, '<NULL>');
+
+            raise notice
+              'issue #136 rollup_1m residual GREEN: named=3.00/11.54 residual=23.00/88.46 top1=NULL compare=NULL/0.00';
+          end $$;
+
+          -- Hour top-set compaction: each input minute has at most 100 query
+          -- IDs, but rollup_hour() must compact their 200-ID union to 100.
+          -- The missing 100 seconds are therefore purely the hourly top-set
+          -- residual, not minute-threshold or uncaptured attribution.
+          do $$
+          declare
+            v_hour timestamptz := date_trunc('hour', now()) - interval '2 hours';
+            v_hour_ts int4;
+            v_wait_id smallint;
+            v_result int;
+            v_stored_rows int;
+            v_stored_query_total numeric;
+            v_stored_wait_total numeric;
+            v_rows int;
+            v_total numeric;
+            v_pct numeric;
+            v_residual record;
+            v_named record;
+          begin
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set sample_interval = interval '1 second',
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+            select ash._register_wait('active', 'CPU*', 'CPU*')
+              into v_wait_id;
+            v_hour_ts := ash.ts_from_timestamptz(v_hour);
+
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            )
+            select
+              v_hour_ts,
+              0::oid,
+              60,
+              300,
+              array[v_wait_id, 300]::int4[],
+              (
+                select array_agg(pair.elem order by query_row.qid, pair.ord)
+                from generate_series(1, 100) as query_row(qid)
+                cross join lateral (
+                  values
+                    (1, query_row.qid::int8),
+                    (2, 3::int8)
+                ) as pair(ord, elem)
+              )::int8[]
+            union all
+            select
+              v_hour_ts + 60,
+              0::oid,
+              60,
+              100,
+              array[v_wait_id, 100]::int4[],
+              (
+                select array_agg(pair.elem order by query_row.qid, pair.ord)
+                from generate_series(1001, 1100) as query_row(qid)
+                cross join lateral (
+                  values
+                    (1, query_row.qid::int8),
+                    (2, 1::int8)
+                ) as pair(ord, elem)
+              )::int8[];
+
+            update ash.config
+            set last_rollup_1m_ts = v_hour_ts + 3600,
+                last_rollup_1h_ts = v_hour_ts
+            where singleton;
+            select ash.rollup_hour() into v_result;
+            assert v_result = 1,
+              'rollup_hour should create exactly one database row, got '
+              || v_result;
+
+            select
+              cardinality(query_counts) / 2,
+              (
+                select sum(query_counts[pos + 1])
+                from generate_subscripts(query_counts, 1) as pos
+                where pos % 2 = 1
+              ),
+              (
+                select sum(wait_counts[pos + 1])
+                from generate_subscripts(wait_counts, 1) as pos
+                where pos % 2 = 1
+              )
+              into
+                v_stored_rows,
+                v_stored_query_total,
+                v_stored_wait_total
+            from ash.rollup_1h
+            where ts = v_hour_ts
+              and datid = 0::oid;
+            assert v_stored_rows = 100
+                   and v_stored_query_total = 300
+                   and v_stored_wait_total = 400,
+              format(
+                'hourly fixture mismatch: rows=%s query_total=%s wait_total=%s',
+                v_stored_rows,
+                v_stored_query_total,
+                v_stored_wait_total
+              );
+
+            truncate ash.rollup_1m;
+            select count(*), sum(backend_seconds), sum(pct)
+              into v_rows, v_total, v_pct
+            from ash.top(
+              'query_id',
+              v_hour,
+              v_hour + interval '1 hour',
+              n => 101
+            );
+            select * into v_residual
+            from ash.top(
+              'query_id',
+              v_hour,
+              v_hour + interval '1 hour',
+              n => 101
+            )
+            where key is null;
+            select * into v_named
+            from ash.top(
+              'query_id',
+              v_hour,
+              v_hour + interval '1 hour',
+              n => 101
+            )
+            where key = '1';
+
+            assert v_rows = 101
+                   and v_total = 400.00
+                   and v_pct = 100.00
+                   and v_residual.source = 'rollup_1h'
+                   and v_residual.effective_bucket = interval '1 hour'
+                   and v_residual.backend_seconds = 100.00
+                   and v_residual.pct = 25.00
+                   and v_residual.peak_aas is null
+                   and v_residual.p99_aas is null
+                   and v_named.backend_seconds = 3.00
+                   and v_named.pct = 0.75,
+              format(
+                'rollup_1h top-100 mismatch: rows=%s total=%s pct=%s residual=%s/%s named=%s/%s source=%s bucket=%s peak=%s p99=%s',
+                v_rows,
+                v_total,
+                v_pct,
+                v_residual.backend_seconds,
+                v_residual.pct,
+                v_named.backend_seconds,
+                v_named.pct,
+                v_residual.source,
+                v_residual.effective_bucket,
+                v_residual.peak_aas,
+                v_residual.p99_aas
+              );
+
+            raise notice
+              'issue #136 rollup_1h top-100 GREEN: rows=101 total=400.00 pct=100.00 residual=100.00/25.00';
+          end $$;
+
+          -- Exact query filters force raw, but a young/raw-only installation
+          -- has no coarser pre-raw history to lose and must remain queryable.
+          do $$
+          declare
+            v_ts int4 := (
+              ash.ts_from_timestamptz(
+                date_trunc('minute', now() - interval '5 minutes')
+              ) / 60
+            ) * 60;
+            v_old_ts int4 := (
+              ash.ts_from_timestamptz(
+                date_trunc('minute', now() - interval '2 hours')
+              ) / 60
+            ) * 60;
+            v_hour_ts int4;
+            v_minute_idx int;
+            v_minute_counts int4[];
+            v_datid oid;
+            v_wait_id smallint;
+            v_q1 int4;
+            v_aas record;
+            v_top record;
+            v_compare record;
+            v_timeline_rows int;
+            v_timeline_data_rows int;
+            v_timeline_source_min text;
+            v_timeline_source_max text;
+            v_timeline_avg numeric;
+            v_aas_error text;
+            v_timeline_error text;
+            v_top_error text;
+            v_compare_error text;
+            v_other_db_error text;
+          begin
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.query_map_0, ash.query_map_1, ash.query_map_2
+              restart identity;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set current_slot = 0,
+                sample_interval = interval '1 second',
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+            select oid into v_datid
+            from pg_database
+            where datname = current_database();
+            select ash._register_wait('active', 'CPU*', 'CPU*')
+              into v_wait_id;
+            insert into ash.query_map_0 (query_id) values (111);
+            select id into v_q1
+            from ash.query_map_0
+            where query_id = 111;
+            insert into ash.sample (
+              sample_ts, datid, active_count, data, slot
+            ) values (
+              v_ts,
+              v_datid,
+              7,
+              array[-v_wait_id, 7] || array_fill(v_q1, array[7]),
+              0
+            );
+
+            -- A normal young install has already rolled its first completed
+            -- minute. _pick_source() names that rollup via its fallback even
+            -- though it starts alongside raw and holds no older history.
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values (
+              v_ts,
+              v_datid,
+              1,
+              7,
+              array[v_wait_id, 7]::int4[],
+              array[111, 7]::int8[]
+            );
+
+            assert now() - interval '1 hour' < ash._raw_retention_start()
+                   and ash._rollup_1m_retention_start()
+                       = date_trunc('minute', ash._raw_retention_start())
+                   and ash._pick_source(now() - interval '1 hour')
+                       = 'rollup_1m',
+              format(
+                'young-install precondition mismatch: raw_start=%s rollup_start=%s pick=%s',
+                ash._raw_retention_start(),
+                ash._rollup_1m_retention_start(),
+                ash._pick_source(now() - interval '1 hour')
+              );
+
+            begin
+              select * into v_aas from ash.aas(query_id => 111);
+            exception when others then
+              v_aas_error := sqlerrm;
+            end;
+            begin
+              select
+                count(*),
+                count(*) filter (where data_points = 1),
+                min(source),
+                max(source),
+                max(avg_aas) filter (where data_points = 1)
+                into
+                  v_timeline_rows,
+                  v_timeline_data_rows,
+                  v_timeline_source_min,
+                  v_timeline_source_max,
+                  v_timeline_avg
+              from ash.timeline(query_id => 111);
+            exception when others then
+              v_timeline_error := sqlerrm;
+            end;
+            begin
+              select * into v_top
+              from ash.top('database', query_id => 111)
+              where key = current_database();
+            exception when others then
+              v_top_error := sqlerrm;
+            end;
+            begin
+              select * into v_compare
+              from ash.compare(
+                date_trunc('minute', now() - interval '10 minutes'),
+                date_trunc('minute', now()),
+                date_trunc('minute', now() - interval '10 minutes'),
+                date_trunc('minute', now()),
+                dimension => 'database',
+                query_id => 111
+              )
+              where key = current_database();
+            exception when others then
+              v_compare_error := sqlerrm;
+            end;
+
+            assert v_aas_error is null
+                   and v_timeline_error is null
+                   and v_top_error is null
+                   and v_compare_error is null,
+              format(
+                'young-install query_id errors: aas=%s timeline=%s top=%s compare=%s',
+                coalesce(v_aas_error, '<none>'),
+                coalesce(v_timeline_error, '<none>'),
+                coalesce(v_top_error, '<none>'),
+                coalesce(v_compare_error, '<none>')
+              );
+            assert v_aas.source = 'raw'
+                   and v_aas.buckets_with_data = 1
+                   and v_aas.backend_seconds = 7.00,
+              format(
+                'young-install aas mismatch: source=%s buckets=%s seconds=%s',
+                v_aas.source,
+                v_aas.buckets_with_data,
+                v_aas.backend_seconds
+              );
+            assert v_timeline_rows = 60
+                   and v_timeline_data_rows = 1
+                   and v_timeline_source_min = 'raw'
+                   and v_timeline_source_max = 'raw'
+                   and v_timeline_avg = 0.12,
+              format(
+                'young-install timeline mismatch: rows=%s data_rows=%s source=%s..%s avg=%s',
+                v_timeline_rows,
+                v_timeline_data_rows,
+                v_timeline_source_min,
+                v_timeline_source_max,
+                v_timeline_avg
+              );
+            assert v_top.source = 'raw'
+                   and v_top.backend_seconds = 7.00
+                   and v_top.pct = 100.00,
+              format(
+                'young-install top mismatch: source=%s seconds=%s pct=%s',
+                v_top.source,
+                v_top.backend_seconds,
+                v_top.pct
+              );
+            assert v_compare.source_1 = 'raw'
+                   and v_compare.source_2 = 'raw'
+                   and v_compare.avg_delta = 0.00
+                   and v_compare.pct_1 = 100.00
+                   and v_compare.pct_2 = 100.00,
+              format(
+                'young-install compare mismatch: source=%s/%s delta=%s pct=%s/%s',
+                v_compare.source_1,
+                v_compare.source_2,
+                v_compare.avg_delta,
+                v_compare.pct_1,
+                v_compare.pct_2
+              );
+
+            -- The same rule applies to a first hourly row with valid minute
+            -- detail: its hour envelope starts earlier, but a non-NULL slot
+            -- only in raw's first retained minute proves no older coverage.
+            v_hour_ts := (v_ts / 3600) * 3600;
+            v_minute_idx := (v_ts - v_hour_ts) / 60 + 1;
+            v_minute_counts := array_fill(null::int4, array[60]);
+            v_minute_counts[v_minute_idx] := 7;
+            truncate ash.rollup_1m;
+            insert into ash.rollup_1h (
+              ts,
+              datid,
+              samples,
+              peak_backends,
+              wait_counts,
+              query_counts,
+              minute_counts
+            ) values (
+              v_hour_ts,
+              v_datid,
+              1,
+              7,
+              array[v_wait_id, 7]::int4[],
+              array[111, 7]::int8[],
+              v_minute_counts
+            );
+            assert ash._pick_source(now() - interval '1 hour') = 'rollup_1h',
+              'young-install hourly fallback precondition mismatch';
+            v_aas_error := null;
+            begin
+              select * into v_aas from ash.aas(query_id => 111);
+            exception when others then
+              v_aas_error := sqlerrm;
+            end;
+            assert v_aas_error is null
+                   and v_aas.source = 'raw'
+                   and v_aas.backend_seconds = 7.00,
+              format(
+                'same-minute hourly query mismatch: error=%s source=%s seconds=%s',
+                coalesce(v_aas_error, '<none>'),
+                v_aas.source,
+                v_aas.backend_seconds
+              );
+
+            -- Once a coarser source really is selected for pre-raw history,
+            -- an explicit query filter must reject compacted rollup data.
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m;
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values (
+              v_old_ts,
+              v_datid,
+              60,
+              2,
+              array[v_wait_id, 2]::int4[],
+              '{}'::int8[]
+            );
+
+            -- Coarser history for one database must not reject an exact query
+            -- for a different/unknown database: no matching retained row is
+            -- discarded by forcing that filtered read to raw.
+            begin
+              select * into v_aas from ash.aas(
+                ash.ts_to_timestamptz(v_old_ts),
+                ash.ts_to_timestamptz(v_old_ts + 60),
+                query_id => 222,
+                database => 'pgash_missing_database'
+              );
+            exception when others then
+              v_other_db_error := sqlerrm;
+            end;
+            assert v_other_db_error is null
+                   and v_aas.source = 'raw'
+                   and v_aas.buckets_with_data = 0
+                   and v_aas.backend_seconds = 0.00,
+              format(
+                'database-scoped exact query mismatch: error=%s source=%s buckets=%s seconds=%s',
+                coalesce(v_other_db_error, '<none>'),
+                v_aas.source,
+                v_aas.buckets_with_data,
+                v_aas.backend_seconds
+              );
+
+            begin
+              perform * from ash.aas(
+                ash.ts_to_timestamptz(v_old_ts),
+                ash.ts_to_timestamptz(v_old_ts + 60),
+                query_id => 222
+              );
+              raise exception 'ash.aas query_id filter should require raw';
+            exception when others then
+              assert sqlerrm like '%exact raw query attribution%'
+                     and sqlerrm like '%entirely outside raw retention%',
+                'ash.aas query_id retention error mismatch: ' || sqlerrm;
+            end;
+            begin
+              perform * from ash.timeline(
+                ash.ts_to_timestamptz(v_old_ts),
+                ash.ts_to_timestamptz(v_old_ts + 60),
+                query_id => 222
+              );
+              raise exception 'ash.timeline query_id filter should require raw';
+            exception when others then
+              assert sqlerrm like '%exact raw query attribution%'
+                     and sqlerrm like '%entirely outside raw retention%',
+                'ash.timeline query_id retention error mismatch: ' || sqlerrm;
+            end;
+            begin
+              perform * from ash.top(
+                'database',
+                ash.ts_to_timestamptz(v_old_ts),
+                ash.ts_to_timestamptz(v_old_ts + 60),
+                query_id => 222
+              );
+              raise exception 'ash.top query_id filter should require raw';
+            exception when others then
+              assert sqlerrm like '%exact raw query attribution%'
+                     and sqlerrm like '%entirely outside raw retention%',
+                'ash.top query_id retention error mismatch: ' || sqlerrm;
+            end;
+            begin
+              perform * from ash.compare(
+                ash.ts_to_timestamptz(v_old_ts),
+                ash.ts_to_timestamptz(v_old_ts + 60),
+                ash.ts_to_timestamptz(v_old_ts),
+                ash.ts_to_timestamptz(v_old_ts + 60),
+                dimension => 'database',
+                query_id => 222
+              );
+              raise exception 'ash.compare query_id filter should require raw';
+            exception when others then
+              assert sqlerrm like '%exact raw query attribution%'
+                     and sqlerrm like '%entirely outside raw retention%',
+                'ash.compare query_id retention error mismatch: ' || sqlerrm;
+            end;
+
+            truncate ash.rollup_1m, ash.rollup_1h;
+            truncate ash.query_map_0, ash.query_map_1, ash.query_map_2;
+            update ash.config
+            set last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+            raise notice
+              'issue #136 young-install GREEN: same-minute 1m/1h rollups ignored; aas=raw/7.00 timeline=raw/0.12 top=raw/7.00 compare=raw/raw; other-db allowed; old rollup rejected';
+          end $$;
+          EOF
+
       - name: "Test 2.0: minute-grain peak/p99 survive the rollup_1h seam"
         env:
           PGPASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4225,6 +4225,10 @@ jobs:
             v_cpu smallint; v_io smallint;
             v_h timestamptz;
             v_mc int4[];
+            v_wait_counts int4[];
+            v_minute_sum bigint;
+            v_hour_sum bigint;
+            v_null_slots bigint;
             n int; v_peak numeric; v_p99 numeric;
           begin
             truncate ash.sample_0, ash.sample_1, ash.sample_2;
@@ -4254,10 +4258,29 @@ jobs:
             perform ash.rollup_hour();
 
             -- rollup_hour() computes minute_counts exactly: 60 slots, storm at 31
-            select minute_counts into v_mc from ash.rollup_1h;
+            select minute_counts, wait_counts into v_mc, v_wait_counts
+            from ash.rollup_1h;
             assert cardinality(v_mc) = 60, 'minute_counts 60 slots, got ' || cardinality(v_mc);
             assert v_mc[31] = 678, 'storm slot 678, got ' || v_mc[31];
             assert (select count(*) from unnest(v_mc) m where m = 60) = 59, '59 quiet slots of 60';
+            select
+              coalesce(sum(minute_count), 0),
+              count(*) filter (where minute_count is null)
+              into v_minute_sum, v_null_slots
+            from unnest(v_mc) as minute_count;
+            select coalesce(sum(v_wait_counts[pos + 1]), 0)
+              into v_hour_sum
+            from generate_subscripts(v_wait_counts, 1) as pos
+            where pos % 2 = 1;
+            assert v_minute_sum = 4218
+               and v_hour_sum = 4218
+               and v_null_slots = 0,
+              format(
+                'rollup_hour invariant minute_sum=%s hour_sum=%s null_slots=%s',
+                v_minute_sum,
+                v_hour_sum,
+                v_null_slots
+              );
 
             -- seam consistency: short window (rollup_1m) vs long window (rollup_1h)
             -- containing the same spike report IDENTICAL minute-grain peak and p99
@@ -4330,6 +4353,511 @@ jobs:
               where singleton;
 
             raise notice 'rollup_1h seam minute-grain peak/p99 PASSED';
+          end $$;
+          EOF
+
+      - name: "Test 2.0: rollup_1h grain honesty and partial-hour degradation (#161, #130)"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          -- B1a: top() must not present an hour average as a minute peak.
+          do $$
+          declare
+            v_cpu smallint;
+            v_io smallint;
+            v_h timestamptz := date_trunc('hour', now()) - interval '45 days';
+            v_aas record;
+            v_wait record;
+            v_database record;
+          begin
+            truncate ash.sample;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set sample_interval = interval '1 second',
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+            select ash._register_wait('active', 'IO', 'DataFileRead') into v_io;
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            ) values (
+              ash.ts_from_timestamptz(v_h),
+              0::oid,
+              3600,
+              10,
+              array[v_io, 2760, v_cpu, 1380]::int4[],
+              '{}'::int8[],
+              array[600]::int4[] || array_fill(60, array[59])
+            );
+
+            select * into v_aas
+            from ash.aas(v_h, v_h + interval '1 hour');
+            select * into v_wait
+            from ash.top(
+              'wait_event',
+              v_h,
+              v_h + interval '1 hour',
+              n => 10,
+              bucket => interval '1 minute'
+            )
+            where key = 'IO:DataFileRead';
+            select * into v_database
+            from ash.top(
+              'database',
+              v_h,
+              v_h + interval '1 hour',
+              n => 10,
+              bucket => interval '1 minute'
+            );
+
+            assert v_aas.avg_aas = 1.15
+               and v_aas.peak_aas = 10.00
+               and v_aas.p99_aas = 4.69
+               and v_wait.avg_aas = 0.77
+               and v_wait.peak_aas is null
+               and v_wait.p99_aas is null
+               and v_database.avg_aas = 1.15
+               and v_database.peak_aas = 10.00
+               and v_database.p99_aas = 4.69,
+              format(
+                'B1a aas avg=%s peak=%s p99=%s; top wait avg=%s peak=%s p99=%s; database avg=%s peak=%s p99=%s',
+                v_aas.avg_aas,
+                v_aas.peak_aas,
+                v_aas.p99_aas,
+                v_wait.avg_aas,
+                v_wait.peak_aas,
+                v_wait.p99_aas,
+                v_database.avg_aas,
+                v_database.peak_aas,
+                v_database.p99_aas
+              );
+          end $$;
+
+          -- B1b: adding a filter must disclose the surviving hour grain by
+          -- keeping exact totals while NULLing unsupported minute extremes.
+          do $$
+          declare
+            v_cpu smallint;
+            v_io smallint;
+            v_h timestamptz := date_trunc('hour', now()) - interval '45 days';
+            v_all record;
+            v_io_minute record;
+            v_io_hour record;
+          begin
+            truncate ash.sample;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set sample_interval = interval '1 second',
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+            select ash._register_wait('active', 'IO', 'DataFileRead') into v_io;
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            ) values (
+              ash.ts_from_timestamptz(v_h),
+              0::oid,
+              3600,
+              21,
+              array[v_io, 8280, v_cpu, 60]::int4[],
+              '{}'::int8[],
+              array[1260]::int4[] || array_fill(120, array[59])
+            );
+
+            select * into v_all
+            from ash.aas(v_h, v_h + interval '1 hour');
+            select * into v_io_minute
+            from ash.aas(
+              v_h,
+              v_h + interval '1 hour',
+              wait_event_type => 'IO',
+              bucket => interval '1 minute'
+            );
+            select * into v_io_hour
+            from ash.aas(
+              v_h,
+              v_h + interval '1 hour',
+              wait_event_type => 'IO',
+              bucket => interval '1 hour'
+            );
+
+            assert v_all.avg_aas = 2.32
+               and v_all.peak_aas = 21.00
+               and v_all.p99_aas = 9.79
+               and v_io_minute.avg_aas = 2.30
+               and v_io_minute.backend_seconds = 8280.00
+               and v_io_minute.peak_aas is null
+               and v_io_minute.p99_aas is null
+               and v_io_hour.peak_aas = 2.30
+               and v_io_hour.p99_aas = 2.30,
+              format(
+                'B1b unfiltered avg=%s peak=%s p99=%s; IO minute avg=%s seconds=%s peak=%s p99=%s; IO hour peak=%s p99=%s',
+                v_all.avg_aas,
+                v_all.peak_aas,
+                v_all.p99_aas,
+                v_io_minute.avg_aas,
+                v_io_minute.backend_seconds,
+                v_io_minute.peak_aas,
+                v_io_minute.p99_aas,
+                v_io_hour.peak_aas,
+                v_io_hour.p99_aas
+              );
+          end $$;
+
+          -- B1c: byte-identical windows across retention tiers keep their
+          -- honest averages. Overall minute-detail extremes remain comparable;
+          -- dimensional hour-vs-minute extremes are suppressed as a pair.
+          do $$
+          declare
+            v_io smallint;
+            v_old_h timestamptz := date_trunc('hour', now()) - interval '45 days';
+            v_new_h timestamptz := date_trunc('hour', now()) - interval '2 hours';
+            v_overall record;
+            v_dimension record;
+          begin
+            truncate ash.sample;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set sample_interval = interval '1 second',
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+
+            select ash._register_wait('active', 'IO', 'DataFileRead') into v_io;
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            ) values (
+              ash.ts_from_timestamptz(v_old_h),
+              0::oid,
+              3600,
+              600,
+              array[v_io, 39540]::int4[],
+              '{}'::int8[],
+              array[36000]::int4[] || array_fill(60, array[59])
+            );
+
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            )
+            select
+              ash.ts_from_timestamptz(
+                v_new_h + minute_idx * interval '1 minute'
+              ),
+              0::oid,
+              60,
+              case when minute_idx = 0 then 600 else 1 end,
+              array[
+                v_io,
+                case when minute_idx = 0 then 36000 else 60 end
+              ]::int4[],
+              '{}'::int8[]
+            from generate_series(0, 59) as minute_idx;
+
+            select * into v_overall
+            from ash.compare(
+              v_old_h,
+              v_old_h + interval '1 hour',
+              v_new_h,
+              v_new_h + interval '1 hour'
+            );
+            select * into v_dimension
+            from ash.compare(
+              v_old_h,
+              v_old_h + interval '1 hour',
+              v_new_h,
+              v_new_h + interval '1 hour',
+              dimension => 'wait_event'
+            );
+
+            assert to_jsonb(v_overall) ->> 'source_1' = 'rollup_1h'
+               and to_jsonb(v_overall) ->> 'source_2' = 'rollup_1m'
+               and v_overall.avg_aas_1 = 10.98
+               and v_overall.avg_aas_2 = 10.98
+               and v_overall.avg_delta = 0.00
+               and v_overall.peak_aas_1 = 600.00
+               and v_overall.peak_aas_2 = 600.00
+               and v_overall.p99_aas_1 = 246.59
+               and v_overall.p99_aas_2 = 246.59
+               and to_jsonb(v_dimension) ->> 'source_1' = 'rollup_1h'
+               and to_jsonb(v_dimension) ->> 'source_2' = 'rollup_1m'
+               and v_dimension.avg_aas_1 = 10.98
+               and v_dimension.avg_aas_2 = 10.98
+               and v_dimension.avg_delta = 0.00
+               and v_dimension.peak_aas_1 is null
+               and v_dimension.peak_aas_2 is null
+               and v_dimension.p99_aas_1 is null
+               and v_dimension.p99_aas_2 is null,
+              format(
+                'B1c overall source=%s/%s avg=%s/%s delta=%s peak=%s/%s p99=%s/%s; dimension source=%s/%s avg=%s/%s delta=%s peak=%s/%s p99=%s/%s',
+                coalesce(to_jsonb(v_overall) ->> 'source_1', '<missing>'),
+                coalesce(to_jsonb(v_overall) ->> 'source_2', '<missing>'),
+                v_overall.avg_aas_1,
+                v_overall.avg_aas_2,
+                v_overall.avg_delta,
+                v_overall.peak_aas_1,
+                v_overall.peak_aas_2,
+                v_overall.p99_aas_1,
+                v_overall.p99_aas_2,
+                coalesce(to_jsonb(v_dimension) ->> 'source_1', '<missing>'),
+                coalesce(to_jsonb(v_dimension) ->> 'source_2', '<missing>'),
+                v_dimension.avg_aas_1,
+                v_dimension.avg_aas_2,
+                v_dimension.avg_delta,
+                v_dimension.peak_aas_1,
+                v_dimension.peak_aas_2,
+                v_dimension.p99_aas_1,
+                v_dimension.p99_aas_2
+              );
+          end $$;
+
+          -- #130: hour-only dimensions snap partial bounds outward and expose
+          -- the effective window; the database dimension keeps minute precision.
+          do $$
+          declare
+            v_cpu smallint;
+            v_io smallint;
+            v_h timestamptz := date_trunc('hour', now()) - interval '45 days';
+            v_aas record;
+            v_wait record;
+            v_database record;
+            v_rows bigint;
+            v_min_aas numeric;
+            v_max_aas numeric;
+          begin
+            truncate ash.sample;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set sample_interval = interval '1 second',
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+            select ash._register_wait('active', 'IO', 'DataFileRead') into v_io;
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            ) values
+              (
+                ash.ts_from_timestamptz(v_h),
+                0::oid,
+                3600,
+                1,
+                array[v_io, 3600]::int4[],
+                '{}'::int8[],
+                array_fill(60, array[60])
+              ),
+              (
+                ash.ts_from_timestamptz(v_h + interval '1 hour'),
+                0::oid,
+                3600,
+                1,
+                array[v_cpu, 3600]::int4[],
+                '{}'::int8[],
+                array_fill(60, array[60])
+              );
+
+            select * into v_aas
+            from ash.aas(
+              v_h,
+              v_h + interval '30 minutes',
+              wait_event_type => 'IO'
+            );
+            select * into v_wait
+            from ash.top(
+              'wait_event_type',
+              v_h + interval '30 minutes',
+              v_h + interval '90 minutes',
+              n => 10
+            )
+            where key = 'IO';
+            select * into v_database
+            from ash.top(
+              'database',
+              v_h,
+              v_h + interval '30 minutes',
+              n => 10
+            );
+
+            assert v_aas.period_start = v_h
+               and v_aas.period_end = v_h + interval '1 hour'
+               and v_aas.avg_aas = 1.00
+               and v_aas.backend_seconds = 3600.00
+               and v_aas.peak_aas is null
+               and v_aas.p99_aas is null
+               and (to_jsonb(v_wait) ->> 'period_start')::timestamptz = v_h
+               and (to_jsonb(v_wait) ->> 'period_end')::timestamptz
+                     = v_h + interval '2 hours'
+               and v_wait.avg_aas = 0.50
+               and v_wait.backend_seconds = 3600.00
+               and v_wait.peak_aas is null
+               and v_wait.p99_aas is null
+               and (to_jsonb(v_database) ->> 'period_start')::timestamptz = v_h
+               and (to_jsonb(v_database) ->> 'period_end')::timestamptz
+                     = v_h + interval '30 minutes'
+               and v_database.avg_aas = 1.00
+               and v_database.backend_seconds = 1800.00
+               and v_database.peak_aas = 1.00
+               and v_database.p99_aas = 1.00,
+              format(
+                '#130 aas period=%s..%s avg=%s seconds=%s peak=%s p99=%s; wait period=%s..%s avg=%s seconds=%s peak=%s p99=%s; database period=%s..%s avg=%s seconds=%s peak=%s p99=%s',
+                v_aas.period_start,
+                v_aas.period_end,
+                v_aas.avg_aas,
+                v_aas.backend_seconds,
+                v_aas.peak_aas,
+                v_aas.p99_aas,
+                coalesce(to_jsonb(v_wait) ->> 'period_start', '<missing>'),
+                coalesce(to_jsonb(v_wait) ->> 'period_end', '<missing>'),
+                v_wait.avg_aas,
+                v_wait.backend_seconds,
+                v_wait.peak_aas,
+                v_wait.p99_aas,
+                coalesce(to_jsonb(v_database) ->> 'period_start', '<missing>'),
+                coalesce(to_jsonb(v_database) ->> 'period_end', '<missing>'),
+                v_database.avg_aas,
+                v_database.backend_seconds,
+                v_database.peak_aas,
+                v_database.p99_aas
+              );
+
+            select
+              count(*) filter (where bucket_start is not null),
+              min(aas) filter (where bucket_start is not null),
+              max(aas) filter (where bucket_start is not null)
+              into v_rows, v_min_aas, v_max_aas
+            from ash.chart(
+              v_h + interval '30 minutes',
+              v_h + interval '90 minutes',
+              interval '30 minutes'
+            );
+            assert v_rows = 2 and v_min_aas = 1.00 and v_max_aas = 1.00,
+              format(
+                '#130 chart snapped rows=%s aas=%s..%s',
+                v_rows,
+                v_min_aas,
+                v_max_aas
+              );
+          end $$;
+
+          -- #131 regression controls: defaults and now()-relative calls remain
+          -- usable when rollup_1h is the only retained source.
+          do $$
+          declare
+            v_io smallint;
+            v_requested_start int4;
+            v_requested_end int4;
+            v_effective_start int4;
+            v_effective_end int4;
+            v_expected_hours int;
+            v_summary_rows bigint;
+            v_summary_avg text;
+            v_chart_rows bigint;
+            v_chart_min numeric;
+            v_chart_max numeric;
+            v_top record;
+            v_aas record;
+          begin
+            truncate ash.sample;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set sample_interval = interval '1 second',
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+
+            select ash._register_wait('active', 'IO', 'DataFileRead') into v_io;
+
+            v_requested_start :=
+              (ash.ts_from_timestamptz(now() - interval '1 hour') / 60) * 60;
+            v_requested_end :=
+              (ash.ts_from_timestamptz(now()) / 60) * 60;
+            v_effective_start := (v_requested_start / 3600) * 3600;
+            v_effective_end :=
+              ((v_requested_end::bigint + 3599) / 3600 * 3600)::int4;
+            v_expected_hours := (v_effective_end - v_effective_start) / 3600;
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            )
+            select
+              hour_ts::int4,
+              0::oid,
+              3600,
+              1,
+              array[v_io, 3600]::int4[],
+              array[111::bigint, 3600]::int8[],
+              array_fill(60, array[60])
+            from generate_series(
+              v_effective_start::bigint,
+              (v_effective_end - 3600)::bigint,
+              3600
+            ) as hour_ts;
+
+            select count(*), max(value) filter (where metric = 'avg_aas')
+              into v_summary_rows, v_summary_avg
+            from ash.summary();
+            select
+              count(*) filter (where bucket_start is not null),
+              min(aas) filter (where bucket_start is not null),
+              max(aas) filter (where bucket_start is not null)
+              into v_chart_rows, v_chart_min, v_chart_max
+            from ash.chart();
+            select * into v_top from ash.top('wait_event_type')
+            where key = 'IO';
+            select * into v_aas from ash.aas(wait_event_type => 'IO');
+
+            assert v_summary_rows = 11
+               and v_summary_avg = '1.00'
+               and v_chart_rows = v_expected_hours
+               and v_chart_min = 1.00
+               and v_chart_max = 1.00
+               and v_top.avg_aas = 1.00
+               and v_top.peak_aas is null
+               and v_top.p99_aas is null
+               and v_aas.avg_aas = 1.00
+               and v_aas.backend_seconds
+                     = (v_effective_end - v_effective_start)::numeric
+               and v_aas.peak_aas is null
+               and v_aas.p99_aas is null,
+              format(
+                '#131 defaults summary rows=%s avg=%s; chart rows=%s expected=%s aas=%s..%s; top avg=%s peak=%s p99=%s; filtered aas avg=%s seconds=%s peak=%s p99=%s',
+                v_summary_rows,
+                v_summary_avg,
+                v_chart_rows,
+                v_expected_hours,
+                v_chart_min,
+                v_chart_max,
+                v_top.avg_aas,
+                v_top.peak_aas,
+                v_top.p99_aas,
+                v_aas.avg_aas,
+                v_aas.backend_seconds,
+                v_aas.peak_aas,
+                v_aas.p99_aas
+              );
+
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+
+            raise notice
+              'rollup_1h grain honesty, partial-hour, and default-call tests PASSED';
           end $$;
           EOF
 
@@ -5422,6 +5950,324 @@ jobs:
             ), 'direct v1.4 -> v1.5 upgrade did not honor rebuilt retained raw slots';
 
             raise notice 'direct v1.4 -> v1.5 release upgrade regression PASSED';
+          end $$;
+
+          select ash.uninstall('yes');
+          EOF
+
+      - name: "Release upgrade path: v1.5 rollup_1h backfill honesty (#161, #168)"
+        if: matrix.postgres == 17 && matrix.cron == 'on'
+        env:
+          PGPASSWORD: postgres
+        run: |
+          released_version="$(python3 devel/scripts/ash_sql_chain.py latest-released-version)"
+          git show "v${released_version}:sql/ash-install.sql" \
+            > /tmp/ash-released-install.sql
+
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          \i /tmp/ash-released-install.sql
+
+          create temporary table upgrade_rollup_probe (
+            label text primary key,
+            hour_ts int4 not null
+          );
+
+          do $$
+          declare
+            v_wait_id smallint;
+            v_flat_h int4 := (
+              ash.ts_from_timestamptz(
+                date_trunc('hour', now()) - interval '60 days'
+              ) / 3600
+            ) * 3600;
+            v_partial_h int4 := (
+              ash.ts_from_timestamptz(
+                date_trunc('hour', now()) - interval '29 days'
+              ) / 3600
+            ) * 3600;
+            v_complete_h int4 := (
+              ash.ts_from_timestamptz(
+                date_trunc('hour', now()) - interval '28 days'
+              ) / 3600
+            ) * 3600;
+          begin
+            assert (
+              select version from ash.config where singleton
+            ) = '1.5',
+              'precondition: real v1.5 installer required';
+            assert not exists (
+              select
+              from information_schema.columns
+              where table_schema = 'ash'
+                and table_name = 'rollup_1h'
+                and column_name = 'minute_counts'
+            ), 'precondition: v1.5 unexpectedly has minute_counts';
+
+            select ash._register_wait('active', 'IO', 'DataFileRead')
+              into v_wait_id;
+
+            insert into upgrade_rollup_probe values
+              ('legacy_flat', v_flat_h),
+              ('partial_backfill', v_partial_h),
+              ('complete_backfill', v_complete_h);
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values
+              (
+                v_flat_h,
+                0::oid,
+                60,
+                10,
+                array[v_wait_id, 600]::int4[],
+                '{}'::int8[]
+              ),
+              (
+                v_partial_h,
+                0::oid,
+                3600,
+                1,
+                array[v_wait_id, 3600]::int4[],
+                '{}'::int8[]
+              ),
+              (
+                v_complete_h,
+                0::oid,
+                3600,
+                10,
+                array[v_wait_id, 4140]::int4[],
+                '{}'::int8[]
+              );
+
+            -- N1: only half of this hour's minute detail survives.
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            )
+            select
+              v_partial_h + minute_idx * 60,
+              0::oid,
+              60,
+              1,
+              array[v_wait_id, 60]::int4[],
+              '{}'::int8[]
+            from generate_series(0, 29) as minute_idx;
+
+            -- Positive control: complete detail with one 600-count spike and
+            -- 59 quiet minutes of 60 counts.
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            )
+            select
+              v_complete_h + minute_idx * 60,
+              0::oid,
+              60,
+              case when minute_idx = 0 then 10 else 1 end,
+              array[
+                v_wait_id,
+                case when minute_idx = 0 then 600 else 60 end
+              ]::int4[],
+              '{}'::int8[]
+            from generate_series(0, 59) as minute_idx;
+          end $$;
+
+          \i sql/migrations/ash-1.5-to-2.0.sql
+
+          -- B1d: a genuine legacy hour is one disclosed hour-grain datum, not
+          -- 60 synthesized observations that claim minute precision.
+          do $$
+          declare
+            v_h int4;
+            v_rows bigint;
+            v_min_source text;
+            v_max_source text;
+            v_points numeric;
+            v_min_avg numeric;
+            v_max_avg numeric;
+            v_peaks bigint;
+            v_p99s bigint;
+            v_aas record;
+          begin
+            select hour_ts into v_h
+            from upgrade_rollup_probe
+            where label = 'legacy_flat';
+
+            select
+              count(*),
+              min(source),
+              max(source),
+              sum(data_points),
+              min(avg_aas),
+              max(avg_aas),
+              count(peak_aas),
+              count(p99_aas)
+              into
+                v_rows,
+                v_min_source,
+                v_max_source,
+                v_points,
+                v_min_avg,
+                v_max_avg,
+                v_peaks,
+                v_p99s
+            from ash.timeline(
+              ash.ts_to_timestamptz(v_h),
+              ash.ts_to_timestamptz(v_h + 3600),
+              interval '1 minute'
+            );
+
+            select * into v_aas
+            from ash.aas(
+              ash.ts_to_timestamptz(v_h),
+              ash.ts_to_timestamptz(v_h + 3600),
+              bucket => interval '1 minute'
+            );
+
+            assert v_rows = 1
+               and v_min_source = 'rollup_1h_flat'
+               and v_max_source = 'rollup_1h_flat'
+               and v_points = 1
+               and v_min_avg = 0.17
+               and v_max_avg = 0.17
+               and v_peaks = 0
+               and v_p99s = 0
+               and v_aas.source = 'rollup_1h_flat'
+               and v_aas.buckets_expected = 1
+               and v_aas.buckets_with_data = 1
+               and v_aas.avg_aas = 0.17
+               and v_aas.peak_aas is null
+               and v_aas.p99_aas is null
+               and v_aas.backend_seconds = 600.00,
+              format(
+                'B1d legacy timeline rows=%s source=%s..%s points=%s avg=%s..%s nonnull_peak=%s nonnull_p99=%s; aas source=%s buckets=%s/%s avg=%s peak=%s p99=%s seconds=%s',
+                v_rows,
+                v_min_source,
+                v_max_source,
+                v_points,
+                v_min_avg,
+                v_max_avg,
+                v_peaks,
+                v_p99s,
+                v_aas.source,
+                v_aas.buckets_with_data,
+                v_aas.buckets_expected,
+                v_aas.avg_aas,
+                v_aas.peak_aas,
+                v_aas.p99_aas,
+                v_aas.backend_seconds
+              );
+          end $$;
+
+          -- N1: a partial candidate is worse than the exact hourly fallback,
+          -- so the migration must leave minute_counts NULL.
+          do $$
+          declare
+            v_mc int4[];
+            v_wait_counts int4[];
+            v_minute_sum bigint;
+            v_hour_sum bigint;
+            v_null_slots bigint;
+          begin
+            select hourly.minute_counts, hourly.wait_counts
+              into v_mc, v_wait_counts
+            from ash.rollup_1h as hourly
+            join upgrade_rollup_probe as probe
+              on probe.hour_ts = hourly.ts
+            where probe.label = 'partial_backfill'
+              and hourly.datid = 0::oid;
+
+            select
+              sum(minute_count),
+              count(*) filter (where minute_count is null)
+              into v_minute_sum, v_null_slots
+            from unnest(v_mc) as minute_count;
+
+            select sum(v_wait_counts[pos + 1])
+              into v_hour_sum
+            from generate_subscripts(v_wait_counts, 1) as pos
+            where pos % 2 = 1;
+
+            assert v_mc is null,
+              format(
+                'N1 partial backfill minute_counts cardinality=%s null_slots=%s minute_sum=%s hour_sum=%s',
+                cardinality(v_mc),
+                v_null_slots,
+                v_minute_sum,
+                v_hour_sum
+              );
+          end $$;
+
+          -- Complete coverage is retained and satisfies the stored invariant.
+          do $$
+          declare
+            v_mc int4[];
+            v_wait_counts int4[];
+            v_minute_sum bigint;
+            v_hour_sum bigint;
+            v_null_slots bigint;
+            v_quiet_slots bigint;
+          begin
+            select hourly.minute_counts, hourly.wait_counts
+              into v_mc, v_wait_counts
+            from ash.rollup_1h as hourly
+            join upgrade_rollup_probe as probe
+              on probe.hour_ts = hourly.ts
+            where probe.label = 'complete_backfill'
+              and hourly.datid = 0::oid;
+
+            select
+              coalesce(sum(minute_count), 0),
+              count(*) filter (where minute_count is null),
+              count(*) filter (where minute_count = 60)
+              into v_minute_sum, v_null_slots, v_quiet_slots
+            from unnest(v_mc) as minute_count;
+
+            select coalesce(sum(v_wait_counts[pos + 1]), 0)
+              into v_hour_sum
+            from generate_subscripts(v_wait_counts, 1) as pos
+            where pos % 2 = 1;
+
+            assert cardinality(v_mc) = 60
+               and v_null_slots = 0
+               and v_mc[1] = 600
+               and v_quiet_slots = 59
+               and v_minute_sum = 4140
+               and v_hour_sum = 4140,
+              format(
+                'complete backfill invariant cardinality=%s null_slots=%s first=%s quiet_slots=%s minute_sum=%s hour_sum=%s',
+                cardinality(v_mc),
+                v_null_slots,
+                v_mc[1],
+                v_quiet_slots,
+                v_minute_sum,
+                v_hour_sum
+              );
+          end $$;
+
+          -- Re-apply repairs a partial array already written by an earlier
+          -- 2.0 beta installer instead of preserving permanent undercounting.
+          update ash.rollup_1h as hourly
+          set minute_counts =
+            array_fill(60, array[30]) || array_fill(null::int4, array[30])
+          from upgrade_rollup_probe as probe
+          where probe.label = 'partial_backfill'
+            and hourly.ts = probe.hour_ts
+            and hourly.datid = 0::oid;
+
+          \i sql/migrations/ash-1.5-to-2.0.sql
+
+          do $$
+          begin
+            assert (
+              select hourly.minute_counts is null
+              from ash.rollup_1h as hourly
+              join upgrade_rollup_probe as probe
+                on probe.hour_ts = hourly.ts
+              where probe.label = 'partial_backfill'
+                and hourly.datid = 0::oid
+            ), 'N1 installer re-apply must NULL a pre-existing partial array';
+
+            raise notice
+              'real v1.5 rollup_1h legacy and backfill honesty PASSED';
           end $$;
 
           select ash.uninstall('yes');

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4214,10 +4214,10 @@ jobs:
           -- p99_aas as a short (rollup_1m-backed) window containing the same spike.
           -- Invariants: (a) monotonic peak — widening the window never shrinks the
           -- peak; (b) seam consistency — identical peak/p99 from either source;
-          -- (c) p99_aas non-null over rollup_1h-backed windows. Also: rollup_hour()
-          -- computes minute_counts exactly, legacy NULL rows flat-fill to the hour
-          -- average (lower bound, never an invented spike), and wait-filtered reads
-          -- honestly stay hour-grain.
+          -- (c) p99_aas non-null over rollup_1h-backed windows with genuine
+          -- minute_counts. Also: rollup_hour() preserves the exact stored-total
+          -- invariant, legacy NULL rows are disclosed at hour grain, and
+          -- wait-filtered reads NULL extrema requested below that grain.
           -- ============================================================================
           do $$
           declare
@@ -4315,35 +4315,80 @@ jobs:
             where data_points > 0;
             assert n = 6, 'timeline 10-min buckets with data over rollup_1h = 6, got ' || n;
 
-            -- wait-filtered long window has no per-minute detail and honestly stays
-            -- hour-grain: peak = IO hour average (59*20+60)/3600 = 0.34, timeline p99 null
+            -- wait-filtered long window has no per-minute detail. The default
+            -- requested minute extremes are unsupported and therefore NULL.
             select * into a from ash.aas(v_h - interval '2 hours', v_h + interval '1 hour',
                                          wait_event_type => 'IO');
-            assert a.source = 'rollup_1h' and a.peak_aas = 0.34,
-              format('filtered long window stays hour-grain: peak=%s (want 0.34)', a.peak_aas);
-            select p99_aas into v_p99
+            assert a.source = 'rollup_1h'
+               and a.avg_aas = 0.11
+               and a.backend_seconds = 1240.00
+               and a.peak_aas is null
+               and a.p99_aas is null,
+              format(
+                'filtered long window source=%s avg=%s seconds=%s peak=%s p99=%s',
+                a.source, a.avg_aas, a.backend_seconds, a.peak_aas, a.p99_aas
+              );
+
+            -- An explicit hour bucket matches the retained grain, so the
+            -- hour-level peak/p99 are honest and remain available.
+            select * into a from ash.aas(
+              v_h - interval '2 hours',
+              v_h + interval '1 hour',
+              wait_event_type => 'IO',
+              bucket => interval '1 hour'
+            );
+            assert a.peak_aas = 0.34 and a.p99_aas = 0.34,
+              format(
+                'filtered hour bucket peak=%s p99=%s (want 0.34/0.34)',
+                a.peak_aas, a.p99_aas
+              );
+            select peak_aas, p99_aas into v_peak, v_p99
             from ash.timeline(v_h - interval '2 hours', v_h + interval '1 hour', '1 hour',
                               wait_event_type => 'IO')
             where data_points > 0;
-            assert v_p99 is null, 'filtered rollup_1h timeline p99 stays null, got ' || coalesce(v_p99::text, 'null');
+            assert v_peak = 0.34 and v_p99 = 0.34,
+              format(
+                'filtered hourly timeline peak=%s p99=%s (want 0.34/0.34)',
+                v_peak, v_p99
+              );
 
-            -- legacy pre-2.0 row (minute_counts null): flat-fills to its hour average
-            -- (AAS 1.00/min) — peak keeps the real spike, p99 non-null, no fake spike
+            -- A legacy pre-2.0 row makes the mixed window conservatively
+            -- hour-grain. It is marked and never becomes 60 fake observations.
             insert into ash.rollup_1h (ts, datid, samples, peak_backends, wait_counts, query_counts, minute_counts)
             values (ash.ts_from_timestamptz(v_h - interval '1 hour'), 0::oid, 3600, 9,
                     array[v_cpu, 3600]::int4[], '{}'::int8[], null);
             select * into a from ash.aas(v_h - interval '2 hours', v_h + interval '1 hour');
-            assert a.peak_aas = 11.30 and a.p99_aas = 1.00 and a.buckets_with_data = 120,
-              format('legacy mix: peak=%s p99=%s bwd=%s (want 11.30 1.00 120)',
-                     a.peak_aas, a.p99_aas, a.buckets_with_data);
+            assert a.source = 'rollup_1h_flat'
+               and a.effective_bucket = interval '1 hour'
+               and a.buckets_expected = 3
+               and a.buckets_with_data = 2
+               and a.avg_aas = 0.72
+               and a.backend_seconds = 7818.00
+               and a.peak_aas is null
+               and a.p99_aas is null,
+              format(
+                'legacy mix source=%s bucket=%s expected=%s data=%s avg=%s seconds=%s peak=%s p99=%s',
+                a.source,
+                a.effective_bucket,
+                a.buckets_expected,
+                a.buckets_with_data,
+                a.avg_aas,
+                a.backend_seconds,
+                a.peak_aas,
+                a.p99_aas
+              );
 
-            -- periods(): the long windows (1w, 1mo) carry the true minute peak and a
-            -- non-null p99 (US-6 capacity planning works past rollup_1m retention)
+            -- periods() carries the same flat provenance and effective bucket.
             for r in select * from ash.periods(v_h + interval '1 hour') loop
               if r.period in ('1w', '1mo') then
-                assert r.peak_aas = 11.30 and r.p99_aas is not null,
-                  format('periods %s: peak=%s p99=%s (want 11.30, non-null)',
-                         r.period, r.peak_aas, r.p99_aas);
+                assert r.source = 'rollup_1h_flat'
+                   and r.bucket = interval '1 hour'
+                   and r.peak_aas is null
+                   and r.p99_aas is null,
+                  format(
+                    'periods %s source=%s bucket=%s peak=%s p99=%s',
+                    r.period, r.source, r.bucket, r.peak_aas, r.p99_aas
+                  );
               end if;
             end loop;
 
@@ -4368,8 +4413,11 @@ jobs:
             v_io smallint;
             v_h timestamptz := date_trunc('hour', now()) - interval '45 days';
             v_aas record;
+            v_aas_90 record;
             v_wait record;
             v_database record;
+            v_timeline_90_rows bigint;
+            v_timeline_90_points bigint;
           begin
             truncate ash.sample;
             truncate ash.rollup_1m, ash.rollup_1h;
@@ -4414,6 +4462,19 @@ jobs:
               n => 10,
               bucket => interval '1 minute'
             );
+            select * into v_aas_90
+            from ash.aas(
+              v_h,
+              v_h + interval '1 hour',
+              bucket => interval '90 seconds'
+            );
+            select count(*), sum(data_points)
+              into v_timeline_90_rows, v_timeline_90_points
+            from ash.timeline(
+              v_h,
+              v_h + interval '1 hour',
+              bucket => interval '90 seconds'
+            );
 
             assert v_aas.avg_aas = 1.15
                and v_aas.peak_aas = 10.00
@@ -4436,6 +4497,32 @@ jobs:
                 v_database.peak_aas,
                 v_database.p99_aas
               );
+
+            assert v_aas_90.effective_bucket = interval '2 minutes'
+               and v_aas_90.buckets_expected = 30
+               and v_timeline_90_rows = 30
+               and v_timeline_90_points = 60,
+              format(
+                'bucket widening effective=%s expected=%s timeline_rows=%s points=%s',
+                v_aas_90.effective_bucket,
+                v_aas_90.buckets_expected,
+                v_timeline_90_rows,
+                v_timeline_90_points
+              );
+
+            begin
+              perform *
+              from ash.aas(
+                v_h,
+                v_h + interval '1 hour',
+                bucket => interval '59.9 seconds'
+              );
+              raise exception 'sub-minute fractional bucket was accepted';
+            exception when others then
+              if sqlerrm not like 'bucket must be at least 1 minute%' then
+                raise;
+              end if;
+            end;
           end $$;
 
           -- B1b: adding a filter must disclose the surviving hour grain by
@@ -4447,6 +4534,7 @@ jobs:
             v_h timestamptz := date_trunc('hour', now()) - interval '45 days';
             v_all record;
             v_io_minute record;
+            v_io_fractional_hour record;
             v_io_hour record;
           begin
             truncate ash.sample;
@@ -4489,6 +4577,13 @@ jobs:
               wait_event_type => 'IO',
               bucket => interval '1 hour'
             );
+            select * into v_io_fractional_hour
+            from ash.aas(
+              v_h,
+              v_h + interval '1 hour',
+              wait_event_type => 'IO',
+              bucket => interval '3599.9 seconds'
+            );
 
             assert v_all.avg_aas = 2.32
                and v_all.peak_aas = 21.00
@@ -4497,10 +4592,13 @@ jobs:
                and v_io_minute.backend_seconds = 8280.00
                and v_io_minute.peak_aas is null
                and v_io_minute.p99_aas is null
+               and v_io_fractional_hour.effective_bucket = interval '1 hour'
+               and v_io_fractional_hour.peak_aas is null
+               and v_io_fractional_hour.p99_aas is null
                and v_io_hour.peak_aas = 2.30
                and v_io_hour.p99_aas = 2.30,
               format(
-                'B1b unfiltered avg=%s peak=%s p99=%s; IO minute avg=%s seconds=%s peak=%s p99=%s; IO hour peak=%s p99=%s',
+                'B1b unfiltered avg=%s peak=%s p99=%s; IO minute avg=%s seconds=%s peak=%s p99=%s; IO fractional-hour bucket=%s peak=%s p99=%s; IO hour peak=%s p99=%s',
                 v_all.avg_aas,
                 v_all.peak_aas,
                 v_all.p99_aas,
@@ -4508,6 +4606,9 @@ jobs:
                 v_io_minute.backend_seconds,
                 v_io_minute.peak_aas,
                 v_io_minute.p99_aas,
+                v_io_fractional_hour.effective_bucket,
+                v_io_fractional_hour.peak_aas,
+                v_io_fractional_hour.p99_aas,
                 v_io_hour.peak_aas,
                 v_io_hour.p99_aas
               );
@@ -4523,6 +4624,7 @@ jobs:
             v_new_h timestamptz := date_trunc('hour', now()) - interval '2 hours';
             v_overall record;
             v_dimension record;
+            v_dimension_hour record;
           begin
             truncate ash.sample;
             truncate ash.rollup_1m, ash.rollup_1h;
@@ -4579,9 +4681,22 @@ jobs:
               v_new_h + interval '1 hour',
               dimension => 'wait_event'
             );
+            select * into v_dimension_hour
+            from ash.compare(
+              v_old_h,
+              v_old_h + interval '1 hour',
+              v_new_h,
+              v_new_h + interval '1 hour',
+              dimension => 'wait_event',
+              bucket => interval '1 hour'
+            );
 
             assert to_jsonb(v_overall) ->> 'source_1' = 'rollup_1h'
                and to_jsonb(v_overall) ->> 'source_2' = 'rollup_1m'
+               and (to_jsonb(v_overall) ->> 'effective_bucket_1')::interval
+                     = interval '1 minute'
+               and (to_jsonb(v_overall) ->> 'effective_bucket_2')::interval
+                     = interval '1 minute'
                and v_overall.avg_aas_1 = 10.98
                and v_overall.avg_aas_2 = 10.98
                and v_overall.avg_delta = 0.00
@@ -4591,6 +4706,10 @@ jobs:
                and v_overall.p99_aas_2 = 246.59
                and to_jsonb(v_dimension) ->> 'source_1' = 'rollup_1h'
                and to_jsonb(v_dimension) ->> 'source_2' = 'rollup_1m'
+               and (to_jsonb(v_dimension) ->> 'effective_bucket_1')::interval
+                     = interval '1 hour'
+               and (to_jsonb(v_dimension) ->> 'effective_bucket_2')::interval
+                     = interval '1 minute'
                and v_dimension.avg_aas_1 = 10.98
                and v_dimension.avg_aas_2 = 10.98
                and v_dimension.avg_delta = 0.00
@@ -4619,6 +4738,39 @@ jobs:
                 v_dimension.p99_aas_1,
                 v_dimension.p99_aas_2
               );
+
+            -- Matching displayed buckets do not make different retained
+            -- grains comparable: the old wait dimension has one hourly
+            -- datum while the recent side has 60 minute observations.
+            assert to_jsonb(v_dimension_hour) ->> 'source_1' = 'rollup_1h'
+               and to_jsonb(v_dimension_hour) ->> 'source_2' = 'rollup_1m'
+               and (
+                 to_jsonb(v_dimension_hour) ->> 'effective_bucket_1'
+               )::interval = interval '1 hour'
+               and (
+                 to_jsonb(v_dimension_hour) ->> 'effective_bucket_2'
+               )::interval = interval '1 hour'
+               and v_dimension_hour.avg_aas_1 = 10.98
+               and v_dimension_hour.avg_aas_2 = 10.98
+               and v_dimension_hour.avg_delta = 0.00
+               and v_dimension_hour.peak_aas_1 is null
+               and v_dimension_hour.peak_aas_2 is null
+               and v_dimension_hour.p99_aas_1 is null
+               and v_dimension_hour.p99_aas_2 is null,
+              format(
+                'B1c equal bucket/different grain source=%s/%s bucket=%s/%s avg=%s/%s delta=%s peak=%s/%s p99=%s/%s',
+                to_jsonb(v_dimension_hour) ->> 'source_1',
+                to_jsonb(v_dimension_hour) ->> 'source_2',
+                to_jsonb(v_dimension_hour) ->> 'effective_bucket_1',
+                to_jsonb(v_dimension_hour) ->> 'effective_bucket_2',
+                v_dimension_hour.avg_aas_1,
+                v_dimension_hour.avg_aas_2,
+                v_dimension_hour.avg_delta,
+                v_dimension_hour.peak_aas_1,
+                v_dimension_hour.peak_aas_2,
+                v_dimension_hour.p99_aas_1,
+                v_dimension_hour.p99_aas_2
+              );
           end $$;
 
           -- #130: hour-only dimensions snap partial bounds outward and expose
@@ -4634,6 +4786,11 @@ jobs:
             v_rows bigint;
             v_min_aas numeric;
             v_max_aas numeric;
+            v_min_source text;
+            v_max_source text;
+            v_points bigint;
+            v_nonnull_peaks bigint;
+            v_nonnull_p99s bigint;
           begin
             truncate ash.sample;
             truncate ash.rollup_1m, ash.rollup_1h;
@@ -4734,6 +4891,50 @@ jobs:
               );
 
             select
+              count(*),
+              min(source),
+              max(source),
+              sum(data_points),
+              min(avg_aas),
+              max(avg_aas),
+              count(peak_aas),
+              count(p99_aas)
+              into
+                v_rows,
+                v_min_source,
+                v_max_source,
+                v_points,
+                v_min_aas,
+                v_max_aas,
+                v_nonnull_peaks,
+                v_nonnull_p99s
+            from ash.timeline(
+              v_h + interval '30 minutes',
+              v_h + interval '90 minutes',
+              interval '30 minutes',
+              wait_event_type => 'IO'
+            );
+            assert v_rows = 2
+               and v_min_source = 'rollup_1h'
+               and v_max_source = 'rollup_1h'
+               and v_points = 2
+               and v_min_aas = 0.00
+               and v_max_aas = 1.00
+               and v_nonnull_peaks = 0
+               and v_nonnull_p99s = 0,
+              format(
+                '#130 timeline rows=%s source=%s..%s points=%s avg=%s..%s nonnull_peak=%s nonnull_p99=%s',
+                v_rows,
+                v_min_source,
+                v_max_source,
+                v_points,
+                v_min_aas,
+                v_max_aas,
+                v_nonnull_peaks,
+                v_nonnull_p99s
+              );
+
+            select
               count(*) filter (where bucket_start is not null),
               min(aas) filter (where bucket_start is not null),
               max(aas) filter (where bucket_start is not null)
@@ -4767,6 +4968,12 @@ jobs:
             v_chart_rows bigint;
             v_chart_min numeric;
             v_chart_max numeric;
+            v_timeline_rows bigint;
+            v_timeline_points bigint;
+            v_timeline_min numeric;
+            v_timeline_max numeric;
+            v_timeline_peaks bigint;
+            v_timeline_p99s bigint;
             v_top record;
             v_aas record;
           begin
@@ -4816,6 +5023,21 @@ jobs:
               max(aas) filter (where bucket_start is not null)
               into v_chart_rows, v_chart_min, v_chart_max
             from ash.chart();
+            select
+              count(*),
+              sum(data_points),
+              min(avg_aas),
+              max(avg_aas),
+              count(peak_aas),
+              count(p99_aas)
+              into
+                v_timeline_rows,
+                v_timeline_points,
+                v_timeline_min,
+                v_timeline_max,
+                v_timeline_peaks,
+                v_timeline_p99s
+            from ash.timeline();
             select * into v_top from ash.top('wait_event_type')
             where key = 'IO';
             select * into v_aas from ash.aas(wait_event_type => 'IO');
@@ -4825,6 +5047,12 @@ jobs:
                and v_chart_rows = v_expected_hours
                and v_chart_min = 1.00
                and v_chart_max = 1.00
+               and v_timeline_rows = 60
+               and v_timeline_points = 60
+               and v_timeline_min = 1.00
+               and v_timeline_max = 1.00
+               and v_timeline_peaks = 60
+               and v_timeline_p99s = 60
                and v_top.avg_aas = 1.00
                and v_top.peak_aas is null
                and v_top.p99_aas is null
@@ -4834,13 +5062,19 @@ jobs:
                and v_aas.peak_aas is null
                and v_aas.p99_aas is null,
               format(
-                '#131 defaults summary rows=%s avg=%s; chart rows=%s expected=%s aas=%s..%s; top avg=%s peak=%s p99=%s; filtered aas avg=%s seconds=%s peak=%s p99=%s',
+                '#131 defaults summary rows=%s avg=%s; chart rows=%s expected=%s aas=%s..%s; timeline rows=%s points=%s avg=%s..%s nonnull_peak=%s nonnull_p99=%s; top avg=%s peak=%s p99=%s; filtered aas avg=%s seconds=%s peak=%s p99=%s',
                 v_summary_rows,
                 v_summary_avg,
                 v_chart_rows,
                 v_expected_hours,
                 v_chart_min,
                 v_chart_max,
+                v_timeline_rows,
+                v_timeline_points,
+                v_timeline_min,
+                v_timeline_max,
+                v_timeline_peaks,
+                v_timeline_p99s,
                 v_top.avg_aas,
                 v_top.peak_aas,
                 v_top.p99_aas,
@@ -5960,12 +6194,36 @@ jobs:
         env:
           PGPASSWORD: postgres
         run: |
-          released_version="$(python3 devel/scripts/ash_sql_chain.py latest-released-version)"
-          git show "v${released_version}:sql/ash-install.sql" \
+          # Discover the final-release source immediately before the current
+          # development version. latest-released-version also sees migration
+          # destinations, which need not have a matching final tag yet.
+          fresh_version="$(
+            python3 devel/scripts/ash_sql_chain.py fresh-install-version
+          )"
+          target_version="${fresh_version%%-*}"
+          mapfile -t upgrade_candidates < <(
+            find sql/migrations -maxdepth 1 -type f \
+              -name "ash-*-to-${target_version}.sql" -print |
+              sort
+          )
+          test "${#upgrade_candidates[@]}" -eq 1
+          upgrade_path="${upgrade_candidates[0]}"
+          released_version="${upgrade_path##*/ash-}"
+          released_version="${released_version%-to-${target_version}.sql}"
+          released_tag="v${released_version}"
+          git cat-file -e "${released_tag}:sql/ash-install.sql"
+          git show "${released_tag}:sql/ash-install.sql" \
             > /tmp/ash-released-install.sql
 
-          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 \
+            -v released_version="$released_version" \
+            -v upgrade_path="$upgrade_path" << 'EOF'
           \i /tmp/ash-released-install.sql
+
+          create temporary table upgrade_release_probe (
+            version text not null
+          );
+          insert into upgrade_release_probe values (:'released_version');
 
           create temporary table upgrade_rollup_probe (
             label text primary key,
@@ -5993,8 +6251,13 @@ jobs:
           begin
             assert (
               select version from ash.config where singleton
-            ) = '1.5',
-              'precondition: real v1.5 installer required';
+            ) = (
+              select version from upgrade_release_probe
+            ),
+              format(
+                'precondition: real v%s installer required',
+                (select version from upgrade_release_probe)
+              );
             assert not exists (
               select
               from information_schema.columns
@@ -6070,7 +6333,7 @@ jobs:
             from generate_series(0, 59) as minute_idx;
           end $$;
 
-          \i sql/migrations/ash-1.5-to-2.0.sql
+          \i :upgrade_path
 
           -- B1d: a genuine legacy hour is one disclosed hour-grain datum, not
           -- 60 synthesized observations that claim minute precision.
@@ -6155,6 +6418,46 @@ jobs:
                 v_aas.p99_aas,
                 v_aas.backend_seconds
               );
+
+            assert (
+              select value
+              from ash.summary(
+                ash.ts_to_timestamptz(v_h),
+                ash.ts_to_timestamptz(v_h + 3600)
+              )
+              where metric = 'source'
+            ) = 'rollup_1h_flat'
+              and (
+                select value
+                from ash.summary(
+                  ash.ts_to_timestamptz(v_h),
+                  ash.ts_to_timestamptz(v_h + 3600)
+                )
+                where metric = 'buckets_with_data'
+              ) = '1'
+              and not exists (
+                select
+                from ash.summary(
+                  ash.ts_to_timestamptz(v_h),
+                  ash.ts_to_timestamptz(v_h + 3600)
+                )
+                where metric = 'minutes_with_data'
+              ),
+              'B1d summary must label its effective-grain count as buckets';
+
+            raise notice
+              'B1d GREEN timeline rows=% source=% points=% avg=% nonnull_peak=% nonnull_p99=%; aas source=% buckets=%/% avg=% peak=NULL p99=NULL seconds=%',
+              v_rows,
+              v_min_source,
+              v_points,
+              v_min_avg,
+              v_peaks,
+              v_p99s,
+              v_aas.source,
+              v_aas.buckets_with_data,
+              v_aas.buckets_expected,
+              v_aas.avg_aas,
+              v_aas.backend_seconds;
           end $$;
 
           -- N1: a partial candidate is worse than the exact hourly fallback,
@@ -6194,6 +6497,10 @@ jobs:
                 v_minute_sum,
                 v_hour_sum
               );
+
+            raise notice
+              'N1 GREEN partial minute_counts=NULL hour_sum=%',
+              v_hour_sum;
           end $$;
 
           -- Complete coverage is retained and satisfies the stored invariant.
@@ -6241,6 +6548,15 @@ jobs:
                 v_minute_sum,
                 v_hour_sum
               );
+
+            raise notice
+              'N1 GREEN complete cardinality=% null_slots=% first=% quiet_slots=% minute_sum=% hour_sum=%',
+              cardinality(v_mc),
+              v_null_slots,
+              v_mc[1],
+              v_quiet_slots,
+              v_minute_sum,
+              v_hour_sum;
           end $$;
 
           -- Re-apply repairs a partial array already written by an earlier
@@ -6253,7 +6569,7 @@ jobs:
             and hourly.ts = probe.hour_ts
             and hourly.datid = 0::oid;
 
-          \i sql/migrations/ash-1.5-to-2.0.sql
+          \i :upgrade_path
 
           do $$
           begin

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4953,6 +4953,111 @@ jobs:
               );
           end $$;
 
+          -- summary(): the minute-precise headline and widened hour-only
+          -- wait/query drills must disclose their distinct effective plans.
+          do $$
+          declare
+            v_cpu smallint;
+            v_io smallint;
+            v_h timestamptz := date_trunc('hour', now()) - interval '45 days';
+            v_period_start text;
+            v_period_end text;
+            v_avg text;
+            v_drill_source text;
+            v_drill_start text;
+            v_drill_end text;
+            v_drill_bucket text;
+            v_top_wait text;
+          begin
+            truncate ash.sample;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set sample_interval = interval '1 second',
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+            select ash._register_wait('active', 'IO', 'DataFileRead') into v_io;
+
+            /*
+             * Both hours contain load only in the halves outside the requested
+             * [h+30m, h+90m) window. The headline can prove measured zero from
+             * minute_counts; the dimensional drills can only report the two
+             * complete hours (IO 36000 / 7200 = 5.00 AAS).
+             */
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            ) values
+              (
+                ash.ts_from_timestamptz(v_h),
+                0::oid,
+                3600,
+                20,
+                array[v_io, 36000]::int4[],
+                '{}'::int8[],
+                array_fill(1200, array[30])
+                  || array_fill(0, array[30])
+              ),
+              (
+                ash.ts_from_timestamptz(v_h + interval '1 hour'),
+                0::oid,
+                3600,
+                10,
+                array[v_cpu, 18000]::int4[],
+                '{}'::int8[],
+                array_fill(0, array[30])
+                  || array_fill(600, array[30])
+              );
+
+            select
+              max(value) filter (where metric = 'period_start'),
+              max(value) filter (where metric = 'period_end'),
+              max(value) filter (where metric = 'avg_aas'),
+              max(value) filter (where metric = 'drill_source'),
+              max(value) filter (where metric = 'drill_period_start'),
+              max(value) filter (where metric = 'drill_period_end'),
+              max(value) filter (where metric = 'drill_effective_bucket'),
+              max(value) filter (where metric = 'top_wait_1')
+              into
+                v_period_start,
+                v_period_end,
+                v_avg,
+                v_drill_source,
+                v_drill_start,
+                v_drill_end,
+                v_drill_bucket,
+                v_top_wait
+            from ash.summary(
+              v_h + interval '30 minutes',
+              v_h + interval '90 minutes'
+            );
+
+            assert v_period_start::timestamptz
+                     = v_h + interval '30 minutes'
+               and v_period_end::timestamptz
+                     = v_h + interval '90 minutes'
+               and v_avg = '0.00'
+               and v_drill_source = 'rollup_1h'
+               and v_drill_start::timestamptz = v_h
+               and v_drill_end::timestamptz = v_h + interval '2 hours'
+               and v_drill_bucket::interval = interval '1 hour'
+               and v_top_wait
+                     = 'IO:DataFileRead (avg_aas 5.00, 66.67%)',
+              format(
+                'summary headline=%s..%s avg=%s; drill=%s %s..%s bucket=%s top=%s',
+                v_period_start,
+                v_period_end,
+                v_avg,
+                v_drill_source,
+                v_drill_start,
+                v_drill_end,
+                v_drill_bucket,
+                v_top_wait
+              );
+          end $$;
+
           -- #131 regression controls: defaults and now()-relative calls remain
           -- usable when rollup_1h is the only retained source.
           do $$
@@ -4965,6 +5070,10 @@ jobs:
             v_expected_hours int;
             v_summary_rows bigint;
             v_summary_avg text;
+            v_summary_drill_source text;
+            v_summary_drill_start text;
+            v_summary_drill_end text;
+            v_summary_drill_bucket text;
             v_chart_rows bigint;
             v_chart_min numeric;
             v_chart_max numeric;
@@ -5014,8 +5123,20 @@ jobs:
               3600
             ) as hour_ts;
 
-            select count(*), max(value) filter (where metric = 'avg_aas')
-              into v_summary_rows, v_summary_avg
+            select
+              count(*),
+              max(value) filter (where metric = 'avg_aas'),
+              max(value) filter (where metric = 'drill_source'),
+              max(value) filter (where metric = 'drill_period_start'),
+              max(value) filter (where metric = 'drill_period_end'),
+              max(value) filter (where metric = 'drill_effective_bucket')
+              into
+                v_summary_rows,
+                v_summary_avg,
+                v_summary_drill_source,
+                v_summary_drill_start,
+                v_summary_drill_end,
+                v_summary_drill_bucket
             from ash.summary();
             select
               count(*) filter (where bucket_start is not null),
@@ -5042,8 +5163,14 @@ jobs:
             where key = 'IO';
             select * into v_aas from ash.aas(wait_event_type => 'IO');
 
-            assert v_summary_rows = 11
+            assert v_summary_rows = 15
                and v_summary_avg = '1.00'
+               and v_summary_drill_source = 'rollup_1h'
+               and v_summary_drill_start::timestamptz
+                     = ash.ts_to_timestamptz(v_effective_start)
+               and v_summary_drill_end::timestamptz
+                     = ash.ts_to_timestamptz(v_effective_end)
+               and v_summary_drill_bucket::interval = interval '1 hour'
                and v_chart_rows = v_expected_hours
                and v_chart_min = 1.00
                and v_chart_max = 1.00
@@ -5062,9 +5189,13 @@ jobs:
                and v_aas.peak_aas is null
                and v_aas.p99_aas is null,
               format(
-                '#131 defaults summary rows=%s avg=%s; chart rows=%s expected=%s aas=%s..%s; timeline rows=%s points=%s avg=%s..%s nonnull_peak=%s nonnull_p99=%s; top avg=%s peak=%s p99=%s; filtered aas avg=%s seconds=%s peak=%s p99=%s',
+                '#131 defaults summary rows=%s avg=%s drill=%s %s..%s bucket=%s; chart rows=%s expected=%s aas=%s..%s; timeline rows=%s points=%s avg=%s..%s nonnull_peak=%s nonnull_p99=%s; top avg=%s peak=%s p99=%s; filtered aas avg=%s seconds=%s peak=%s p99=%s',
                 v_summary_rows,
                 v_summary_avg,
+                v_summary_drill_source,
+                v_summary_drill_start,
+                v_summary_drill_end,
+                v_summary_drill_bucket,
                 v_chart_rows,
                 v_expected_hours,
                 v_chart_min,

--- a/README.md
+++ b/README.md
@@ -228,9 +228,22 @@ from ash.top(
 );
 ```
 
-Combining a query filter with a wait filter requires the raw wait-to-query link. If
-the window is past raw retention, pg_ash raises with the raw-retention boundary
-instead of returning a fake empty result.
+Every explicit `query_id` filter reads raw samples: compacted rollups cannot
+prove either an exact count or a true zero. A query breakdown combined with a
+wait filter also needs the raw wait-to-query link. If coarser retained history
+would otherwise cover data before raw retention, pg_ash raises with the
+boundary instead of treating an omitted query as zero. On a young or
+post-reset install with no older rollup history, a default window may begin
+before the first sample and still reads the available raw rows — including
+after the first rollup covers only the same retained minute as raw.
+
+An unfiltered `ash.top('query_id')` can use rollups efficiently. Rollup query
+IDs are compacted (low-volume IDs may be omitted, and hourly rows retain a top
+set), so named rows describe only preserved attribution. A `NULL` row carries
+everything not preserved — including uncaptured query IDs — and makes
+`backend_seconds` and the percentage denominator reconcile to total load. The
+residual competes for `n` like every named row, so use a large enough `n` when
+you need the full reconciliation.
 
 ### 5. Pull raw evidence
 

--- a/README.md
+++ b/README.md
@@ -105,9 +105,10 @@ Full mapping: [`blueprints/AAS_EXAMPLES.md`](blueprints/AAS_EXAMPLES.md).
 Start with `ash.periods()`, then drill down with `ash.timeline()` and `ash.top()`.
 Typed aggregate readers report `raw`, `rollup_1m`, `rollup_1h`,
 `rollup_1h_flat`, or `none`; `ash.compare()` reports `source_1` / `source_2`,
-`ash.report()` embeds provenance in JSON coverage, `ash.summary()` includes a
-source metric, `ash.samples()` is raw-only, and `ash.chart()` emits a planning
-`NOTICE` when hour grain widens the request. `rollup_1h_flat` means a
+`ash.report()` embeds provenance in JSON coverage, and `ash.summary()` includes
+separate headline and wait/query drill source/bounds metrics. `ash.samples()`
+is raw-only, and `ash.chart()` emits a planning `NOTICE` when hour grain widens
+the request. `rollup_1h_flat` means a
 minute-capable plan encountered legacy/incomplete detail and degraded honestly
 to hour grain.
 

--- a/README.md
+++ b/README.md
@@ -103,8 +103,13 @@ Full mapping: [`blueprints/AAS_EXAMPLES.md`](blueprints/AAS_EXAMPLES.md).
 ## Reader API
 
 Start with `ash.periods()`, then drill down with `ash.timeline()` and `ash.top()`.
-Every reader reports its data source: `raw`, `rollup_1m`, `rollup_1h`, or
-`none`.
+Typed aggregate readers report `raw`, `rollup_1m`, `rollup_1h`,
+`rollup_1h_flat`, or `none`; `ash.compare()` reports `source_1` / `source_2`,
+`ash.report()` embeds provenance in JSON coverage, `ash.summary()` includes a
+source metric, `ash.samples()` is raw-only, and `ash.chart()` emits a planning
+`NOTICE` when hour grain widens the request. `rollup_1h_flat` means a
+minute-capable plan encountered legacy/incomplete detail and degraded honestly
+to hour grain.
 
 | Function | Use it for |
 |---|---|
@@ -134,14 +139,19 @@ Filters are consistent where they apply:
 
 `order_by` is `avg`, `peak`, or `p99`. During incidents, `order_by => 'peak'`
 is usually the right first cut because it surfaces short spikes that averages
-hide.
+hide. When retained grain is coarser than the requested bucket, peak/p99 are
+NULL instead of being filled with an hour average. Hour-only partial-window
+drills snap outward and disclose effective bounds/bucket; plain
+`top('database')` keeps minute precision through per-database `minute_counts`.
 
 ## Investigation flow
 
 ### 1. Is it bad now, or was it a spike?
 
 ```sql
-select * from ash.periods();
+select period, source, bucket, buckets_with_data,
+       avg_aas, peak_aas, p99_aas
+from ash.periods();
 ```
 
 Typical output:
@@ -160,7 +170,8 @@ load.
 ### 2. What kind of wait dominated?
 
 ```sql
-select *
+select key, query_text, source, avg_aas, peak_aas, p99_aas,
+       backend_seconds, pct
 from ash.top(
   'wait_event_type',
   since => now() - interval '5 minutes',

--- a/blueprints/AAS_API.md
+++ b/blueprints/AAS_API.md
@@ -27,18 +27,17 @@ removed (see §8). Sampling, storage, rollups, and admin/lifecycle functions
    `database`) are uniform named parameters across all readers.
 4. **Data ≠ presentation.** Data functions return typed columns only. ASCII
    bars/charts/colors live in exactly two human helpers (§5).
-5. **Source honesty (the trust property).** Every reader auto-selects its data
-   source by window (raw → `rollup_1m` → `rollup_1h`). Every over-time /
-   breakdown reader (`periods`, `aas`, `timeline`, `top`, `chart`) reports the
-   chosen source in a `source` column (`samples` reads raw only, by definition).
-   `compare()` and `report()`
-   surface provenance differently: `compare()` has no `source` column — a window
-   with no coverage yields NULL columns plus a NOTICE (never a fake zero
-   baseline, see §2.5); `report()` returns `jsonb`, so its source and coverage
-   live inside a `coverage` object (`coverage.source`, always `rollup_1m` — see
-   §4). When a request *cannot* be answered (the event↔query tie needs raw
-   samples but the window exceeds raw retention), the reader raises a clear
-   exception naming the boundary — never a silent empty result.
+5. **Source honesty (the trust property).** Aggregate readers auto-select their
+   data source by window (raw → `rollup_1m` → `rollup_1h`). `periods`, `aas`,
+   `timeline`, and `top` report it in `source`; `compare` reports
+   `source_1` / `source_2`; `report` embeds it in `coverage.source`; and the
+   presentation-only `chart` emits a `NOTICE` when hour grain widens its plan.
+   `samples` is raw-only by definition, while `summary` includes a `source`
+   metric. `rollup_1h_flat` marks legacy/incomplete detail only when a
+   minute-capable plan must degrade to hour grain. When a request *cannot* be
+   answered (the event↔query tie needs raw samples but the window exceeds raw
+   retention), the reader raises a clear exception naming the boundary—never a
+   silent empty result.
 6. **Self-describing.** Every function carries a catalog `comment` stating the
    unit, the column contract, and the recommended next call, so an AI agent
    can navigate via `\df+` / `obj_description()` alone.
@@ -77,50 +76,74 @@ bucket          interval    default '1 minute'  -- sub-bucket grain for peak/p99
 
 `peak_aas` = max per-`bucket` AAS over the window; `p99_aas` =
 `percentile_cont(0.99)` over the same per-bucket AAS values, **zero-filled**
-for buckets with no activity within data coverage. Buckets with *no data*
-(sampler off) are excluded from percentiles and reported via coverage columns.
+for stored buckets with no matching activity. When retained grain is coarser
+than the requested `bucket`, both extrema are **NULL** rather than presenting
+an hour average as a minute peak/percentile. A missing stored row does not say
+why it is missing: `take_sample()` writes no row when no backend qualifies, so
+a sampled-idle minute and an uncovered minute are indistinguishable until
+sampling cadence/coverage is persisted by issue #137.
 
 ### 2.1 `ash.periods(until timestamptz default null)`
 
-One row per standard trailing window (1m, 5m, 1h, 1d, 1w, 1mo) ending at
-`until` (default `now()`). The zero-argument "start here" call.
+One row per standard trailing window (1m, 5m, 1h, 1d, 1w, 1mo) requested to
+end at `until` (default `now()`). The zero-argument "start here" call.
 
 Returns:
 `(period text, period_start timestamptz, period_end timestamptz, source text,
 bucket interval, buckets_with_data bigint, avg_aas numeric, peak_aas numeric,
 p99_aas numeric)`
 
-`buckets_with_data` (renamed from `minutes_with_data`, to match `aas()`) counts
-the covered buckets at the grain named by the new `bucket` column. Every
-unfiltered read is minute-grain after the `rollup_1h` seam fix, so `bucket` is
-always `'1 minute'` here — `43200 @ 1 minute` reads without cross-referencing.
+`period_start` / `period_end` are the effective returned bounds. They normally
+match the requested trailing window, but an hour-only plan snaps them outward,
+so `period_end` can be later than `until`. `buckets_with_data` (renamed from
+`minutes_with_data`, to match `aas()`) counts covered buckets at the effective
+grain named by `bucket`. Genuine `rollup_1h.minute_counts` keeps unfiltered
+reads at one minute. If a minute-capable plan encounters legacy/incomplete
+detail, the row reports `source = 'rollup_1h_flat'`, `bucket = '1 hour'`, and
+NULL sub-hour extrema instead of synthesizing 60 measured minutes.
 
 ### 2.2 `ash.aas(since, until, wait_event_type, wait_event, query_id, database, bucket)`
 
-Scalar load summary for one window, optionally filtered. This is also the
-US-4 "leaf summary": `ash.aas(wait_event => 'DataFileRead')` returns that
-event's avg/peak/p99.
+Scalar load summary for one effective window, optionally filtered. This is
+also the US-4 "leaf summary":
+`ash.aas(wait_event => 'DataFileRead')` returns that event's avg/peak/p99.
 
 Returns one row:
 `(period_start timestamptz, period_end timestamptz, source text,
+effective_bucket interval,
 buckets_expected bigint, buckets_with_data bigint,
 avg_aas numeric, peak_aas numeric, p99_aas numeric, backend_seconds numeric)`
 
 The per-`bucket` peak/p99 buckets are **calendar-aligned** (§2.3): floored to
-`bucket` on UTC/epoch boundaries, not anchored to `since`, so the same
-absolute window always yields the same buckets regardless of when the call runs.
+`bucket` on UTC/epoch boundaries, not anchored to `since`. `effective_bucket`
+reports the bucket actually used after retained-grain widening. A bucket that
+is not a whole multiple of retained grain is rounded **up** to the next
+multiple, so the effective bucket is never finer than the request. On
+`rollup_1h`, wait/query-filtered reads have only hour arrays; partial bounds
+snap outward to complete hours and are disclosed by `period_start` /
+`period_end`. Their average/backend seconds are exact for that disclosed
+effective window, while
+peak/p99 requested below one hour are NULL. Unfiltered/database-only reads use
+per-`(ts, datid)` `minute_counts` when valid. Legacy/incomplete detail reports
+`rollup_1h_flat` and follows the honest hour-grain behavior.
 
 ### 2.3 `ash.timeline(since, until, bucket interval default null, filters…)`
 
 Time series. `bucket => null` auto-selects grain by span (≤ 6 h → 1 minute,
 ≤ 7 d → 1 hour, else 1 day) and is always safely bounded. Emits a row for
-**every** bucket in the window: `data_points = 0` with null AAS marks
-"no data", distinguishing it from measured-zero load. When ranking buckets to
-find a spike, use `order by peak_aas desc nulls last` — no-data buckets carry
-null `peak_aas`, which sorts first under a bare `desc` and would hide the spike. An **explicit**
+**every** effective bucket in the window. `data_points = 0` with NULL AAS
+means there is no stored observation. It cannot distinguish sampled-idle from
+uncovered time because both states store no row; issue #137 tracks the
+coverage/cadence architecture needed to do that. When ranking buckets to find
+a spike, use `order by peak_aas desc nulls last` — no-observation buckets carry
+NULL `peak_aas`, which sorts first under a bare `desc` and would hide the spike. An **explicit**
 `bucket` that would emit more than 100 000 buckets (e.g. `'1 minute'` over a
 year) raises rather than materialize an unbounded result — pass `null` for
 auto-grain or a coarser bucket.
+
+An explicit bucket that is not a whole multiple of retained grain widens to
+the next multiple (for example, 90 seconds over minute data becomes 2
+minutes); it never rounds down to a finer bucket.
 
 **Calendar-aligned buckets.** `bucket_start` is floored to `bucket` on
 UTC/epoch boundaries — a 1-minute bucket starts on the minute, a 1-hour bucket
@@ -135,11 +158,14 @@ Returns:
 `(bucket_start timestamptz, source text, data_points bigint,
 avg_aas numeric, peak_aas numeric, p99_aas numeric)`
 
-`peak_aas` and `p99_aas` are **per-minute even on `rollup_1h`-backed windows**:
-`rollup_hour()` preserves per-minute totals in `rollup_1h.minute_counts`, so a
-long-window read keeps minute-grain extremes across the hourly seam (US-6). The
-only case that returns null `p99_aas` is a **wait/query-filtered**
-`rollup_1h`-backed bucket, where the surviving grain is the hour.
+`peak_aas` and `p99_aas` stay per-minute on a `rollup_1h`-backed window only
+when valid `minute_counts` preserves that detail. Wait/query-filtered reads and
+legacy/incomplete `rollup_1h_flat` reads have hour grain. Their partial bounds
+and sub-hour buckets widen outward to complete hours instead of falling
+through to unavailable `rollup_1m`; both extrema are NULL when the requested
+bucket is finer than that retained grain. `data_points` counts retained-grain
+rows contributing to the effective bucket (for example, about 60 minute rows
+in a covered one-hour bucket), not one-second samples.
 
 ### 2.4 `ash.top(dimension text, since, until, filters…, n int default 10, bucket, order_by text default 'avg')`
 
@@ -157,17 +183,21 @@ select * from ash.top('query_id', wait_event => 'DataFileRead');          -- US-
 
 Returns:
 `(key text, query_text text, source text,
+period_start timestamptz, period_end timestamptz, effective_bucket interval,
 avg_aas numeric, peak_aas numeric, p99_aas numeric,
 backend_seconds numeric, pct numeric)`
 
-- **Every row carries avg + peak + p99** (US-3). `pct` is the row's share of
-  the window's total AAS.
+- Every row carries exact avg/backend seconds and `pct`, plus effective bounds
+  and bucket. `peak_aas` / `p99_aas` are NULL when retained grain exceeds the
+  requested bucket.
 - **`order_by` ∈ `'avg' | 'peak' | 'p99'` (default `'avg'`)** picks the
   ranking metric applied **before** the `n` cut. This is how you surface a
   spiky-but-low-average row: `order_by => 'peak'` ranks by the per-bucket
   spike, so a query that spiked for one minute outranks steady background rows
-  that a mean would keep on top (the spike-first triage recipe). An unknown
-  value raises `ash.top: unknown order_by <v>; use avg|peak|p99`.
+  that a mean would keep on top (the spike-first triage recipe). If the
+  requested extreme is unavailable, ordering falls back to average/total
+  rather than ranking on an undisclosed hourly surrogate. An unknown value
+  raises `ash.top: unknown order_by <v>; use avg|peak|p99`.
 - `query_text` is non-null only for `dimension = 'query_id'` with
   pg_stat_statements present **and** a caller that can read other roles'
   pgss text — i.e. holding `pg_read_all_stats` (e.g. via `pg_monitor`
@@ -195,11 +225,12 @@ backend_seconds numeric, pct numeric)`
     the exact boundary to move to: *"…raw retention starts at `<ts>` but the
     requested window starts at `<ts>`. Narrow the window to start at or after
     `<ts>` … or drill without the query/event tie."*
-- On a `rollup_1h`-backed window (`source = rollup_1h`), each row's `peak_aas`
-  and `p99_aas` collapse to **hour** grain — the per-dimension arrays are stored
-  per hour, so a one-minute spike is averaged into its hour. For a minute-grain
-  peak over a long window use `ash.timeline()`, whose unfiltered `peak_aas` stays
-  per-minute across the `rollup_1h` seam (§2.3).
+- On a `rollup_1h`-backed window, wait/query dimensions and any database
+  breakdown carrying a wait/query filter have hour grain. Partial bounds snap
+  outward, and minute-requested extrema are NULL. Plain
+  `dimension = 'database'` is the exception: `minute_counts` is stored per
+  `(ts, datid)`, so it retains minute precision. Legacy/incomplete database
+  detail reports `rollup_1h_flat`.
 
 ### 2.5 `ash.compare(since_1, until_1, since_2, until_2, dimension text default null, n int default 10, filters…, bucket)`
 
@@ -208,7 +239,10 @@ dimension: top rows by `abs(avg_delta)` (full outer across the two windows —
 a wait/query present in only one window still appears).
 
 Returns:
-`(key text, query_text text,
+`(key text, query_text text, source_1 text, source_2 text,
+period_start_1 timestamptz, period_end_1 timestamptz,
+period_start_2 timestamptz, period_end_2 timestamptz,
+effective_bucket_1 interval, effective_bucket_2 interval,
 avg_aas_1 numeric, avg_aas_2 numeric, avg_delta numeric,
 peak_aas_1 numeric, peak_aas_2 numeric,
 p99_aas_1 numeric, p99_aas_2 numeric,
@@ -222,6 +256,13 @@ pct_1 numeric, pct_2 numeric)`
   the empty window and pointing at `ash.status()`. This is consistent across
   **both** modes: the overall row and every per-dimension row. Within a
   *covered* window, an absent key is a true zero.
+- **Grain visibility.** `source_1` / `source_2`, effective bounds, and
+  `effective_bucket_1` / `_2` are constant per window. If the two retained
+  read grains differ, both peak values and both p99 values are NULL as
+  incomparable—even when an explicit coarse request makes the two effective
+  bucket labels equal. Exact averages and `avg_delta` remain available.
+  Different physical sources can still be comparable—for example valid
+  `rollup_1h.minute_counts` and `rollup_1m` are both minute grain.
 - **Validation from `compare`'s own frame.** An unknown `dimension` raises
   `ash.compare: unknown dimension <v>; use wait_event_type|wait_event|query_id|database (or null for one overall row)` —
   named `ash.compare`, not `ash.top`.
@@ -372,7 +413,10 @@ pg_ash never uses it in computation.
   wait events **UNION any event that is top-1 in at least one bucket**, plus
   `Other` — so a single-bucket spike culprit always appears in the legend even
   if it never makes the window-wide top-N. Buckets are calendar-aligned exactly
-  like `ash.timeline()` (§2.3).
+  like `ash.timeline()` (§2.3). When only hour arrays can answer a partial
+  window, the chart snaps the bounds outward and the bucket up to hour grain,
+  then emits a `NOTICE` with the effective source, bounds, and bucket instead
+  of silently falling through to missing minute data.
 - `ash.summary(since, until)` — key/value overview (v1.x `activity_summary`,
   AAS units, plus top waits/queries), the human companion to `periods`.
 
@@ -393,12 +437,16 @@ function does any of that.
   `top('wait_event', query_id => …)`) and `samples` — force `raw`, because
   rollups don't preserve that association; past raw retention they raise (§1
   rule 5) rather than return empty.
-- Each reader reports the source it used in the `source` column
-  (`raw` | `rollup_1m` | `rollup_1h` | `none`). Scalar readers and `top` pick a
-  single source per result (never mixing — no double-counting); `timeline`
-  reports its source per bucket, so a long series may show different sources
-  across rows. A window with no data at all reports `source = 'none'`
-  uniformly across readers.
+- Typed aggregate readers report `source`
+  (`raw` | `rollup_1m` | `rollup_1h` | `rollup_1h_flat` | `none`);
+  `compare` reports `source_1` / `source_2`, `report` uses JSON coverage,
+  `summary` uses a key/value metric, `samples` is raw-only, and `chart`
+  discloses hour-grain widening by `NOTICE`. `rollup_1h_flat` is a
+  conservative window-level marker for a minute-capable plan: at least one
+  contributing legacy or incomplete hour lacks trustworthy minute detail.
+  Scalar readers and `top` pick a single source/effective grain per result
+  (never mixing grains under one undisclosed label). A typed aggregate window
+  with no data reports `source = 'none'`.
 - `ash.status()` gains rows for `raw_retention_start`,
   `rollup_1m_retention_start`, `rollup_1h_retention_start` so callers can
   plan windows before querying.
@@ -417,9 +465,9 @@ Unchanged from [AAS_USER_STORIES.md §6](AAS_USER_STORIES.md) except:
   → `query_id`, …). Positional calls are unaffected; only callers passing
   named arguments need to update. This is a breaking change for v1.x named-arg
   callers.
-- **Performance budgets:** rollup-backed reads < 100 ms for a 1-day window;
-  raw-backed reads (incl. `report` over 1 day and US-4 leaf drills
-  over 1 hour) < 1 s on a default-config instance.
+- **Performance budgets:** rollup-backed reads (including `report`) < 100 ms
+  for a 1-day window; raw-backed US-4 leaf drills over 1 hour < 1 s on a
+  default-config instance.
 
 ## 8. Removed in 2.0
 

--- a/blueprints/AAS_API.md
+++ b/blueprints/AAS_API.md
@@ -35,9 +35,11 @@ removed (see §8). Sampling, storage, rollups, and admin/lifecycle functions
    `samples` is raw-only by definition, while `summary` includes separate
    headline and wait/query drill provenance metrics. `rollup_1h_flat` marks
    legacy/incomplete detail only when a minute-capable plan must degrade to
-   hour grain. When a request *cannot* be answered (the event↔query tie needs
-   raw samples but the window exceeds raw retention), the reader raises a
-   clear exception naming the boundary — never a silent empty result.
+   hour grain. When a request *cannot* be answered exactly (an explicit
+   `query_id` filter or an event↔query tie needs raw samples, while a coarser
+   source holds earlier history), the reader raises a clear exception naming
+   the boundary — never a silent empty result or an omitted query reported as
+   zero.
 6. **Self-describing.** Every function carries a catalog `comment` stating the
    unit, the column contract, and the recommended next call, so an AI agent
    can navigate via `\df+` / `obj_description()` alone.
@@ -119,13 +121,21 @@ The per-`bucket` peak/p99 buckets are **calendar-aligned** (§2.3): floored to
 reports the bucket actually used after retained-grain widening. A bucket that
 is not a whole multiple of retained grain is rounded **up** to the next
 multiple, so the effective bucket is never finer than the request. On
-`rollup_1h`, wait/query-filtered reads have only hour arrays; partial bounds
-snap outward to complete hours and are disclosed by `period_start` /
+`rollup_1h`, wait-filtered reads have only hour arrays; partial bounds snap
+outward to complete hours and are disclosed by `period_start` /
 `period_end`. Their average/backend seconds are exact for that disclosed
 effective window, while
 peak/p99 requested below one hour are NULL. Unfiltered/database-only reads use
 per-`(ts, datid)` `minute_counts` when valid. Legacy/incomplete detail reports
 `rollup_1h_flat` and follows the honest hour-grain behavior.
+
+Every explicit `query_id` filter forces raw samples because compacted
+`query_counts` cannot prove an exact count or zero. A query-only filter raises
+only when ordinary planning selects a rollup that has retained coverage in the
+requested pre-raw slice. If a young/post-reset installation has only raw data,
+or its first rollup covers only raw's first retained minute, the request reads
+its available raw rows even when the requested left edge predates the first
+sample. A wait+query tie keeps the raw-retention guard described in §2.4.
 
 ### 2.3 `ash.timeline(since, until, bucket interval default null, filters…)`
 
@@ -159,13 +169,15 @@ Returns:
 avg_aas numeric, peak_aas numeric, p99_aas numeric)`
 
 `peak_aas` and `p99_aas` stay per-minute on a `rollup_1h`-backed window only
-when valid `minute_counts` preserves that detail. Wait/query-filtered reads and
+when valid `minute_counts` preserves that detail. Wait-filtered reads and
 legacy/incomplete `rollup_1h_flat` reads have hour grain. Their partial bounds
 and sub-hour buckets widen outward to complete hours instead of falling
 through to unavailable `rollup_1m`; both extrema are NULL when the requested
 bucket is finer than that retained grain. `data_points` counts retained-grain
 rows contributing to the effective bucket (for example, about 60 minute rows
 in a covered one-hour bucket), not one-second samples.
+
+Explicit `query_id` filters follow the exact-raw rule from §2.2.
 
 ### 2.4 `ash.top(dimension text, since, until, filters…, n int default 10, bucket, order_by text default 'avg')`
 
@@ -204,33 +216,44 @@ backend_seconds numeric, pct numeric)`
   membership). A plain `grant_reader` role without it sees null even with
   pgss installed, because pgss restricts query text to the owning role.
   Degrades to null, never errors.
-- For `dimension = 'query_id'`, the unattributed bucket is a **NULL `key`**
-  (not the literal string `'unknown'`): activity whose `query_id` was not
-  captured (client not reporting a queryid, truncated, or utility /
-  idle-in-transaction work). It is real load, not an error; `compare()` pairs
-  NULL keys and `summary()` renders it as `(unattributed)`.
-- Combinations requiring the event↔query association
-  (`'query_id'` + `wait_event`/`wait_event_type`, or `'wait_event'` +
-  `query_id`) are answerable **only from raw samples**. Past raw retention the
-  function raises, and the message now splits by how the window sits against the
-  boundary:
-  - **Window entirely past raw retention** — the tie is unrecoverable and
-    narrowing cannot help; the message says so and points at the untied
-    aggregate readers: *"…is entirely outside raw retention (raw retention
-    starts at `<ts>`). The tie is unrecoverable for that window — narrowing it
-    will not help. Use the untied aggregate readers instead: drop either the
-    wait filter or query_id (e.g. ash.aas(), ash.timeline(), ash.top() with
-    one of the two)."*
+- For `dimension = 'query_id'`, unattributed load has a **NULL `key`** (not the
+  literal string `'unknown'`). On raw reads it is activity whose `query_id`
+  was not captured (client not reporting a queryid, truncated, or utility /
+  idle-in-transaction work). On rollup reads, `query_counts` is deliberately
+  compacted: low-volume query IDs may be omitted and hourly rows retain only a
+  top set. The NULL row is therefore the exact non-negative residual between
+  total wait counts and preserved named-query attribution. It combines
+  uncaptured and compacted-away attribution so `backend_seconds` and the
+  percentage denominator reconcile to total load. It enters ranking before
+  the `n` cut, `compare()` pairs it across windows, and `summary()` renders it
+  as `(other / unattributed)`.
+- Every explicit `query_id` filter is answerable **only from raw samples**;
+  compacted rollups cannot prove either its exact count or its absence. A
+  `query_id` breakdown combined with `wait_event`/`wait_event_type` likewise
+  needs the raw event↔query association. When coarser retained history would
+  be lost, the function raises and the message splits by how the window sits
+  against the boundary:
+  - **Window entirely past raw retention** — exact attribution is
+    unrecoverable and narrowing cannot help; the message points at an
+    unfiltered aggregate read: *"…needs exact raw query attribution … is
+    entirely outside raw retention … narrowing it will not help. Use the
+    untied aggregate readers instead: remove query_id …"*
   - **Partial overlap** (window end still inside retention) — the message names
     the exact boundary to move to: *"…raw retention starts at `<ts>` but the
     requested window starts at `<ts>`. Narrow the window to start at or after
-    `<ts>` … or drill without the query/event tie."*
+    `<ts>` … or remove query_id."*
+  - **No coarser history** — a query-only filter on a young install reads
+    available raw rows without raising merely because the requested left edge
+    predates its first sample, including when the first rollup covers only the
+    same retained minute as raw. The event↔query tie's partial-minute boundary
+    behavior remains tracked by #163.
 - On a `rollup_1h`-backed window, wait/query dimensions and any database
-  breakdown carrying a wait/query filter have hour grain. Partial bounds snap
+  breakdown carrying a wait filter have hour grain. Partial bounds snap
   outward, and minute-requested extrema are NULL. Plain
   `dimension = 'database'` is the exception: `minute_counts` is stored per
   `(ts, datid)`, so it retains minute precision. Legacy/incomplete database
-  detail reports `rollup_1h_flat`.
+  detail reports `rollup_1h_flat`. Explicit query filters never use this path;
+  they force raw.
 
 ### 2.5 `ash.compare(since_1, until_1, since_2, until_2, dimension text default null, n int default 10, filters…, bucket)`
 
@@ -263,6 +286,11 @@ pct_1 numeric, pct_2 numeric)`
   bucket labels equal. Exact averages and `avg_delta` remain available.
   Different physical sources can still be comparable — for example valid
   `rollup_1h.minute_counts` and `rollup_1m` are both minute grain.
+- **Query attribution.** An explicit `query_id` filter makes both sides raw
+  and inherits the same coarser-history guard as `aas` / `top`. An unfiltered
+  `dimension => 'query_id'` comparison may use rollups; each side includes its
+  compacted-attribution NULL residual, and the full outer join pairs those
+  NULL keys safely.
 - **Validation from `compare`'s own frame.** An unknown `dimension` raises
   `ash.compare: unknown dimension <v>; use wait_event_type|wait_event|query_id|database (or null for one overall row)` —
   named `ash.compare`, not `ash.top`.
@@ -431,18 +459,23 @@ function does any of that.
 
 ## 6. Source selection & retention metadata
 
-- **Aggregate readers** (`aas`, `timeline`, `periods`, and non-tie `top` /
+- **Aggregate readers** (`aas`, `timeline`, `periods`, and unfiltered `top` /
   `chart`) prefer `rollup_1m` for any window wider than ~1 hour that
-  `rollup_1m` fully covers — even when that window is still within raw
-  retention. Rollups are far cheaper for wide windows and just as accurate at
-  minute grain, so triage never pays the cost of decoding raw samples. `raw`
-  is used only for narrow (≤ ~1 h) windows, where it is both cheap and
-  freshest, and for windows rollups cannot cover.
-- **Leaf tie-drills** — any drill that needs the `wait_event ↔ query_id`
-  association (`top('query_id', wait_event/​wait_event_type => …)`,
-  `top('wait_event', query_id => …)`) and `samples` — force `raw`, because
-  rollups don't preserve that association; past raw retention they raise (§1
-  rule 5) rather than return empty.
+  starts at or after the earliest `rollup_1m` row — even when that window is
+  still within raw retention. Rollups are far cheaper for wide windows and
+  just as accurate at minute grain, so triage never pays the cost of decoding
+  raw samples. The separate end-watermark/completeness gap remains tracked by
+  #122. `raw` is used for narrow (≤ ~1 h) windows, where it is both cheap and
+  freshest, and for windows whose start rollups cannot reach.
+- **Exact query drills** — every explicit `query_id` filter, any query
+  breakdown that also filters `wait_event`/`wait_event_type`, and `samples`
+  force `raw`. Rollups compact query attribution and do not preserve the
+  event↔query association. When ordinary planning selects a rollup with
+  coverage in the requested pre-raw slice, these calls raise (§1 rule 5)
+  rather than return a false zero. A young query filter remains usable when
+  the first rollup covers only raw's first retained minute. Unfiltered
+  `top('query_id')` stays a fast rollup read and exposes unpreserved
+  attribution in its NULL residual.
 - Typed aggregate readers report `source`
   (`raw` | `rollup_1m` | `rollup_1h` | `rollup_1h_flat` | `none`);
   `compare` reports `source_1` / `source_2`, `report` uses JSON coverage,

--- a/blueprints/AAS_API.md
+++ b/blueprints/AAS_API.md
@@ -32,12 +32,12 @@ removed (see §8). Sampling, storage, rollups, and admin/lifecycle functions
    `timeline`, and `top` report it in `source`; `compare` reports
    `source_1` / `source_2`; `report` embeds it in `coverage.source`; and the
    presentation-only `chart` emits a `NOTICE` when hour grain widens its plan.
-   `samples` is raw-only by definition, while `summary` includes a `source`
-   metric. `rollup_1h_flat` marks legacy/incomplete detail only when a
-   minute-capable plan must degrade to hour grain. When a request *cannot* be
-   answered (the event↔query tie needs raw samples but the window exceeds raw
-   retention), the reader raises a clear exception naming the boundary—never a
-   silent empty result.
+   `samples` is raw-only by definition, while `summary` includes separate
+   headline and wait/query drill provenance metrics. `rollup_1h_flat` marks
+   legacy/incomplete detail only when a minute-capable plan must degrade to
+   hour grain. When a request *cannot* be answered (the event↔query tie needs
+   raw samples but the window exceeds raw retention), the reader raises a
+   clear exception naming the boundary — never a silent empty result.
 6. **Self-describing.** Every function carries a catalog `comment` stating the
    unit, the column contract, and the recommended next call, so an AI agent
    can navigate via `\df+` / `obj_description()` alone.
@@ -259,9 +259,9 @@ pct_1 numeric, pct_2 numeric)`
 - **Grain visibility.** `source_1` / `source_2`, effective bounds, and
   `effective_bucket_1` / `_2` are constant per window. If the two retained
   read grains differ, both peak values and both p99 values are NULL as
-  incomparable—even when an explicit coarse request makes the two effective
+  incomparable — even when an explicit coarse request makes the two effective
   bucket labels equal. Exact averages and `avg_delta` remain available.
-  Different physical sources can still be comparable—for example valid
+  Different physical sources can still be comparable — for example valid
   `rollup_1h.minute_counts` and `rollup_1m` are both minute grain.
 - **Validation from `compare`'s own frame.** An unknown `dimension` raises
   `ash.compare: unknown dimension <v>; use wait_event_type|wait_event|query_id|database (or null for one overall row)` —
@@ -419,6 +419,12 @@ pg_ash never uses it in computation.
   of silently falling through to missing minute data.
 - `ash.summary(since, until)` — key/value overview (v1.x `activity_summary`,
   AAS units, plus top waits/queries), the human companion to `periods`.
+  `period_start` / `period_end` / `source` describe the headline `aas()` plan;
+  `drill_period_start` / `drill_period_end` / `drill_source` /
+  `drill_effective_bucket` separately describe the shared wait/query `top()`
+  plan. On `rollup_1h`, the headline can retain an exact partial-hour window
+  through `minute_counts` while the dimensional drills honestly widen to
+  complete hours.
 
 Both are presentation-only: they may format, color, truncate. No data
 function does any of that.
@@ -440,13 +446,16 @@ function does any of that.
 - Typed aggregate readers report `source`
   (`raw` | `rollup_1m` | `rollup_1h` | `rollup_1h_flat` | `none`);
   `compare` reports `source_1` / `source_2`, `report` uses JSON coverage,
-  `summary` uses a key/value metric, `samples` is raw-only, and `chart`
-  discloses hour-grain widening by `NOTICE`. `rollup_1h_flat` is a
+  `summary` uses separate headline and drill key/value provenance,
+  `samples` is raw-only, and `chart` discloses hour-grain widening by
+  `NOTICE`. `rollup_1h_flat` is a
   conservative window-level marker for a minute-capable plan: at least one
   contributing legacy or incomplete hour lacks trustworthy minute detail.
   Scalar readers and `top` pick a single source/effective grain per result
   (never mixing grains under one undisclosed label). A typed aggregate window
-  with no data reports `source = 'none'`.
+  with no covered rows keeps its planned source and reports
+  `buckets_with_data = 0`; `source = 'none'` means all aggregate source tables
+  are globally empty, not merely that this particular window is uncovered.
 - `ash.status()` gains rows for `raw_retention_start`,
   `rollup_1m_retention_start`, `rollup_1h_retention_start` so callers can
   plan windows before querying.

--- a/blueprints/AAS_EXAMPLES.md
+++ b/blueprints/AAS_EXAMPLES.md
@@ -16,7 +16,9 @@ Conventions that repeat below, stated once:
 - v1.5 units vary by function — `samples` (raw readers), `backend_seconds`
   (rollup readers), active sessions (chart only). 2.0 always answers in AAS
   (`avg_aas` / `peak_aas` / `p99_aas`), with `backend_seconds` as a secondary
-  column and a `source` column showing where the data came from.
+  column. Typed aggregate readers expose source columns; `report`, `summary`,
+  `samples`, and `chart` disclose provenance in the forms documented in
+  [AAS_API.md](AAS_API.md).
 
 ---
 
@@ -47,21 +49,24 @@ columns, p99 so a spike is legible without a second call:
 select * from ash.periods();
 ```
 ```
- period | period_start        | source    | bucket   | buckets_with_data | avg_aas | peak_aas | p99_aas
---------+---------------------+-----------+----------+-------------------+---------+----------+---------
- 1m     | 2026-07-04 14:44:00 | raw       | 00:01:00 |                 1 |    2.9  |     3.4  |    3.4
- 5m     | 2026-07-04 14:40:00 | raw       | 00:01:00 |                 5 |    3.1  |     4.0  |    3.9
- 1h     | 2026-07-04 13:45:00 | rollup_1m | 00:01:00 |                60 |    3.2  |    41.0  |   12.7
- 1d     | 2026-07-03 14:45:00 | rollup_1m | 00:01:00 |              1440 |    2.8  |    41.0  |    6.3
- 1w     | 2026-06-27 14:45:00 | rollup_1h | 00:01:00 |             10080 |    2.6  |    41.0  |    5.9
- 1mo    | 2026-06-04 14:45:00 | rollup_1h | 00:01:00 |             43200 |    2.5  |    41.0  |    5.7
+ period | period_start        | period_end          | source    | bucket   | buckets_with_data | avg_aas | peak_aas | p99_aas
+--------+---------------------+---------------------+-----------+----------+-------------------+---------+----------+---------
+ 1m     | 2026-07-04 14:44:00 | 2026-07-04 14:45:00 | raw       | 00:01:00 |                 1 |    2.9  |     3.4  |    3.4
+ 5m     | 2026-07-04 14:40:00 | 2026-07-04 14:45:00 | raw       | 00:01:00 |                 5 |    3.1  |     4.0  |    3.9
+ 1h     | 2026-07-04 13:45:00 | 2026-07-04 14:45:00 | rollup_1m | 00:01:00 |                60 |    3.2  |    41.0  |   12.7
+ 1d     | 2026-07-03 14:45:00 | 2026-07-04 14:45:00 | rollup_1m | 00:01:00 |              1440 |    2.8  |    41.0  |    6.3
+ 1w     | 2026-06-27 14:45:00 | 2026-07-04 14:45:00 | rollup_1h | 00:01:00 |             10080 |    2.6  |    41.0  |    5.9
+ 1mo    | 2026-06-04 14:45:00 | 2026-07-04 14:45:00 | rollup_1h | 00:01:00 |             43200 |    2.5  |    41.0  |    5.7
 ```
 
 Reading: the last hour peaked at 41 while the average is 3.2 — a spike, not a
 sustained shift. (`ash.summary()` renders the same picture for humans.) The
 `buckets_with_data` column (renamed from `minutes_with_data`) counts covered
-buckets at the grain named by `bucket` — always `1 minute` post-`rollup_1h`
-seam fix, so `43200` reads as `43200 @ 1 minute`.
+buckets at the effective grain named by `bucket`. Valid `minute_counts` keeps
+one-minute grain; a legacy/incomplete hour reports `rollup_1h_flat` and an
+hour bucket instead of synthetic minute observations. `period_start` /
+`period_end` are effective bounds, so an hour-only row can snap outward and
+end after the requested `until`.
 
 ## 2. Locate
 
@@ -86,17 +91,21 @@ select * from ash.wait_timeline('30 minutes', '5 minutes');
 no-data rows:
 
 ```sql
-select * from ash.timeline(since => '2026-07-04 14:15', until => '2026-07-04 14:45');
+select * from ash.timeline(
+  since => '2026-07-04 14:15',
+  until => '2026-07-04 14:45',
+  bucket => interval '5 minutes'
+);
 ```
 ```
     bucket_start     | source | data_points | avg_aas | peak_aas | p99_aas
 ---------------------+--------+-------------+---------+----------+---------
- 2026-07-04 14:15:00 | raw    |         300 |    2.7  |     3.6  |    3.5
- 2026-07-04 14:20:00 | raw    |         300 |    2.9  |     4.1  |    4.0
- 2026-07-04 14:25:00 | raw    |           0 |         |          |          -- sampler was off: no data ≠ zero
- 2026-07-04 14:30:00 | raw    |         300 |   24.8  |    41.0  |   39.2   -- ← the spike
- 2026-07-04 14:35:00 | raw    |         300 |    6.1  |    11.4  |   10.9
- 2026-07-04 14:40:00 | raw    |         300 |    3.0  |     3.8  |    3.7
+ 2026-07-04 14:15:00 | raw    |           5 |    2.7  |     3.6  |    3.5
+ 2026-07-04 14:20:00 | raw    |           5 |    2.9  |     4.1  |    4.0
+ 2026-07-04 14:25:00 | raw    |           0 |         |          |          -- no stored observation; idle vs uncovered needs #137
+ 2026-07-04 14:30:00 | raw    |           5 |   24.8  |    41.0  |   39.2   -- ← the spike
+ 2026-07-04 14:35:00 | raw    |           5 |    6.1  |    11.4  |   10.9
+ 2026-07-04 14:40:00 | raw    |           5 |    3.0  |     3.8  |    3.7
 ```
 
 `bucket_start` labels are **calendar-aligned** (floored to `bucket` on
@@ -128,8 +137,17 @@ select * from ash.top_by_type('15 minutes');
 **After** — same drill, AAS + peak + p99 per row (a spiky class is
 distinguishable from a steadily-busy one), no presentation columns:
 
+The projection keeps the tables readable; `select *` additionally returns
+`period_start`, `period_end`, and `effective_bucket`.
+
 ```sql
-select * from ash.top('wait_event_type', since => '2026-07-04 14:30', until => '2026-07-04 14:45');
+select key, query_text, source, avg_aas, peak_aas, p99_aas,
+       backend_seconds, pct
+from ash.top(
+  'wait_event_type',
+  since => '2026-07-04 14:30',
+  until => '2026-07-04 14:45'
+);
 ```
 ```
  key    | query_text | source | avg_aas | peak_aas | p99_aas | backend_seconds |  pct
@@ -159,8 +177,14 @@ select * from ash.top_waits('15 minutes', 5);
 separate function:
 
 ```sql
-select * from ash.top('wait_event', wait_event_type => 'IO',
-                      since => '2026-07-04 14:30', until => '2026-07-04 14:45');
+select key, query_text, source, avg_aas, peak_aas, p99_aas,
+       backend_seconds, pct
+from ash.top(
+  'wait_event',
+  wait_event_type => 'IO',
+  since => '2026-07-04 14:30',
+  until => '2026-07-04 14:45'
+);
 ```
 ```
  key              | query_text | source | avg_aas | peak_aas | p99_aas | backend_seconds |  pct
@@ -189,7 +213,14 @@ select * from ash.top_queries('15 minutes', 3);
 **After:**
 
 ```sql
-select * from ash.top('query_id', since => '2026-07-04 14:30', until => '2026-07-04 14:45', n => 3);
+select key, query_text, source, avg_aas, peak_aas, p99_aas,
+       backend_seconds, pct
+from ash.top(
+  'query_id',
+  since => '2026-07-04 14:30',
+  until => '2026-07-04 14:45',
+  n => 3
+);
 ```
 ```
        key         |            query_text             | source | avg_aas | peak_aas | p99_aas | backend_seconds |  pct
@@ -221,8 +252,14 @@ select * from ash.query_waits(8231004856741017, '15 minutes');
 **After:**
 
 ```sql
-select * from ash.top('wait_event', query_id => 8231004856741017,
-                      since => '2026-07-04 14:30', until => '2026-07-04 14:45');
+select key, query_text, source, avg_aas, peak_aas, p99_aas,
+       backend_seconds, pct
+from ash.top(
+  'wait_event',
+  query_id => 8231004856741017,
+  since => '2026-07-04 14:30',
+  until => '2026-07-04 14:45'
+);
 ```
 
 Same shape as every other `top()` call — `avg_aas 11.2, peak_aas 26.0, p99_aas 24.9` for `IO:DataFileRead`, etc.
@@ -313,8 +350,8 @@ select * from ash.timeline(since => now() - interval '7 days');  -- auto: 1-hour
 ```
     bucket_start     |  source   | data_points | avg_aas | peak_aas | p99_aas
 ---------------------+-----------+-------------+---------+----------+---------
- 2026-06-28 00:00:00 | rollup_1h |        3600 |    2.1  |     4.0  |
- 2026-06-28 01:00:00 | rollup_1h |        3600 |    2.3  |     5.0  |
+ 2026-06-28 00:00:00 | rollup_1h |          60 |    2.1  |     4.0  |    3.8
+ 2026-06-28 01:00:00 | rollup_1h |          60 |    2.3  |     5.0  |    4.6
  …
 ```
 
@@ -324,7 +361,9 @@ same query ranking, over rollups, in AAS.
 ### `samples_by_database(...)` → `ash.top('database', …)`
 
 ```sql
-select * from ash.top('database', since => now() - interval '1 hour');
+select key, query_text, source, avg_aas, peak_aas, p99_aas,
+       backend_seconds, pct
+from ash.top('database', since => now() - interval '1 hour');
 ```
 ```
    key    | query_text | source    | avg_aas | peak_aas | p99_aas | backend_seconds |  pct
@@ -351,24 +390,31 @@ select * from ash.samples(n => 3, wait_event => 'DataFileRead');
 select * from ash.aas();   -- the last hour, one row
 ```
 ```
-    period_start     |      period_end      | source    | buckets_expected | buckets_with_data | avg_aas | peak_aas | p99_aas | backend_seconds
----------------------+----------------------+-----------+------------------+-------------------+---------+----------+---------+-----------------
- 2026-07-04 13:45:00 | 2026-07-04 14:45:00  | rollup_1m |               60 |                59 |    3.2  |    41.0  |   12.7  |           11520
+    period_start     |      period_end      | source    | effective_bucket | buckets_expected | buckets_with_data | avg_aas | peak_aas | p99_aas | backend_seconds
+---------------------+----------------------+-----------+------------------+------------------+-------------------+---------+----------+---------+-----------------
+ 2026-07-04 13:45:00 | 2026-07-04 14:45:00  | rollup_1m | 00:01:00         |               60 |                59 |    3.2  |    41.0  |   12.7  |           11520
 ```
 
 ### `ash.compare()` — before/after a deploy
 
 ```sql
-select * from ash.compare(since_1 => '2026-07-04 14:00', until_1 => '2026-07-04 14:30',    -- baseline
-                          since_2 => '2026-07-04 14:30', until_2 => '2026-07-04 15:00',    -- after deploy
-                          dimension => 'wait_event');
+select key, source_1, source_2, effective_bucket_1, effective_bucket_2,
+       avg_aas_1, avg_aas_2, avg_delta,
+       peak_aas_1, peak_aas_2, p99_aas_1, p99_aas_2, pct_1, pct_2
+from ash.compare(
+  since_1 => '2026-07-04 14:00',
+  until_1 => '2026-07-04 14:30',    -- baseline
+  since_2 => '2026-07-04 14:30',
+  until_2 => '2026-07-04 15:00',    -- after deploy
+  dimension => 'wait_event'
+);
 ```
 ```
-        key         | avg_aas_1 | avg_aas_2 | avg_delta | peak_aas_1 | peak_aas_2 | p99_aas_1 | p99_aas_2 | pct_1 | pct_2
---------------------+-----------+-----------+-----------+------------+------------+-----------+-----------+-------+-------
- IO:DataFileRead    |      1.1  |     14.0  |    +12.9  |       2.0  |      31.0  |      1.9  |     29.8  |  34.4 |  55.4
- Lock:transactionid |      0.2  |      4.6  |     +4.4  |       1.0  |      12.0  |      0.9  |     11.2  |   6.3 |  18.4
- CPU*               |      1.7  |      3.8  |     +2.1  |       3.0  |       6.0  |      2.8  |      5.7  |  53.1 |  14.9
+        key         | source_1   | source_2   | effective_bucket_1 | effective_bucket_2 | avg_aas_1 | avg_aas_2 | avg_delta | peak_aas_1 | peak_aas_2 | p99_aas_1 | p99_aas_2 | pct_1 | pct_2
+--------------------+------------+------------+--------------------+--------------------+-----------+-----------+-----------+------------+------------+-----------+-----------+-------+-------
+ IO:DataFileRead    | rollup_1m  | rollup_1m  | 00:01:00           | 00:01:00           |      1.1  |     14.0  |    +12.9  |       2.0  |      31.0  |      1.9  |     29.8  |  34.4 |  55.4
+ Lock:transactionid | rollup_1m  | rollup_1m  | 00:01:00           | 00:01:00           |      0.2  |      4.6  |     +4.4  |       1.0  |      12.0  |      0.9  |     11.2  |   6.3 |  18.4
+ CPU*               | rollup_1m  | rollup_1m  | 00:01:00           | 00:01:00           |      1.7  |      3.8  |     +2.1  |       3.0  |       6.0  |      2.8  |      5.7  |  53.1 |  14.9
 ```
 
 ### `ash.report()` — one JSON load report per period (machine ingest)
@@ -460,9 +506,12 @@ select * from ash.timeline(since => now() - interval '6 hours') order by peak_aa
 
 ### (c) Recurring peak hours (capacity / US-6)
 
-`rollup_1h.minute_counts` preserves per-minute extremes across the hourly seam,
-so `peak_aas` stays honest over weeks. Group hourly buckets by hour-of-day to
-find the recurring hot hours:
+Valid `rollup_1h.minute_counts` preserves per-minute extremes across the
+hourly seam, so `peak_aas` stays honest over weeks. Legacy/incomplete flat
+hours return NULL extremes only when the requested bucket is below their
+retained one-hour grain; an explicit one-hour bucket can report honest
+hour-level extrema. Group supported hourly buckets by hour-of-day to find the
+recurring hot hours:
 
 ```sql
 select extract(hour from bucket_start) as hod, max(peak_aas) as peak

--- a/blueprints/AAS_EXAMPLES.md
+++ b/blueprints/AAS_EXAMPLES.md
@@ -18,7 +18,9 @@ Conventions that repeat below, stated once:
   (`avg_aas` / `peak_aas` / `p99_aas`), with `backend_seconds` as a secondary
   column. Typed aggregate readers expose source columns; `report`, `summary`,
   `samples`, and `chart` disclose provenance in the forms documented in
-  [AAS_API.md](AAS_API.md).
+  [AAS_API.md](AAS_API.md). `summary` uses separate headline and wait/query
+  drill source/bounds metrics because the two plans can have different
+  effective windows.
 
 ---
 
@@ -60,7 +62,9 @@ select * from ash.periods();
 ```
 
 Reading: the last hour peaked at 41 while the average is 3.2 — a spike, not a
-sustained shift. (`ash.summary()` renders the same picture for humans.) The
+sustained shift. (`ash.summary()` renders the same picture for humans and
+labels a widened wait/query plan with `drill_source`, `drill_period_start`,
+`drill_period_end`, and `drill_effective_bucket`.) The
 `buckets_with_data` column (renamed from `minutes_with_data`) counts covered
 buckets at the effective grain named by `bucket`. Valid `minute_counts` keeps
 one-minute grain; a legacy/incomplete hour reports `rollup_1h_flat` and an

--- a/blueprints/AAS_EXAMPLES.md
+++ b/blueprints/AAS_EXAMPLES.md
@@ -237,6 +237,20 @@ from ash.top(
 (pg_stat_statements execution metrics no longer ride along — join on
 `query_id` yourself when you want them.)
 
+For rollup-backed windows, named rows are compacted query attribution: minute
+thresholds can omit low-volume IDs and hourly rows retain a top set. A
+NULL-key row carries the uncaptured plus compacted-away residual, so the query
+breakdown still reconciles to total load. The residual participates in the
+`n` cut; request enough rows when you need every preserved ID plus the
+residual.
+
+Filtering for one concrete `query_id` always uses raw samples, because a
+missing rollup entry cannot distinguish zero from an omitted ID. If a coarser
+source holds earlier history, the filter raises rather than discard it. A
+young install with no older rollup history still reads its available raw rows
+even when the default window begins before the first sample, including after
+the first rollup covers only the same retained minute as raw.
+
 ## 4. Leaf (the drill v1.x could only half-do)
 
 ### `query_waits(query_id, …)` → `ash.top('wait_event', query_id => …)`
@@ -303,29 +317,28 @@ And if you ask for a window whose raw samples are gone, you get an error, not
 an empty table — and the message differs by how the window sits against the
 raw-retention boundary.
 
-**Window entirely past raw retention** — the tie is gone for good; narrowing
-cannot recover it, so the error says so and redirects to the untied aggregate
-readers:
+**Window entirely past raw retention** — exact query attribution is gone for
+good; narrowing cannot recover it, so the error says so and redirects to an
+unfiltered aggregate read:
 
 ```
-ERROR:  pg_ash: this drill needs the raw wait<->query tie, but the requested
+ERROR:  pg_ash: this drill needs exact raw query attribution, but the requested
         window (2026-06-28 00:00:00+00 to 2026-06-28 01:00:00+00) is entirely
         outside raw retention (raw retention starts at 2026-07-03 00:00:00+00).
-        The tie is unrecoverable for that window — narrowing it will not help.
-        Use the untied aggregate readers instead: drop either the wait filter
-        or query_id (e.g. ash.aas(), ash.timeline(), ash.top() with one of
-        the two).
+        Exact query attribution is unrecoverable for that window — narrowing
+        it will not help. Use the untied aggregate readers instead: remove
+        query_id (or drop the wait filter when drilling queries by wait).
 ```
 
 **Partial overlap** — the window end is still inside retention, so the error
 names the exact boundary to move the start to:
 
 ```
-ERROR:  pg_ash: this drill needs raw samples; raw retention starts at
-        2026-07-03 00:00:00+00 but the requested window starts at
+ERROR:  pg_ash: this drill needs exact raw query attribution; raw retention
+        starts at 2026-07-03 00:00:00+00 but the requested window starts at
         2026-07-02 23:00:00+00. Narrow the window to start at or after
         2026-07-03 00:00:00+00 (the window end is still inside raw retention),
-        or drill without the query/event tie.
+        or remove query_id.
 ```
 
 ## 5. Long windows (rollup readers)

--- a/blueprints/AAS_USER_STORIES.md
+++ b/blueprints/AAS_USER_STORIES.md
@@ -133,8 +133,9 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   5. Callable by the least-privilege reader role, and degrades gracefully when pg_stat_statements is absent.
 - **Primary API:** cross-cutting across the whole family.
 - **Coverage:** ✅ Covered by design — typed aggregate readers expose `source`
-  fields, while `report` uses JSON coverage, `summary` a metric, `chart` a
-  planning `NOTICE`, and `samples` is raw-only; retention rows live in
+  fields, while `report` uses JSON coverage, `summary` has separate headline
+  and wait/query drill provenance metrics, `chart` a planning `NOTICE`, and
+  `samples` is raw-only; retention rows live in
   `ash.status()`, with a raise-don't-return-empty rule for unanswerable drills
   ([AAS_API.md §5–§6](AAS_API.md)).
 - **Drivable from the catalog alone.** pg_ash self-documents in-DB, which is what

--- a/blueprints/AAS_USER_STORIES.md
+++ b/blueprints/AAS_USER_STORIES.md
@@ -78,7 +78,8 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   1. Returns one row per time bucket (bucket size configurable).
   2. Includes `peak_aas` per bucket (not just `avg_aas`), so short spikes are not averaged away; orderable by peak to surface the worst buckets.
   3. Auto-selects rollup granularity by span — per-minute for short spans, per-hour for long spans — and reaches back across the relevant rollup retention.
-  4. Distinguishes "no data" buckets from "zero load" buckets.
+  4. Marks buckets with no stored observation; sampled-idle and uncovered
+     time remain indistinguishable until issue #137 persists cadence/coverage.
 - **Primary API:** `ash.timeline(since, until, bucket)`.
 - **Coverage:** ✅ Covered by design ([AAS_API.md §2.3](AAS_API.md)); adds per-bucket `p99_aas` and explicit no-data rows.
 
@@ -131,7 +132,11 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   4. Self-describing catalog comments (`obj_description`) covering the term, the columns, and the recommended next call.
   5. Callable by the least-privilege reader role, and degrades gracefully when pg_stat_statements is absent.
 - **Primary API:** cross-cutting across the whole family.
-- **Coverage:** ✅ Covered by design — `source` column on every reader, retention rows in `ash.status()`, and the raise-don't-return-empty rule for unanswerable drills ([AAS_API.md §5–§6](AAS_API.md)).
+- **Coverage:** ✅ Covered by design — typed aggregate readers expose `source`
+  fields, while `report` uses JSON coverage, `summary` a metric, `chart` a
+  planning `NOTICE`, and `samples` is raw-only; retention rows live in
+  `ash.status()`, with a raise-don't-return-empty rule for unanswerable drills
+  ([AAS_API.md §5–§6](AAS_API.md)).
 - **Drivable from the catalog alone.** pg_ash self-documents in-DB, which is what
   lets an agent navigate it without external docs: `COMMENT ON SCHEMA ash` names
   the reader entry points and the reader-vs-ops split, and **every** function —
@@ -154,7 +159,10 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
   2. Per-bucket `peak_aas` (and ideally `p99_aas`) preserved at hour/day grain.
   3. Works to the limit of `rollup_1h` retention and signals that horizon.
 - **Primary API:** `ash.timeline` over long spans.
-- **Coverage:** ✅ Covered — auto `rollup_1h` selection; `rollup_1h.minute_counts` preserves per-minute totals, so unfiltered/database-filtered long windows report exact minute-grain `peak_aas` and non-null `p99_aas` (seam-consistent with `rollup_1m`); `p99_aas` is null only for wait/query-filtered `rollup_1h`-backed buckets (hour grain).
+- **Coverage:** ✅ Covered — auto `rollup_1h` selection; valid
+  `rollup_1h.minute_counts` preserves unfiltered/database-only minute totals.
+  Wait/query dimensions and legacy/incomplete `rollup_1h_flat` data retain
+  hour grain and NULL extrema requested below that grain.
 
 ### US-7 — Before/after comparison
 
@@ -196,7 +204,7 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
 | US-2 Locate | `timeline` | ✅ | — |
 | US-3 Drill | `top(dimension, filters…)` | ✅ | — |
 | US-4 Leaf | `aas(event…)` + `top('query_id', event…)` | ✅ | — |
-| US-5 Programmatic | whole family (`source` column, retention in `status()`) | ✅ | — |
+| US-5 Programmatic | whole family (explicit provenance, retention in `status()`) | ✅ | — |
 | US-6 Capacity | `timeline` (long span) | ✅ | — |
 | US-7 Before/after | `compare` | ✅ | — |
 | US-8 Load report | `report` | ✅ | — |
@@ -210,7 +218,10 @@ These apply to every story above.
 
 - **Unit consistency.** AAS is the primary unit (`avg_aas` / `peak_aas` / `p99_aas`); `backend_seconds` may appear as a secondary column. No third unit.
 - **Percentile definition.** `p99_aas` = the 99th percentile of per-sub-bucket AAS. The sub-bucket grain is a parameter (default `'1 minute'`). `peak_aas` is the max over the same sub-buckets.
-- **Raw-vs-rollup honesty (trust property).** Any reader auto-selects its source by window; when a requested drill or window cannot be answered (rollup can't tie event→query; window exceeds retention), it signals this explicitly rather than returning a silent empty/partial result.
+- **Raw-vs-rollup honesty (trust property).** Aggregate readers select or
+  declare their source by window; when a requested drill or window cannot be
+  answered (rollup can't tie event→query; window exceeds retention), it signals
+  this explicitly rather than returning a silent empty/partial result.
 - **Time addressing convention (2.0).** Every reader takes `since timestamptz default null` (→ `now() - '1 hour'`) and `until timestamptz default null` (→ `now()`). The v1.x `f(p_interval)` / `f_at(p_start, p_end)` twin convention is dropped — 2.0 breaks compat, and the single convention halves the surface. ([AAS_API.md §1](AAS_API.md))
 - **Naming.** Function and column names use full domain terms — no abbreviations in user-facing names. Drill dimensions and filters spell out `wait_event_type` / `wait_event` / `query_id` / `database`, as the `dimension` values and parameter names of `top`. The on-CPU class is spelled `CPU*` — the asterisk marks "on CPU *or* uninstrumented wait" and must not be dropped.
 - **Dual audience.** Data functions are typed and presentation-free; ASCII bars/charts live only in dedicated rendering helpers.

--- a/blueprints/AAS_USER_STORIES.md
+++ b/blueprints/AAS_USER_STORIES.md
@@ -93,7 +93,10 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
 - **Acceptance criteria:**
   1. Breakdown by `wait_event_type` over an absolute window, with each member's `pct` of total activity.
   2. Breakdown by `wait_event`, filterable to a single `wait_event_type` (the drill-in from level 1).
-  3. Breakdown by `query_id`, with `query_text` when pg_stat_statements is present (and degrading to `query_id` only otherwise).
+  3. Breakdown by `query_id`, with `query_text` when pg_stat_statements is
+     present (and degrading to `query_id` only otherwise). Unfiltered rollup
+     reads expose compacted-away attribution as a NULL residual; filtering an
+     exact `query_id` forces raw.
   4. **Every breakdown row carries `avg_aas`, `peak_aas`, AND `p99_aas`** — not avg alone — so a spiky member is distinguishable from a steadily-busy one.
   5. The doc/comment is explicit that the deeper event→query tie is NOT recoverable from rollups (see US-4).
 - **Primary API:** `ash.top(dimension, …)` — one function; the drill levels are `top('wait_event_type')` → `top('wait_event', wait_event_type => …)` → `top('query_id', …)`.
@@ -163,7 +166,8 @@ and US-8 (machine load-report ingest) are cross-cutting or extension stories.
 - **Coverage:** ✅ Covered — auto `rollup_1h` selection; valid
   `rollup_1h.minute_counts` preserves unfiltered/database-only minute totals.
   Wait/query dimensions and legacy/incomplete `rollup_1h_flat` data retain
-  hour grain and NULL extrema requested below that grain.
+  hour grain and NULL extrema requested below that grain. Explicit query
+  filters force raw samples for exact attribution.
 
 ### US-7 — Before/after comparison
 
@@ -220,9 +224,11 @@ These apply to every story above.
 - **Unit consistency.** AAS is the primary unit (`avg_aas` / `peak_aas` / `p99_aas`); `backend_seconds` may appear as a secondary column. No third unit.
 - **Percentile definition.** `p99_aas` = the 99th percentile of per-sub-bucket AAS. The sub-bucket grain is a parameter (default `'1 minute'`). `peak_aas` is the max over the same sub-buckets.
 - **Raw-vs-rollup honesty (trust property).** Aggregate readers select or
-  declare their source by window; when a requested drill or window cannot be
-  answered (rollup can't tie event→query; window exceeds retention), it signals
-  this explicitly rather than returning a silent empty/partial result.
+  declare their source by window. Rollup query breakdowns expose
+  compacted-away attribution as a NULL residual, while exact `query_id`
+  filters and event→query ties force raw. When coarser retained history makes
+  an exact drill impossible, or a window exceeds all retention, the reader
+  signals this explicitly rather than returning a silent empty/partial result.
 - **Time addressing convention (2.0).** Every reader takes `since timestamptz default null` (→ `now() - '1 hour'`) and `until timestamptz default null` (→ `now()`). The v1.x `f(p_interval)` / `f_at(p_start, p_end)` twin convention is dropped — 2.0 breaks compat, and the single convention halves the surface. ([AAS_API.md §1](AAS_API.md))
 - **Naming.** Function and column names use full domain terms — no abbreviations in user-facing names. Drill dimensions and filters spell out `wait_event_type` / `wait_event` / `query_id` / `database`, as the `dimension` values and parameter names of `top`. The on-CPU class is spelled `CPU*` — the asterisk marks "on CPU *or* uninstrumented wait" and must not be dropped.
 - **Dual audience.** Data functions are typed and presentation-free; ASCII bars/charts live only in dedicated rendering helpers.

--- a/blueprints/SPEC.md
+++ b/blueprints/SPEC.md
@@ -466,8 +466,9 @@ Row count depends only on sampling frequency, not backend count. Size scales wit
 - Respect config flag: `include_bg_workers`
 - Store `active_count` per row — total sampled backends for this datid+tick
 - **No row for zero activity:** If a database has zero matching backends in a
-  tick, no row is emitted. Gaps in the time series for a specific `datid` mean
-  "no active or idle-in-transaction sessions during those ticks" — not data loss.
+  tick, no row is emitted. The stored state therefore cannot distinguish an
+  observed idle tick from missing sampler coverage; issue #137 tracks
+  persistent cadence/coverage.
 - Performance: select only needed columns, filter early on `state` and
   `backend_type` to minimize shared memory reads
 - **Error handling:** Per-row `BEGIN ... EXCEPTION WHEN OTHERS` around

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -189,6 +189,7 @@ begin
         'rollup_minute',
         '_color_on', '_wait_color', '_reset', '_bar',
         '_pick_source', '_pick_source_agg', '_raise_tie_retention',
+        '_minute_counts_valid', '_rollup_1h_has_flat',
         '_grain_counts', '_grain_by',
         'timeline', 'compare', '_pgss_query_text',
         '_hr_top_events', '_hr_top_queryids',
@@ -2663,12 +2664,11 @@ create table if not exists ash.rollup_1h (
   minute_counts   int4[],            -- 60-slot per-minute total activity counts:
                                      -- element i = sum of wait_counts counts of the
                                      -- rollup_1m row at ts + (i-1)*60; NULL element =
-                                     -- no rollup_1m row for that minute. Preserves the
-                                     -- true minute-grain AAS distribution so long
-                                     -- (rollup_1h-backed) windows report the exact
-                                     -- per-minute peak_aas / p99_aas. NULL column =
-                                     -- legacy pre-2.0 row (readers fall back to the
-                                     -- flat hour average for such hours).
+                                     -- no stored rollup_1m row for that minute.
+                                     -- A valid array preserves minute-grain totals.
+                                     -- NULL/invalid column = legacy or incomplete
+                                     -- detail; readers use one disclosed hour-grain
+                                     -- datum instead of synthesizing 60 observations.
   primary key (ts, datid)
 );
 
@@ -2677,31 +2677,88 @@ alter table ash.rollup_1h
   add column if not exists minute_counts int4[];
 
 /*
+ * A minute_counts array is usable only when all 60 slots are represented and
+ * its non-NULL elements preserve the exact hourly activity total. NULL slots
+ * can be legitimate because the storage model writes no row for both an idle
+ * minute and an uncovered minute (#137); equality, not physical row count, is
+ * the strongest invariant the stored data can prove.
+ */
+create or replace function ash._minute_counts_valid(
+  minute_counts int4[],
+  wait_counts int4[]
+)
+returns boolean
+language sql
+immutable
+set search_path = pg_catalog, ash
+as $$
+  select coalesce(
+    cardinality(minute_counts) = 60
+    and (
+      select coalesce(sum(minute_count), 0)
+      from unnest(minute_counts) as minute_count
+    ) = (
+      select coalesce(sum(wait_counts[pos + 1]), 0)
+      from generate_subscripts(wait_counts, 1) as pos
+      where pos % 2 = 1
+    ),
+    false
+  )
+$$;
+
+/*
  * Upgrade backfill: reconstruct minute_counts for legacy rollup_1h rows whose
  * hour is still covered by rollup_1m (per-minute detail survives there for
- * rollup_1m_retention_days). Older hours keep minute_counts NULL and readers
- * fall back to the flat hour average — a lower bound, never a wrong spike.
- * Idempotent: only touches rows where minute_counts is still NULL.
+ * rollup_1m_retention_days). A candidate is accepted only when it preserves
+ * the hourly total. Older hours and partial candidates that fail that
+ * invariant keep minute_counts NULL and readers disclose hour grain. Re-apply
+ * also repairs partial arrays written by earlier 2.0 beta installers.
  */
 update ash.rollup_1h as rollup_hour
-set minute_counts = (
-  select array_agg(minute_total.total order by minute_series.idx)
-  from generate_series(0, 59) as minute_series(idx)
-  left join lateral (
-    select (select coalesce(sum(rollup_min.wait_counts[sub + 1]), 0)::int4
-            from generate_subscripts(rollup_min.wait_counts, 1) as sub
-            where sub % 2 = 1) as total
-    from ash.rollup_1m as rollup_min
-    where rollup_min.datid = rollup_hour.datid
-      and rollup_min.ts = rollup_hour.ts + minute_series.idx * 60
-  ) as minute_total on true
+set minute_counts = null
+where rollup_hour.minute_counts is not null
+  and not ash._minute_counts_valid(
+    rollup_hour.minute_counts,
+    rollup_hour.wait_counts
+  );
+
+with candidates as (
+  select
+    rollup_hour.ts,
+    rollup_hour.datid,
+    rollup_hour.wait_counts,
+    (
+      select array_agg(minute_total.total order by minute_series.idx)
+      from generate_series(0, 59) as minute_series(idx)
+      left join lateral (
+        select (
+          select coalesce(sum(rollup_min.wait_counts[sub + 1]), 0)::int4
+          from generate_subscripts(rollup_min.wait_counts, 1) as sub
+          where sub % 2 = 1
+        ) as total
+        from ash.rollup_1m as rollup_min
+        where rollup_min.datid = rollup_hour.datid
+          and rollup_min.ts = rollup_hour.ts + minute_series.idx * 60
+      ) as minute_total on true
+    ) as minute_counts
+  from ash.rollup_1h as rollup_hour
+  where rollup_hour.minute_counts is null
+    and exists (
+      select
+      from ash.rollup_1m as rollup_min
+      where rollup_min.datid = rollup_hour.datid
+        and rollup_min.ts >= rollup_hour.ts
+        and rollup_min.ts < rollup_hour.ts + 3600
+    )
 )
-where rollup_hour.minute_counts is null
-  and exists (
-    select from ash.rollup_1m as rollup_min
-    where rollup_min.datid = rollup_hour.datid
-      and rollup_min.ts >= rollup_hour.ts
-      and rollup_min.ts < rollup_hour.ts + 3600
+update ash.rollup_1h as rollup_hour
+set minute_counts = candidates.minute_counts
+from candidates
+where rollup_hour.ts = candidates.ts
+  and rollup_hour.datid = candidates.datid
+  and ash._minute_counts_valid(
+    candidates.minute_counts,
+    candidates.wait_counts
   );
 
 /*
@@ -3431,12 +3488,12 @@ $$;
 /*
  * The minimal AAS surface (issue #113, blueprints/AAS_API.md): seven data
  * functions (periods, aas, timeline, top, compare, samples, report) and two
- * render helpers (chart, summary). AAS = Average Active Sessions. Every reader
- * auto-selects its data source by window (raw -> rollup_1m -> rollup_1h),
- * reports it in a `source` column, and raises rather than returning a silent
- * empty result when a wait<->query drill exceeds raw retention. Internal
- * workhorses (_grain_counts / _grain_by) and the retention helpers back the
- * whole family.
+ * render helpers (chart, summary). AAS = Average Active Sessions. Aggregate
+ * readers auto-select raw -> rollup_1m -> rollup_1h; typed readers expose a
+ * source column, compare exposes both sources, report embeds provenance in
+ * JSON, and chart emits a planning NOTICE when hour grain widens its request.
+ * Unanswerable wait<->query drills raise past raw retention. Internal
+ * workhorses (_grain_counts / _grain_by) and retention helpers back the family.
  */
 
 /*
@@ -3471,6 +3528,39 @@ stable
 set search_path = pg_catalog, ash
 as $$
   select ash.ts_to_timestamptz(min(ts)) from ash.rollup_1h
+$$;
+
+/*
+ * True when a rollup_1h window overlaps legacy or incomplete minute detail.
+ * Minute-capable readers then conservatively use hour grain for the whole
+ * window and publish source = rollup_1h_flat.
+ */
+create or replace function ash._rollup_1h_has_flat(
+  start_ts int4,
+  end_ts int4,
+  database name default null
+)
+returns boolean
+language sql
+stable
+set search_path = pg_catalog, ash
+as $$
+  select exists (
+    select
+    from ash.rollup_1h as rollup_hour
+    left join pg_database as db
+      on db.oid = rollup_hour.datid
+    where rollup_hour.ts::bigint < end_ts::bigint
+      and rollup_hour.ts::bigint + 3600 > start_ts::bigint
+      and (
+        _rollup_1h_has_flat.database is null
+        or db.datname = _rollup_1h_has_flat.database
+      )
+      and not ash._minute_counts_valid(
+        rollup_hour.minute_counts,
+        rollup_hour.wait_counts
+      )
+  )
 $$;
 
 /*
@@ -3600,8 +3690,9 @@ $$;
  * 'raw' supports the wait<->query tie (both a wait filter and query_id);
  * the rollup sources cannot and must not be asked for it (caller routes such
  * requests to 'raw'). grain_secs is 60 (raw / rollup_1m / rollup_1h_minutes)
- * or 3600 (rollup_1h). 'rollup_1h_minutes' is the internal minute-grain view
- * of rollup_1h (unfiltered / database-filtered only) via minute_counts.
+ * or 3600 (rollup_1h and legacy/incomplete rollup_1h detail).
+ * 'rollup_1h_minutes' is the internal minute-capable view used for
+ * unfiltered/database-only totals; invalid detail emits one hourly row.
  */
 create or replace function ash._grain_counts(
   start_ts int4,
@@ -3696,10 +3787,9 @@ begin
      * arrays, so peak_aas / p99_aas survive the rollup_1m -> rollup_1h seam
      * (same values a rollup_1m read of the window would produce). Totals only:
      * wait/query filters need the hour-grain arrays, so callers route filtered
-     * reads to 'rollup_1h'. Legacy pre-2.0 rows (minute_counts is null)
-     * flatten to their hour average per covered minute — a lower bound for the
-     * peak and an "hour was flat" assumption for percentiles, never an
-     * invented spike.
+     * reads to 'rollup_1h'. Legacy/incomplete arrays emit one exact hourly
+     * datum: callers detect that case up front, normalize the whole window to
+     * hour grain, and publish source = rollup_1h_flat.
      */
     if wait_event_type is not null or wait_event is not null
        or query_id is not null then
@@ -3709,31 +3799,36 @@ begin
     return query
     with hours as (
       select rollup_hour.ts, rollup_hour.datid,
-             rollup_hour.minute_counts, rollup_hour.wait_counts
+             rollup_hour.minute_counts, rollup_hour.wait_counts,
+             ash._minute_counts_valid(
+               rollup_hour.minute_counts,
+               rollup_hour.wait_counts
+             ) as has_minutes
       from ash.rollup_1h as rollup_hour
       where rollup_hour.ts >= start_ts - 3540 and rollup_hour.ts < end_ts
         and (v_datid is null or rollup_hour.datid = v_datid)
     ),
     mins as (
       select (hours.ts + (minute_elem.idx - 1) * 60)::int4 as mts,
-             minute_elem.mc::numeric as cnt
+             minute_elem.mc::numeric as cnt,
+             60::int4 as grain_secs
       from hours
       cross join lateral unnest(hours.minute_counts)
         with ordinality as minute_elem(mc, idx)
-      where hours.minute_counts is not null and minute_elem.mc is not null
+      where hours.has_minutes and minute_elem.mc is not null
       union all
-      select (hours.ts + minute_series.idx * 60)::int4,
+      select hours.ts,
              (select coalesce(sum(hours.wait_counts[pos + 1]), 0)
               from generate_subscripts(hours.wait_counts, 1) as pos
-              where pos % 2 = 1)::numeric / 60.0
+              where pos % 2 = 1)::numeric,
+             3600::int4
       from hours
-      cross join generate_series(0, 59) as minute_series(idx)
-      where hours.minute_counts is null
+      where not hours.has_minutes
     )
-    select mins.mts, sum(mins.cnt)::numeric, 60
+    select mins.mts, sum(mins.cnt)::numeric, mins.grain_secs
     from mins
     where mins.mts >= start_ts and mins.mts < end_ts
-    group by mins.mts;
+    group by mins.mts, mins.grain_secs;
 
   elsif source = 'rollup_1h' then
     if query_id is not null then
@@ -3835,6 +3930,7 @@ returns table (
   period_start timestamptz,
   period_end timestamptz,
   source text,
+  effective_bucket interval,
   buckets_expected bigint,
   buckets_with_data bigint,
   avg_aas numeric,
@@ -3853,17 +3949,20 @@ declare
   v_start_ts int4;
   v_end_ts int4;
   v_bucket_secs int4;
+  v_requested_bucket_secs numeric;
   v_grain_secs int4;
   v_si numeric;
   v_source text;
   v_read_source text;
   v_tie boolean;
+  v_extrema_supported boolean;
   v_raw_start timestamptz;
 begin
-  v_bucket_secs := extract(epoch from bucket)::int4;
-  if v_bucket_secs is null or v_bucket_secs < 60 then
+  v_requested_bucket_secs := extract(epoch from bucket);
+  if v_requested_bucket_secs is null or v_requested_bucket_secs < 60 then
     raise exception 'bucket must be at least 1 minute, got %', bucket;
   end if;
+  v_bucket_secs := ceil(v_requested_bucket_secs)::int4;
 
   v_start_ts := (ash.ts_from_timestamptz(v_from) / 60) * 60;
   v_end_ts := (ash.ts_from_timestamptz(v_to) / 60) * 60;
@@ -3892,17 +3991,34 @@ begin
   v_read_source := v_source;
 
   /*
-   * rollup_1h preserves the per-minute totals (minute_counts), so the
-   * unfiltered / database-only read keeps minute grain across the
-   * rollup_1m -> rollup_1h seam: peak_aas / p99_aas stay per-minute and match
-   * what a rollup_1m-backed window of the same span reports (wider window
-   * never shrinks the peak). Wait/query filters still need the hour-grain
-   * arrays. The reported source stays 'rollup_1h' — that is what was read.
+   * Genuine minute_counts keep unfiltered/database-only reads at minute
+   * grain. If any contributing hour has legacy/incomplete detail, disclose
+   * rollup_1h_flat and conservatively plan the whole window at hour grain.
+   * Wait/query filters always need the hour-grain arrays.
    */
   if v_source = 'rollup_1h' and wait_event_type is null
      and wait_event is null and query_id is null then
     v_read_source := 'rollup_1h_minutes';
-    v_grain_secs := 60;
+    if ash._rollup_1h_has_flat(v_start_ts, v_end_ts, database) then
+      v_source := 'rollup_1h_flat';
+      v_grain_secs := 3600;
+    else
+      v_grain_secs := 60;
+    end if;
+  end if;
+
+  /*
+   * Hour arrays describe whole [ts, ts + 1 hour) intervals. Expand partial
+   * requested bounds to complete hours so totals are never divided by a
+   * clipped duration (#130). period_start/period_end disclose these effective
+   * bounds.
+   */
+  if v_grain_secs = 3600 then
+    v_start_ts := ((v_start_ts::bigint / 3600) * 3600)::int4;
+    v_end_ts := least(
+      ((v_end_ts::bigint + 3599) / 3600) * 3600,
+      2147483647
+    )::int4;
   end if;
 
   /*
@@ -3911,10 +4027,14 @@ begin
    * minute grain) misaligns with the grain rows — a bucket then holds up to
    * ceil(bucket/grain) whole grains of activity but divides by its own
    * (shorter) coverage, fabricating AAS peaks that no grain ever reached.
-   * Integer division snaps down to the nearest grain multiple.
+   * Round UP to the nearest grain multiple so the effective bucket is never
+   * finer than the caller requested.
    */
-  v_bucket_secs := (greatest(v_bucket_secs, v_grain_secs) / v_grain_secs)
-                   * v_grain_secs;
+  v_bucket_secs := (
+    (greatest(v_bucket_secs, v_grain_secs)::bigint + v_grain_secs - 1)
+    / v_grain_secs * v_grain_secs
+  )::int4;
+  v_extrema_supported := v_grain_secs <= v_requested_bucket_secs;
 
   return query
   /*
@@ -3951,14 +4071,21 @@ begin
     ash.ts_to_timestamptz(v_start_ts),
     ash.ts_to_timestamptz(v_end_ts),
     v_source,
+    v_bucket_secs * interval '1 second',
     (((v_end_ts - 1) / v_bucket_secs)
       - (v_start_ts / v_bucket_secs) + 1)::bigint,
     (select count(*) from per_bucket)::bigint,
     round((select coalesce(sum(cnt), 0) from per_bucket) * v_si
           / (v_end_ts - v_start_ts)::numeric, 2),
-    coalesce(round((select max(aas) from bucket_aas), 2), 0),
-    coalesce(round((select percentile_cont(0.99) within group (order by aas)
-                    from bucket_aas)::numeric, 2), 0),
+    case when v_extrema_supported then
+      coalesce(round((select max(aas) from bucket_aas), 2), 0)
+    end,
+    case when v_extrema_supported then
+      coalesce(round((
+        select percentile_cont(0.99) within group (order by aas)
+        from bucket_aas
+      )::numeric, 2), 0)
+    end,
     round((select coalesce(sum(cnt), 0) from per_bucket) * v_si, 2);
 end;
 $$;
@@ -3967,10 +4094,10 @@ $$;
  * AAS time series: one row per bucket across the whole window (no-data buckets
  * included with data_points = 0 and null AAS). bucket => null auto-selects
  * grain by span. peak_aas is the worst underlying grain within the bucket;
- * p99_aas is the 99th percentile of the per-grain AAS. Unfiltered /
- * database-filtered reads are minute-grain on every source (rollup_1h keeps
- * per-minute totals in minute_counts); p99_aas is null only for wait/query-
- * filtered rollup_1h-backed buckets, which remain hour-grain.
+ * p99_aas is the 99th percentile of the per-grain AAS. Genuine rollup_1h
+ * minute_counts preserve minute grain for unfiltered/database-only reads.
+ * Hour-grain reads widen partial bounds and buckets; peak/p99 are NULL when
+ * that retained grain exceeds the bucket the caller requested.
  */
 create or replace function ash.timeline(
   since timestamptz default null,
@@ -4001,11 +4128,13 @@ declare
   v_end_ts int4;
   v_span int4;
   v_bucket_secs int4;
+  v_requested_bucket_secs numeric;
   v_grain_secs int4;
   v_si numeric;
   v_source text;
   v_read_source text;
   v_tie boolean;
+  v_extrema_supported boolean;
   v_raw_start timestamptz;
 begin
   v_start_ts := (ash.ts_from_timestamptz(v_from) / 60) * 60;
@@ -4021,23 +4150,13 @@ begin
       when v_span <= 6 * 3600 then 60
       when v_span <= 7 * 86400 then 3600
       else 86400 end;
+    v_requested_bucket_secs := v_bucket_secs;
   else
-    v_bucket_secs := extract(epoch from bucket)::int4;
-    if v_bucket_secs is null or v_bucket_secs < 60 then
+    v_requested_bucket_secs := extract(epoch from bucket);
+    if v_requested_bucket_secs < 60 then
       raise exception 'bucket must be at least 1 minute, got %', bucket;
     end if;
-  end if;
-
-  /*
-   * Bound the emitted-row count: one row per bucket, so an explicit fine
-   * bucket over a very wide window can blow up (1 minute over 10 years ~ 5M
-   * rows). Cap at 100000 and tell the caller to widen bucket.
-   */
-  if (v_span::bigint / v_bucket_secs) > 100000 then
-    raise exception
-      'ash.timeline: % buckets exceeds the 100000-row cap; use a coarser '
-      'bucket (or bucket => null for auto grain)',
-      (v_span::bigint / v_bucket_secs);
+    v_bucket_secs := ceil(v_requested_bucket_secs)::int4;
   end if;
 
   v_si := ash._sample_interval_secs();
@@ -4055,29 +4174,50 @@ begin
     if v_source = 'rollup_1h' and wait_event_type is null
        and wait_event is null and query_id is null then
       /*
-       * rollup_1h preserves per-minute totals (minute_counts), so the
-       * unfiltered / database-only read keeps minute grain: peak_aas /
-       * p99_aas stay per-minute across the rollup_1m -> rollup_1h seam, and
-       * sub-hour buckets work. The reported source stays 'rollup_1h'.
+       * Genuine minute_counts keep the unfiltered/database-only read at
+       * minute grain. Any legacy/incomplete contributing hour makes the
+       * whole effective read hour-grain and is disclosed in the source.
        */
       v_read_source := 'rollup_1h_minutes';
-    elsif v_source = 'rollup_1h' and v_bucket_secs < 3600 then
-      /*
-       * filtered sub-hour buckets need minute grain; the hour-grain arrays
-       * cannot supply it, so fall back to rollup_1m (older buckets simply
-       * show no data). 'none' (a truly empty window) is left as-is and
-       * reported honestly.
-       */
-      v_source := 'rollup_1m';
+      if ash._rollup_1h_has_flat(v_start_ts, v_end_ts, database) then
+        v_source := 'rollup_1h_flat';
+        v_grain_secs := 3600;
+      else
+        v_grain_secs := 60;
+      end if;
+    else
+      v_grain_secs := case when v_source = 'rollup_1h' then 3600 else 60 end;
     end if;
     v_read_source := coalesce(v_read_source, v_source);
-    v_grain_secs := case when v_read_source = 'rollup_1h' then 3600 else 60 end;
   end if;
   v_read_source := coalesce(v_read_source, v_source);
+
+  if v_grain_secs = 3600 then
+    v_start_ts := ((v_start_ts::bigint / 3600) * 3600)::int4;
+    v_end_ts := least(
+      ((v_end_ts::bigint + 3599) / 3600) * 3600,
+      2147483647
+    )::int4;
+  end if;
+
   -- snap to a whole grain multiple (see ash.aas): a non-multiple bucket
   -- misaligns with the grain rows and fabricates per-bucket AAS.
-  v_bucket_secs := (greatest(v_bucket_secs, v_grain_secs) / v_grain_secs)
-                   * v_grain_secs;
+  v_bucket_secs := (
+    (greatest(v_bucket_secs, v_grain_secs)::bigint + v_grain_secs - 1)
+    / v_grain_secs * v_grain_secs
+  )::int4;
+  v_extrema_supported := v_grain_secs <= v_requested_bucket_secs;
+  v_span := v_end_ts - v_start_ts;
+
+  /*
+   * Bound the emitted-row count after widening to the effective grain.
+   */
+  if (v_span::bigint / v_bucket_secs) > 100000 then
+    raise exception
+      'ash.timeline: % buckets exceeds the 100000-row cap; use a coarser '
+      'bucket (or bucket => null for auto grain)',
+      (v_span::bigint / v_bucket_secs);
+  end if;
 
   return query
   /*
@@ -4090,11 +4230,24 @@ begin
    * calendar hour/UTC-day label. The first bucket_start may therefore precede
    * since; edge buckets divide by their in-window coverage only.
    */
-  with grains as (
-    select (grain_row.ts / v_bucket_secs) * v_bucket_secs as bstart,
-           (grain_row.cnt * v_si / v_grain_secs) as gaas, grain_row.cnt
+  with source_grains as (
+    select grain_row.ts, grain_row.cnt
     from ash._grain_counts(v_start_ts, v_end_ts, v_read_source,
            wait_event_type, wait_event, query_id, database) as grain_row
+  ),
+  normalized_grains as (
+    select
+      (source_grains.ts / v_grain_secs) * v_grain_secs as gstart,
+      sum(source_grains.cnt) as cnt
+    from source_grains
+    group by 1
+  ),
+  grains as (
+    select
+      (normalized_grains.gstart / v_bucket_secs) * v_bucket_secs as bstart,
+      normalized_grains.cnt * v_si / v_grain_secs as gaas,
+      normalized_grains.cnt
+    from normalized_grains
   ),
   agg as (
     select bstart, count(*) as n, sum(cnt) as cnt, max(gaas) as peak,
@@ -4117,14 +4270,10 @@ begin
       round(agg.cnt * v_si / (least(buckets.bstart + v_bucket_secs, v_end_ts)
                             - greatest(buckets.bstart, v_start_ts)), 2)
     end,
-    case when agg.n > 0 then round(agg.peak, 2) end,
-    /*
-     * p99 stays null only for the genuinely hour-grain read (filtered
-     * rollup_1h): a percentile over hour averages would masquerade as a
-     * minute percentile. The unfiltered rollup_1h read is minute-grain via
-     * minute_counts and reports a real per-minute p99.
-     */
-    case when agg.n > 0 and v_read_source <> 'rollup_1h' then
+    case when agg.n > 0 and v_extrema_supported then
+      round(agg.peak, 2)
+    end,
+    case when agg.n > 0 and v_extrema_supported then
       round(agg.p99::numeric, 2)
     end
   from buckets
@@ -4134,17 +4283,15 @@ end;
 $$;
 
 /*
- * Standard trailing windows for triage: one summary row per window ending at
- * until. Each window delegates to ash.aas(), which auto-selects its source
- * (short windows may read raw for the freshest partial minute; the wide
- * windows read rollups). peak_aas/p99_aas are per-minute (worst /
- * 99th-percentile minute), which is what capacity triage wants, and
- * buckets_with_data is a true count of covered buckets at the grain named by
- * the bucket column — always '1 minute' here (unfiltered reads are
- * minute-grain on every source, incl. rollup_1h via minute_counts), exposed
- * per row so "43200 buckets" reads as "43200 @ 1 minute" without
- * cross-referencing. After the arithmetic-bucketing fix this is cheap even
- * for the 1-month window (~90ms for the whole call on a month of rollups).
+ * Standard trailing windows for triage: one summary row per window requested
+ * to end at until. Each delegates to ash.aas(), whose effective bounds may
+ * snap outward at hour grain. Short windows may read raw for the freshest
+ * partial minute; wide windows read rollups. Genuine minute_counts keep
+ * minute-grain peak/p99;
+ * legacy flat hours disclose an effective hour bucket and NULL unsupported
+ * extremes. buckets_with_data is a true count at the grain named by bucket.
+ * After the arithmetic-bucketing fix this is cheap even for the 1-month
+ * window (~90ms for the whole call on a month of rollups).
  */
 create or replace function ash.periods(
   until timestamptz default null
@@ -4182,7 +4329,7 @@ as $$
     aas_result.period_start,
     aas_result.period_end,
     aas_result.source,
-    interval '1 minute',
+    aas_result.effective_bucket,
     aas_result.buckets_with_data,
     aas_result.avg_aas,
     aas_result.peak_aas,
@@ -4311,6 +4458,77 @@ begin
     return;
   end if;
 
+  if source = 'rollup_1h_minutes' then
+    /*
+     * minute_counts is stored per (hour, datid), so a plain database
+     * breakdown retains the same minute precision as an unfiltered scalar
+     * read. Wait/query filters cannot be reconstructed from this total.
+     */
+    if dimension <> 'database'
+       or wait_event_type is not null
+       or wait_event is not null
+       or query_id is not null then
+      raise exception
+        'ash._grain_by: rollup_1h_minutes supports only an unfiltered '
+        'database dimension';
+    end if;
+
+    return query
+    with hours as (
+      select
+        rollup_hour.ts,
+        rollup_hour.datid,
+        coalesce(
+          db.datname::text,
+          '<oid:' || rollup_hour.datid || '>'
+        ) as database_key,
+        rollup_hour.minute_counts,
+        rollup_hour.wait_counts,
+        ash._minute_counts_valid(
+          rollup_hour.minute_counts,
+          rollup_hour.wait_counts
+        ) as has_minutes
+      from ash.rollup_1h as rollup_hour
+      left join pg_database as db
+        on db.oid = rollup_hour.datid
+      where rollup_hour.ts >= start_ts - 3540
+        and rollup_hour.ts < end_ts
+        and (v_datid is null or rollup_hour.datid = v_datid)
+    ),
+    grains as (
+      select
+        (hours.ts + (minute_elem.idx - 1) * 60)::int4 as mts,
+        hours.database_key,
+        minute_elem.mc::numeric as cnt
+      from hours
+      cross join lateral unnest(hours.minute_counts)
+        with ordinality as minute_elem(mc, idx)
+      where hours.has_minutes
+        and minute_elem.mc is not null
+      union all
+      select
+        hours.ts,
+        hours.database_key,
+        (
+          select coalesce(sum(hours.wait_counts[pos + 1]), 0)
+          from generate_subscripts(hours.wait_counts, 1) as pos
+          where pos % 2 = 1
+        )::numeric
+      from hours
+      where not hours.has_minutes
+    )
+    select
+      grains.mts,
+      grains.database_key,
+      null::bigint,
+      sum(grains.cnt)::numeric
+    from grains
+    where grains.mts >= start_ts
+      and grains.mts < end_ts
+    group by grains.mts, grains.database_key;
+    return;
+  end if;
+
   v_tbl := case
     when source = 'rollup_1h' then 'ash.rollup_1h'
     else 'ash.rollup_1m'
@@ -4419,6 +4637,9 @@ returns table (
   key text,
   query_text text,
   source text,
+  period_start timestamptz,
+  period_end timestamptz,
+  effective_bucket interval,
   avg_aas numeric,
   peak_aas numeric,
   p99_aas numeric,
@@ -4439,10 +4660,13 @@ declare
   v_start_ts int4;
   v_end_ts int4;
   v_bucket_secs int4;
+  v_requested_bucket_secs numeric;
   v_grain_secs int4;
   v_si numeric;
   v_source text;
+  v_read_source text;
   v_tie boolean;
+  v_extrema_supported boolean;
   v_raw_start timestamptz;
   v_has_pgss boolean := false;
   v_pgss_schema text;
@@ -4458,10 +4682,11 @@ begin
   if order_by not in ('avg', 'peak', 'p99') then
     raise exception 'ash.top: unknown order_by %; use avg|peak|p99', order_by;
   end if;
-  v_bucket_secs := extract(epoch from bucket)::int4;
-  if v_bucket_secs is null or v_bucket_secs < 60 then
+  v_requested_bucket_secs := extract(epoch from bucket);
+  if v_requested_bucket_secs is null or v_requested_bucket_secs < 60 then
     raise exception 'bucket must be at least 1 minute, got %', bucket;
   end if;
+  v_bucket_secs := ceil(v_requested_bucket_secs)::int4;
 
   v_start_ts := (ash.ts_from_timestamptz(v_from) / 60) * 60;
   v_end_ts := (ash.ts_from_timestamptz(v_to) / 60) * 60;
@@ -4489,10 +4714,42 @@ begin
                                      ash.ts_to_timestamptz(v_end_ts));
     v_grain_secs := case when v_source = 'rollup_1h' then 3600 else 60 end;
   end if;
+  v_read_source := v_source;
+
+  /*
+   * minute_counts is per (hour, datid), so a plain database breakdown keeps
+   * minute precision. Database reads with wait/query filters and every other
+   * rollup_1h dimension use the hourly arrays.
+   */
+  if v_source = 'rollup_1h'
+     and dimension = 'database'
+     and wait_event_type is null
+     and wait_event is null
+     and query_id is null then
+    v_read_source := 'rollup_1h_minutes';
+    if ash._rollup_1h_has_flat(v_start_ts, v_end_ts, database) then
+      v_source := 'rollup_1h_flat';
+      v_grain_secs := 3600;
+    else
+      v_grain_secs := 60;
+    end if;
+  end if;
+
+  if v_grain_secs = 3600 then
+    v_start_ts := ((v_start_ts::bigint / 3600) * 3600)::int4;
+    v_end_ts := least(
+      ((v_end_ts::bigint + 3599) / 3600) * 3600,
+      2147483647
+    )::int4;
+  end if;
+
   -- snap to a whole grain multiple (see ash.aas): a non-multiple bucket
   -- misaligns with the grain rows and fabricates per-bucket AAS.
-  v_bucket_secs := (greatest(v_bucket_secs, v_grain_secs) / v_grain_secs)
-                   * v_grain_secs;
+  v_bucket_secs := (
+    (greatest(v_bucket_secs, v_grain_secs)::bigint + v_grain_secs - 1)
+    / v_grain_secs * v_grain_secs
+  )::int4;
+  v_extrema_supported := v_grain_secs <= v_requested_bucket_secs;
 
   /*
    * pgss presence/readability probe, schema-qualified from the catalog (#115):
@@ -4512,18 +4769,50 @@ begin
     end;
   end if;
 
-  for key, v_key_num, source, avg_aas, peak_aas, p99_aas, backend_seconds, pct in
+  for
+    key,
+    v_key_num,
+    source,
+    period_start,
+    period_end,
+    effective_bucket,
+    avg_aas,
+    peak_aas,
+    p99_aas,
+    backend_seconds,
+    pct
+  in
   /*
    * Buckets are calendar-aligned (floored to bucket relative to ash.epoch(),
    * midnight UTC), matching ash.aas()/ash.timeline(): the same absolute
    * window always yields the same bucket boundaries. Edge buckets clipped by
    * the window divide by their in-window coverage only.
    */
-  with keyed as (
-    select (grain_by_row.ts / v_bucket_secs) * v_bucket_secs as bstart,
-           grain_by_row.key, grain_by_row.key_num, grain_by_row.cnt
-    from ash._grain_by(v_start_ts, v_end_ts, v_source, dimension,
+  with source_keyed as (
+    select
+      grain_by_row.ts,
+      grain_by_row.key,
+      grain_by_row.key_num,
+      grain_by_row.cnt
+    from ash._grain_by(v_start_ts, v_end_ts, v_read_source, dimension,
            wait_event_type, wait_event, query_id, database) as grain_by_row
+  ),
+  keyed_grains as (
+    select
+      (source_keyed.ts / v_grain_secs) * v_grain_secs as gstart,
+      source_keyed.key,
+      max(source_keyed.key_num) as key_num,
+      sum(source_keyed.cnt) as cnt
+    from source_keyed
+    group by 1, source_keyed.key
+  ),
+  keyed as (
+    select
+      (keyed_grains.gstart / v_bucket_secs) * v_bucket_secs as bstart,
+      keyed_grains.key,
+      keyed_grains.key_num,
+      keyed_grains.cnt
+    from keyed_grains
   ),
   /*
    * Zero-fill frame = the sampler-covered buckets, derived from the source's
@@ -4532,10 +4821,17 @@ begin
    * with ash.aas() for the same drill. database is the only filter that
    * legitimately restricts coverage, so it is the only one passed here.
    */
-  covered as (
-    select distinct (grain_row.ts / v_bucket_secs) * v_bucket_secs as bstart
-    from ash._grain_counts(v_start_ts, v_end_ts, v_source,
+  coverage_grains as (
+    select
+      (grain_row.ts / v_grain_secs) * v_grain_secs as gstart
+    from ash._grain_counts(v_start_ts, v_end_ts, v_read_source,
            null, null, null, database) as grain_row
+    group by 1
+  ),
+  covered as (
+    select distinct
+      (coverage_grains.gstart / v_bucket_secs) * v_bucket_secs as bstart
+    from coverage_grains
   ),
   keys as (
     select keyed.key, max(keyed.key_num) as key_num, sum(keyed.cnt) as total
@@ -4554,7 +4850,8 @@ begin
    */
   top_keys as (
     select * from keys order by total desc
-    limit case when order_by = 'avg' then greatest(n, 0)
+    limit case when order_by = 'avg' or not v_extrema_supported
+          then greatest(n, 0)
           else 2147483647 end
   ),
   key_bucket_data as (
@@ -4574,15 +4871,18 @@ begin
     select key_bucket.key, key_bucket.key_num, key_bucket.total,
            round(key_bucket.total * v_si
                  / (v_end_ts - v_start_ts)::numeric, 2) as avg_aas,
-           round(max(key_bucket.bcnt * v_si
-                     / (least(key_bucket.bstart + v_bucket_secs, v_end_ts)
-                        - greatest(key_bucket.bstart, v_start_ts))), 2)
-             as peak_aas,
-           round(percentile_cont(0.99) within group (
-                   order by key_bucket.bcnt * v_si
-                     / (least(key_bucket.bstart + v_bucket_secs, v_end_ts)
-                        - greatest(key_bucket.bstart, v_start_ts)))::numeric, 2)
-             as p99_aas
+           case when v_extrema_supported then
+             round(max(key_bucket.bcnt * v_si
+                       / (least(key_bucket.bstart + v_bucket_secs, v_end_ts)
+                          - greatest(key_bucket.bstart, v_start_ts))), 2)
+           end as peak_aas,
+           case when v_extrema_supported then
+             round(percentile_cont(0.99) within group (
+                     order by key_bucket.bcnt * v_si
+                       / (least(key_bucket.bstart + v_bucket_secs, v_end_ts)
+                          - greatest(key_bucket.bstart, v_start_ts))
+                   )::numeric, 2)
+           end as p99_aas
     from key_bucket
     group by key_bucket.key, key_bucket.key_num, key_bucket.total
   )
@@ -4590,6 +4890,9 @@ begin
     per_key.key,
     per_key.key_num,
     v_source,
+    ash.ts_to_timestamptz(v_start_ts),
+    ash.ts_to_timestamptz(v_end_ts),
+    v_bucket_secs * interval '1 second',
     per_key.avg_aas,
     per_key.peak_aas,
     per_key.p99_aas,
@@ -4640,6 +4943,14 @@ create or replace function ash.compare(
 returns table (
   key text,
   query_text text,
+  source_1 text,
+  source_2 text,
+  period_start_1 timestamptz,
+  period_end_1 timestamptz,
+  period_start_2 timestamptz,
+  period_end_2 timestamptz,
+  effective_bucket_1 interval,
+  effective_bucket_2 interval,
   avg_aas_1 numeric,
   avg_aas_2 numeric,
   avg_delta numeric,
@@ -4660,6 +4971,23 @@ declare
   v_aas2 record;
   v_cov1 boolean;
   v_cov2 boolean;
+  v_from1 timestamptz := coalesce(since_1, now() - interval '1 hour');
+  v_to1 timestamptz := coalesce(until_1, now());
+  v_from2 timestamptz := coalesce(since_2, now() - interval '1 hour');
+  v_to2 timestamptz := coalesce(until_2, now());
+  v_start1 int4;
+  v_end1 int4;
+  v_start2 int4;
+  v_end2 int4;
+  v_requested_bucket_secs numeric;
+  v_effective_bucket_secs1 int4;
+  v_effective_bucket_secs2 int4;
+  v_grain1 int4;
+  v_grain2 int4;
+  v_source1 text;
+  v_source2 text;
+  v_top_tie boolean;
+  v_extrema_mismatch boolean;
 begin
   -- validate here, in compare's own frame, so the error names ash.compare
   -- and never leaks the internal delegation to ash.top.
@@ -4700,21 +5028,163 @@ begin
       v_aas2.period_start, v_aas2.period_end;
   end if;
 
+  /*
+   * The displayed bucket can be the same even when one side consists of one
+   * retained hour average and the other consists of minute observations.
+   * Track that underlying read grain separately: equal bucket labels alone
+   * do not make the extrema distributions comparable.
+   */
+  v_grain1 := case
+    when v_aas1.source in ('rollup_1h', 'rollup_1h_flat')
+         and (
+           v_aas1.source = 'rollup_1h_flat'
+           or wait_event_type is not null
+           or wait_event is not null
+           or query_id is not null
+         ) then 3600
+    else 60
+  end;
+  v_grain2 := case
+    when v_aas2.source in ('rollup_1h', 'rollup_1h_flat')
+         and (
+           v_aas2.source = 'rollup_1h_flat'
+           or wait_event_type is not null
+           or wait_event is not null
+           or query_id is not null
+         ) then 3600
+    else 60
+  end;
+
   if dimension is null then
+    v_extrema_mismatch :=
+      v_grain1 <> v_grain2
+      or v_aas1.effective_bucket <> v_aas2.effective_bucket;
     return query
     select
       'overall'::text, null::text,
+      v_aas1.source,
+      v_aas2.source,
+      v_aas1.period_start,
+      v_aas1.period_end,
+      v_aas2.period_start,
+      v_aas2.period_end,
+      v_aas1.effective_bucket,
+      v_aas2.effective_bucket,
       case when v_cov1 then v_aas1.avg_aas end,
       case when v_cov2 then v_aas2.avg_aas end,
       case when v_cov1 and v_cov2
            then round(v_aas2.avg_aas - v_aas1.avg_aas, 2) end,
-      case when v_cov1 then v_aas1.peak_aas end,
-      case when v_cov2 then v_aas2.peak_aas end,
-      case when v_cov1 then v_aas1.p99_aas end,
-      case when v_cov2 then v_aas2.p99_aas end,
+      case when v_cov1 and not v_extrema_mismatch
+           then v_aas1.peak_aas end,
+      case when v_cov2 and not v_extrema_mismatch
+           then v_aas2.peak_aas end,
+      case when v_cov1 and not v_extrema_mismatch
+           then v_aas1.p99_aas end,
+      case when v_cov2 and not v_extrema_mismatch
+           then v_aas2.p99_aas end,
       null::numeric, null::numeric;
     return;
   end if;
+
+  /*
+   * Plan the dimensional windows independently. This cannot reuse aas()'s
+   * effective grain: an unfiltered scalar rollup_1h read can use minute_counts
+   * while a wait/query breakdown over that same physical source is hourly.
+   */
+  v_requested_bucket_secs := extract(epoch from bucket);
+  v_start1 := (ash.ts_from_timestamptz(v_from1) / 60) * 60;
+  v_end1 := (ash.ts_from_timestamptz(v_to1) / 60) * 60;
+  if v_end1 <= v_start1 then
+    v_end1 := least(v_start1::bigint + 60, 2147483647)::int4;
+  end if;
+  v_start2 := (ash.ts_from_timestamptz(v_from2) / 60) * 60;
+  v_end2 := (ash.ts_from_timestamptz(v_to2) / 60) * 60;
+  if v_end2 <= v_start2 then
+    v_end2 := least(v_start2::bigint + 60, 2147483647)::int4;
+  end if;
+
+  v_top_tie := (
+    dimension in ('wait_event_type', 'wait_event')
+    and query_id is not null
+  ) or (
+    dimension = 'query_id'
+    and (wait_event_type is not null or wait_event is not null)
+  ) or (
+    dimension = 'database'
+    and query_id is not null
+    and (wait_event_type is not null or wait_event is not null)
+  );
+
+  if v_top_tie then
+    v_source1 := 'raw';
+    v_source2 := 'raw';
+  else
+    v_source1 := ash._pick_source_agg(
+      ash.ts_to_timestamptz(v_start1),
+      ash.ts_to_timestamptz(v_end1)
+    );
+    v_source2 := ash._pick_source_agg(
+      ash.ts_to_timestamptz(v_start2),
+      ash.ts_to_timestamptz(v_end2)
+    );
+  end if;
+  v_grain1 := case when v_source1 = 'rollup_1h' then 3600 else 60 end;
+  v_grain2 := case when v_source2 = 'rollup_1h' then 3600 else 60 end;
+
+  if v_source1 = 'rollup_1h'
+     and dimension = 'database'
+     and wait_event_type is null
+     and wait_event is null
+     and query_id is null then
+    if ash._rollup_1h_has_flat(v_start1, v_end1, database) then
+      v_source1 := 'rollup_1h_flat';
+    else
+      v_grain1 := 60;
+    end if;
+  end if;
+  if v_source2 = 'rollup_1h'
+     and dimension = 'database'
+     and wait_event_type is null
+     and wait_event is null
+     and query_id is null then
+    if ash._rollup_1h_has_flat(v_start2, v_end2, database) then
+      v_source2 := 'rollup_1h_flat';
+    else
+      v_grain2 := 60;
+    end if;
+  end if;
+
+  if v_grain1 = 3600 then
+    v_start1 := ((v_start1::bigint / 3600) * 3600)::int4;
+    v_end1 := least(
+      ((v_end1::bigint + 3599) / 3600) * 3600,
+      2147483647
+    )::int4;
+  end if;
+  if v_grain2 = 3600 then
+    v_start2 := ((v_start2::bigint / 3600) * 3600)::int4;
+    v_end2 := least(
+      ((v_end2::bigint + 3599) / 3600) * 3600,
+      2147483647
+    )::int4;
+  end if;
+  v_effective_bucket_secs1 := (
+    (
+      greatest(ceil(v_requested_bucket_secs)::int4, v_grain1)::bigint
+      + v_grain1 - 1
+    )
+    / v_grain1 * v_grain1
+  )::int4;
+  v_effective_bucket_secs2 := (
+    (
+      greatest(ceil(v_requested_bucket_secs)::int4, v_grain2)::bigint
+      + v_grain2 - 1
+    )
+    / v_grain2 * v_grain2
+  )::int4;
+  v_extrema_mismatch :=
+    v_grain1 <> v_grain2
+    or v_effective_bucket_secs1 <> v_effective_bucket_secs2;
 
   return query
   with window1 as (
@@ -4728,6 +5198,14 @@ begin
   select
     coalesce(window1.key, window2.key),
     coalesce(window1.query_text, window2.query_text),
+    v_source1,
+    v_source2,
+    ash.ts_to_timestamptz(v_start1),
+    ash.ts_to_timestamptz(v_end1),
+    ash.ts_to_timestamptz(v_start2),
+    ash.ts_to_timestamptz(v_end2),
+    v_effective_bucket_secs1 * interval '1 second',
+    v_effective_bucket_secs2 * interval '1 second',
     window1.avg_aas, window2.avg_aas,
     /*
      * a key absent from a COVERED window is a true zero; an UNCOVERED window
@@ -4736,8 +5214,10 @@ begin
     case when v_cov1 and v_cov2
          then round(coalesce(window2.avg_aas, 0)
                     - coalesce(window1.avg_aas, 0), 2) end,
-    window1.peak_aas, window2.peak_aas,
-    window1.p99_aas, window2.p99_aas,
+    case when not v_extrema_mismatch then window1.peak_aas end,
+    case when not v_extrema_mismatch then window2.peak_aas end,
+    case when not v_extrema_mismatch then window1.p99_aas end,
+    case when not v_extrema_mismatch then window2.p99_aas end,
     window1.pct, window2.pct
   from window1
   /*
@@ -5511,17 +5991,46 @@ begin
     v_bucket_secs := case when v_span <= 6 * 3600 then 60
                           when v_span <= 7 * 86400 then 3600 else 86400 end;
   else
-    v_bucket_secs := extract(epoch from bucket)::int4;
-    if v_bucket_secs is null or v_bucket_secs < 60 then
+    if extract(epoch from bucket) < 60 then
       raise exception 'bucket must be at least 1 minute, got %', bucket;
     end if;
+    v_bucket_secs := ceil(extract(epoch from bucket))::int4;
+  end if;
+
+  v_si := ash._sample_interval_secs();
+  v_source := ash._pick_source_agg(ash.ts_to_timestamptz(v_start_ts),
+                                   ash.ts_to_timestamptz(v_end_ts));
+  if v_source = 'none' then v_source := 'rollup_1m'; end if;
+  v_grain_secs := case when v_source = 'rollup_1h' then 3600 else 60 end;
+  if v_grain_secs = 3600 then
+    v_start_ts := ((v_start_ts::bigint / 3600) * 3600)::int4;
+    v_end_ts := least(
+      ((v_end_ts::bigint + 3599) / 3600) * 3600,
+      2147483647
+    )::int4;
+  end if;
+  -- snap to a whole grain multiple (see ash.aas): a non-multiple bucket
+  -- misaligns with the grain rows and fabricates per-bucket AAS.
+  v_bucket_secs := (
+    (greatest(v_bucket_secs, v_grain_secs)::bigint + v_grain_secs - 1)
+    / v_grain_secs * v_grain_secs
+  )::int4;
+  v_span := v_end_ts - v_start_ts;
+
+  /*
+   * chart has no metadata columns, so disclose its effective hour-grain plan
+   * with a NOTICE instead of silently changing the requested window.
+   */
+  if v_source = 'rollup_1h' then
+    raise notice
+      'ash.chart: source rollup_1h uses effective window [% to %) and bucket %',
+      ash.ts_to_timestamptz(v_start_ts),
+      ash.ts_to_timestamptz(v_end_ts),
+      v_bucket_secs * interval '1 second';
   end if;
 
   /*
-   * Bound the emitted-row count (same cap as ash.timeline): one row per
-   * bucket, so an explicit fine bucket over a very wide window can blow up
-   * (1 minute over 10 years ~ 5M rows). Cap at 100000 and tell the caller
-   * to widen bucket.
+   * Bound the emitted-row count (same cap as ash.timeline) after widening.
    */
   if (v_span::bigint / v_bucket_secs) > 100000 then
     raise exception
@@ -5529,19 +6038,6 @@ begin
       'bucket (or bucket => null for auto grain)',
       (v_span::bigint / v_bucket_secs);
   end if;
-
-  v_si := ash._sample_interval_secs();
-  v_source := ash._pick_source_agg(ash.ts_to_timestamptz(v_start_ts),
-                                   ash.ts_to_timestamptz(v_end_ts));
-  if v_source = 'none' then v_source := 'rollup_1m'; end if;
-  if v_source = 'rollup_1h' and v_bucket_secs < 3600 then
-    v_source := 'rollup_1m';
-  end if;
-  v_grain_secs := case when v_source = 'rollup_1h' then 3600 else 60 end;
-  -- snap to a whole grain multiple (see ash.aas): a non-multiple bucket
-  -- misaligns with the grain rows and fabricates per-bucket AAS.
-  v_bucket_secs := (greatest(v_bucket_secs, v_grain_secs) / v_grain_secs)
-                   * v_grain_secs;
 
   /*
    * Legend/series events: the window-wide top-n PLUS any event that is
@@ -5719,7 +6215,7 @@ begin
   return query select 'period_start'::text, v_aas.period_start::text;
   return query select 'period_end'::text, v_aas.period_end::text;
   return query select 'source'::text, v_aas.source;
-  return query select 'minutes_with_data'::text, v_aas.buckets_with_data::text;
+  return query select 'buckets_with_data'::text, v_aas.buckets_with_data::text;
   return query select 'avg_aas'::text, v_aas.avg_aas::text;
   return query select 'peak_aas'::text, v_aas.peak_aas::text;
   return query select 'p99_aas'::text, v_aas.p99_aas::text;
@@ -5764,19 +6260,19 @@ $$;
  * everywhere user-facing.
  */
 comment on function ash.periods(timestamptz) is
-$$START HERE (US-1 triage): AAS for six standard trailing windows (1m, 5m, 1h, 1d, 1w, 1mo) ending at until (default now()), one row each. Columns (period, period_start, period_end, source, bucket, buckets_with_data, avg_aas, peak_aas, p99_aas): peak/p99 vs avg distinguishes a spike from sustained load; buckets_with_data counts covered buckets at the grain named by bucket (always 1 minute here). Rollup-backed (source = rollup_1m|rollup_1h). Next: locate the spike in time with ash.timeline(), then drill with ash.top().$$;
+$$START HERE (US-1 triage): AAS for six standard trailing windows (1m, 5m, 1h, 1d, 1w, 1mo) requested to end at until (default now()), one row each. Columns (period, period_start, period_end, source, bucket, buckets_with_data, avg_aas, peak_aas, p99_aas): period bounds are effective and may snap outward for hour-only reads; peak/p99 vs avg distinguishes a spike from sustained load; buckets_with_data counts covered buckets at the effective grain named by bucket. Genuine rollup_1h.minute_counts keeps minute grain; legacy/incomplete detail on a minute-capable plan reports source = rollup_1h_flat, bucket = 1 hour, and NULL sub-hour peak/p99 instead of fabricated minute extremes. Next: locate the spike in time with ash.timeline(), then drill with ash.top().$$;
 
 comment on function ash.aas(timestamptz, timestamptz, text, text, bigint, name, interval) is
-$$Scalar AAS summary for one window [since, until) (defaults: last 1 hour). Optional uniform filters wait_event_type/wait_event/query_id/database. Columns (period_start, period_end, source, buckets_expected, buckets_with_data, avg_aas, peak_aas, p99_aas, backend_seconds); peak/p99 are over per-bucket AAS. Buckets are calendar-aligned (floored to bucket in UTC: an hour bucket starts on the hour, a day bucket on the UTC day) — the same absolute window always produces the same buckets. Also the US-4 leaf event summary: ash.aas(wait_event => 'IO:DataFileRead'). Combining a wait filter with query_id needs raw samples and raises past raw retention. source = raw|rollup_1m|rollup_1h. Next: ash.top('query_id', wait_event => ...).$$;
+$$Scalar AAS summary for one requested window [since, until) (defaults: last 1 hour). Optional uniform filters wait_event_type/wait_event/query_id/database. Columns (period_start, period_end, source, effective_bucket, buckets_expected, buckets_with_data, avg_aas, peak_aas, p99_aas, backend_seconds). period_start/period_end are effective bounds: hour-only rollup_1h reads snap partial bounds outward, and avg/backend_seconds are exact for those disclosed bounds. peak/p99 are NULL when retained grain exceeds the requested bucket, never hour averages presented as minute extremes. Genuine minute_counts preserves minute grain for unfiltered/database-only reads; legacy/incomplete detail on that minute-capable plan reports source = rollup_1h_flat. Combining a wait filter with query_id needs raw samples and raises past raw retention. source = raw|rollup_1m|rollup_1h|rollup_1h_flat|none. Next: ash.top('query_id', wait_event => ...).$$;
 
 comment on function ash.timeline(timestamptz, timestamptz, interval, text, text, bigint, name) is
-$$AAS time series (US-2 locate / US-6 capacity): one row per bucket across [since, until). bucket => null auto-selects grain by span (<= 6h: 1 minute, <= 7d: 1 hour, else 1 day). bucket_start is calendar-aligned (floored to bucket in UTC: hour buckets start on the hour, day buckets on the UTC day), so the same absolute window always returns identical bucket_start labels; the first bucket may start before since and edge buckets average over their in-window part only. Columns (bucket_start, source, data_points, avg_aas, peak_aas, p99_aas): data_points = 0 with null AAS marks a no-data bucket (distinct from measured-zero). Order by peak_aas desc nulls last to find the worst buckets (no-data buckets carry null peak_aas, which sorts first under a bare desc and would bury the real spike), then drill that window with ash.top(). peak_aas/p99_aas are per-minute even on rollup_1h-backed windows (per-minute totals are preserved in rollup_1h.minute_counts); p99_aas is null only for wait/query-filtered rollup_1h-backed buckets (hour grain).$$;
+$$AAS time series (US-2 locate / US-6 capacity): one row per effective bucket. bucket => null auto-selects requested grain by span (<= 6h: 1 minute, <= 7d: 1 hour, else 1 day); hour-only rollup_1h reads widen partial bounds/buckets instead of falling through to missing rollup_1m data. Columns (bucket_start, source, data_points, avg_aas, peak_aas, p99_aas). data_points counts retained-grain rows, not one-second samples; 0 with NULL AAS means no stored observation. take_sample() also writes no row for a sampled idle tick, so idle and uncovered time remain indistinguishable until #137. Genuine minute_counts preserves minute extremes; legacy/incomplete detail on a minute-capable plan reports source = rollup_1h_flat. peak/p99 are NULL whenever retained grain exceeds the requested bucket. Order by peak_aas desc nulls last, then drill with ash.top().$$;
 
 comment on function ash.top(text, timestamptz, timestamptz, text, text, bigint, name, int, interval, text) is
-$$The single vertical drill (US-3): AAS broken down by dimension in wait_event_type|wait_event|query_id|database over [since, until). Every row carries avg_aas, peak_aas, p99_aas, backend_seconds, and pct (share of window total). order_by in avg|peak|p99 (default avg) picks the ranking metric BEFORE the top-n cut — use order_by => 'peak' during incident triage so a query that spiked for one minute outranks steady background rows. For the query_id dimension, a NULL key is the unattributed bucket (activity whose query_id was not captured: not run with a queryid-reporting client, truncated, or utility/idle-in-transaction work) — it is real load, not an error. Filters compose: ash.top('wait_event', wait_event_type => 'IO') is the level-2 drill; ash.top('query_id', wait_event => 'IO:DataFileRead') is the US-4 leaf. query_text is filled for the query_id dimension when pg_stat_statements is present AND the caller can read other roles pg_stat_statements text — i.e. holds pg_read_all_stats (e.g. via membership in pg_monitor); a plain ash.grant_reader() role without it sees query_text NULL even though pgss is installed, because pgss restricts query text to the owning role. When pgss lives outside public, the caller also needs USAGE on that schema, else query_text is NULL. Crossing the wait<->query tie (query_id dimension + wait filter, or a wait dimension + query_id) reads raw samples and raises past raw retention. source = raw|rollup_1m|rollup_1h.$$;
+$$The single vertical drill (US-3): AAS broken down by wait_event_type|wait_event|query_id|database. Columns (key, query_text, source, period_start, period_end, effective_bucket, avg_aas, peak_aas, p99_aas, backend_seconds, pct). Hour-only rollup_1h dimensions snap partial bounds outward; the effective bounds/bucket disclose that degradation and peak/p99 are NULL when retained grain exceeds the requested bucket. Plain database breakdowns retain minute precision through per-(hour,datid) minute_counts; database plus wait/query filters remains hour-grain. order_by in avg|peak|p99 applies before n; when the requested extreme is unavailable it falls back to avg ordering. A NULL query_id key is real unattributed load. The wait<->query tie reads raw and raises past raw retention. source = raw|rollup_1m|rollup_1h|rollup_1h_flat|none.$$;
 
 comment on function ash.compare(timestamptz, timestamptz, timestamptz, timestamptz, text, int, text, text, bigint, name, interval) is
-$$Before/after comparison of two windows (US-7): window 1 = [since_1, until_1), window 2 = [since_2, until_2). dimension => null gives one overall row; a dimension gives the top n keys by abs(avg_delta) via a full outer join (a key present in only one window still appears). Columns (key, query_text, avg_aas_1, avg_aas_2, avg_delta, peak_aas_1, peak_aas_2, p99_aas_1, p99_aas_2, pct_1, pct_2); avg_delta = window 2 minus window 1. A window with no data coverage (e.g. past retention) reports NULL on its side and a NULL avg_delta (plus a NOTICE) — never a fake zero baseline; within a covered window an absent key is a true zero. Use to tell whether a deploy regressed load and where.$$;
+$$Before/after comparison of two windows (US-7). dimension => null gives one overall row; a dimension gives top keys by abs(avg_delta). Columns (key, query_text, source_1, source_2, period_start_1, period_end_1, period_start_2, period_end_2, effective_bucket_1, effective_bucket_2, avg_aas_1, avg_aas_2, avg_delta, peak_aas_1, peak_aas_2, p99_aas_1, p99_aas_2, pct_1, pct_2). Sources and effective plans are disclosed per window. If retained read grains differ, both peak values and both p99 values are NULL as incomparable even when explicit effective buckets match; honest averages/delta remain. No-coverage sides and avg_delta are NULL plus a NOTICE; within a covered window an absent key is a true zero.$$;
 
 comment on function ash.samples(timestamptz, timestamptz, int, text, text, bigint, name) is
 $$Decoded raw sample rows, newest first (US-5 raw evidence) over [since, until) (default last 1 hour), up to n. Uniform filters wait_event_type/wait_event/query_id/database. Columns (sample_time, database_name, active_backends, wait_event, query_id, query_text). query_text needs pg_stat_statements AND that the caller holds pg_read_all_stats (e.g. via pg_monitor membership); it is null otherwise — a plain ash.grant_reader() role without pg_read_all_stats sees null even with pgss installed, because pgss restricts query text to the owning role. When pgss lives outside public, the caller also needs USAGE on that schema, else query_text is null. Reads ash.sample directly (raw retention only).$$;
@@ -5785,17 +6281,17 @@ comment on function ash.report(timestamptz, timestamptz, int, int) is
 $$Machine-readable load report as one jsonb (US-8) for [since, until) (default last 1 day). Per wait class (cpu=CPU*, io=IO, ipc=IPC, lock=Lock, lwlock=LWLock; total = their sum) at 1-minute resolution: aas_avg / aas_worst1m / aas_p99 / aas_p999. Plus top_events_{worst1m,p99,p999} (keys io/ipc/lock/lwlock, entries "event(aas)") and top_queryids_{worst1m,p99,p999} (keys total+the four non-cpu classes, entries "queryid(aas)"). Query attribution is decided per extreme minute: a top_queryids key appears when raw samples still cover that class's worst/percentile minute(s), even if the window start predates raw retention (percentile sets attribute over their raw-covered minutes). top_queryids_available (boolean, always present) says whether any attribution was possible — branch on it, not on key absence. coverage {from, to, source, minutes_expected, minutes_with_data, raw_retention_start} reconciles the payload against ash.aas()/ash.top() and flags degraded resolution. vcpus (echoed, never used) and cluster_name are pass-throughs. Returns null when the window has no coverage; never raises. Payload contract is frozen per 2.0 minor line (keys only added, never renamed/removed); scoring/normalization is the consumer's job.$$;
 
 comment on function ash.chart(timestamptz, timestamptz, interval, int, int, boolean) is
-$$Human render helper: stacked ASCII per-bucket AAS chart over [since, until) (default last 1 hour). Series/legend = the window-wide top n wait events PLUS any event that is top-1 in at least one bucket (so a single-bucket spike culprit is always visible), plus Other. bucket => null auto-selects grain by span; buckets are calendar-aligned like ash.timeline(). Presentation-only (columns bucket_start, aas, detail, chart); for typed data use ash.timeline(). Enable ANSI color with color => true or "set ash.color = on".$$;
+$$Human render helper: stacked ASCII per-bucket AAS chart over [since, until) (default last 1 hour). Series/legend = the window-wide top n wait events PLUS any event that is top-1 in at least one bucket, plus Other. bucket => null auto-selects grain by span. On rollup_1h the chart snaps partial bounds/buckets outward and emits a NOTICE naming source and effective plan; it never silently falls through to unavailable rollup_1m data. Presentation-only (bucket_start, aas, detail, chart); for typed data use ash.timeline(). Enable ANSI color with color => true or "set ash.color = on".$$;
 
 comment on function ash.summary(timestamptz, timestamptz) is
-$$Human render helper: key/value AAS overview for one window [since, until) (default last 1 hour) — the companion to ash.periods(). Returns (metric, value): period bounds, source, minutes_with_data, avg/peak/p99 AAS, backend_seconds, databases_active, and top waits/queries. Presentation-only; for typed data use ash.aas() and ash.top().$$;
+$$Human render helper: key/value AAS overview for one window [since, until) (default last 1 hour) — the companion to ash.periods(). Returns (metric, value): effective period bounds, source, buckets_with_data, avg/peak/p99 AAS, backend_seconds, databases_active, and top waits/queries. Presentation-only; source = rollup_1h_flat means the bucket count is hourly. For typed data use ash.aas() and ash.top().$$;
 
 /*
  * Schema-level map: one obj_description() lookup orients a human or agent on
  * the whole surface (readers vs operations) before any \df spelunking.
  */
 comment on schema ash is
-$$pg_ash: Active Session History for Postgres (pure SQL, no extension). Reader entry points (start with ash.periods()): periods, aas, timeline, top, compare, samples, report, chart, summary, status — every reader reports load in AAS (Average Active Sessions) and names its data source. Operations/admin (owner-only, not granted by grant_reader): start, stop, take_sample, rotate, rollup_minute, rollup_hour, rollup_cleanup, rebuild_partitions, set_debug_logging, uninstall, grant_reader, revoke_reader. Each function documents itself: select obj_description('ash.<name>(<argtypes>)'::regprocedure).$$;
+$$pg_ash: Active Session History for Postgres (pure SQL, no extension). Reader entry points (start with ash.periods()): periods, aas, timeline, top, compare, samples, report, chart, summary, status — readers report load in AAS (Average Active Sessions), and their function comments state how provenance is exposed. Operations/admin (owner-only, not granted by grant_reader): start, stop, take_sample, rotate, rollup_minute, rollup_hour, rollup_cleanup, rebuild_partitions, set_debug_logging, uninstall, grant_reader, revoke_reader. Each function documents itself: select obj_description('ash.<name>(<argtypes>)'::regprocedure).$$;
 
 /*
  * Operational / admin surface: obj_description for every entry point, so the
@@ -5820,7 +6316,7 @@ comment on function ash.rollup_minute(int) is
 $$Admin: fold completed minutes of raw samples into ash.rollup_1m (the every-minute job scheduled by ash.start()); batch_limit caps catch-up minutes per call. Returns minutes processed. Readers pick rollups automatically — this only needs manual calls when pg_cron is absent.$$;
 
 comment on function ash.rollup_hour() is
-$$Admin: fold completed hours of ash.rollup_1m into ash.rollup_1h, preserving per-minute totals in minute_counts so long-window peak/p99 stay minute-grain (the hourly job scheduled by ash.start()). Returns hours processed.$$;
+$$Admin: fold completed hours of ash.rollup_1m into ash.rollup_1h. minute_counts preserves available per-minute totals and must sum to the hourly wait total; missing stored rows remain NULL slots because idle and uncovered minutes are indistinguishable (#137). Returns hours processed.$$;
 
 comment on function ash.rollup_cleanup() is
 $$Admin: delete rollup rows past retention (rollup_1m_retention_days / rollup_1h_retention_days in ash.config; the daily job scheduled by ash.start()). Returns a summary of rows deleted.$$;

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -188,7 +188,8 @@ begin
         '_merge_wait_counts', '_merge_query_counts', '_truncate_pairs',
         'rollup_minute',
         '_color_on', '_wait_color', '_reset', '_bar',
-        '_pick_source', '_pick_source_agg', '_raise_tie_retention',
+        '_pick_source', '_pick_source_agg', '_exact_query_uses_coarser',
+        '_raise_tie_retention',
         '_minute_counts_valid', '_rollup_1h_has_flat',
         '_grain_counts', '_grain_by',
         'timeline', 'compare', '_pgss_query_text',
@@ -2570,7 +2571,7 @@ begin
   /*
    * Retention-start boundaries (2.0): the earliest timestamp each source can
    * answer, so a caller can plan a window before querying and knows where the
-   * raw wait<->query drill stops. NULL when the source holds no data yet.
+   * raw exact-query drill stops. NULL when the source holds no data yet.
    */
   metric := 'raw_retention_start';
   value := coalesce(ash._raw_retention_start()::text, 'no samples'); return next;
@@ -3492,9 +3493,26 @@ $$;
  * readers auto-select raw -> rollup_1m -> rollup_1h; typed readers expose a
  * source column, compare exposes both sources, report embeds provenance in
  * JSON, and chart emits a planning NOTICE when hour grain widens its request.
- * Unanswerable wait<->query drills raise past raw retention. Internal
+ * Unanswerable exact-query drills raise past raw retention. Internal
  * workhorses (_grain_counts / _grain_by) and retention helpers back the family.
  */
+
+/*
+ * Physical raw coverage is kept separate from the public planning boundary.
+ * They are identical until #163 teaches _raw_retention_start() about the
+ * logical ring boundary; source selection and exact-query loss detection need
+ * the physical oldest retained sample across that change.
+ */
+create or replace function ash._raw_oldest_sample()
+returns timestamptz
+language sql
+stable
+set search_path = pg_catalog, ash
+as $$
+  select ash.ts_to_timestamptz(min(sample_ts))
+  from ash.sample
+  where slot = any(ash._active_slots())
+$$;
 
 /*
  * Retention-start helpers: earliest timestamp each source can answer. Null
@@ -3507,9 +3525,7 @@ language sql
 stable
 set search_path = pg_catalog, ash
 as $$
-  select ash.ts_to_timestamptz(min(sample_ts))
-  from ash.sample
-  where slot = any(ash._active_slots())
+  select ash._raw_oldest_sample()
 $$;
 
 create or replace function ash._rollup_1m_retention_start()
@@ -3566,11 +3582,11 @@ $$;
 /*
  * Source auto-selection (the trust property, AAS_API.md §6): the finest
  * source whose retention reaches since. Raw is preferred within raw retention
- * (most accurate, and the only source that can tie wait<->query or answer
- * while rollups lag/are disabled); then rollup_1m, then rollup_1h. Returns
- * 'none' only when nothing holds data. Callers that need the tie force 'raw'
- * and raise past raw retention rather than falling back to a rollup that
- * cannot answer.
+ * (most accurate, and the only source that can provide exact query attribution
+ * or answer while rollups lag/are disabled); then rollup_1m, then rollup_1h.
+ * Returns 'none' only when nothing holds data. Callers that need exact query
+ * attribution force 'raw' and raise when falling back to a compacted rollup
+ * would discard retained history.
  */
 create or replace function ash._pick_source(since timestamptz)
 returns text
@@ -3592,15 +3608,16 @@ $$;
 
 /*
  * Source selection for the AGGREGATE readers (aas / timeline / periods, and
- * the non-tie drills of top / chart). Raw and rollup_1m share per-minute
- * grain, so for anything wider than ~1 hour that rollup_1m fully covers we
- * prefer rollup_1m (a raw decode of a wide window spills hundreds of MB — the
- * last-24h read cost ~4.5s and ~500MB before this). Narrow windows still fall
- * through to _pick_source (raw preferred) so the freshest partial minute is
- * captured, and windows rollup can't cover (or where rollup is
- * disabled/lagging) still fall to raw / rollup_1h. Leaf tie-drills
- * (top/samples) bypass this and force raw. The source column stays honest —
- * it names whatever was actually read.
+ * unfiltered breakdowns in top / chart). Raw and rollup_1m share per-minute
+ * grain, so for anything wider than ~1 hour whose requested start is within
+ * rollup_1m retention we prefer rollup_1m (a raw decode of a wide window spills
+ * hundreds of MB — the last-24h read cost ~4.5s and ~500MB before this).
+ * #122 tracks the separate end-watermark/completeness gap. Narrow windows
+ * still fall through to _pick_source (raw preferred) so the freshest partial
+ * minute is captured, and windows rollup can't cover (or where rollup is
+ * disabled/lagging) still fall to raw / rollup_1h. Exact-query drills and
+ * samples bypass this and force raw. The source column stays honest — it names
+ * whatever was actually read.
  */
 create or replace function ash._pick_source_agg(
   since timestamptz,
@@ -3620,12 +3637,99 @@ as $$
 $$;
 
 /*
- * Raw-retention guard for the wait<->query tie drills (aas / timeline / top
- * with both a wait filter and query_id). Returns silently when raw samples
- * cover the window start; otherwise raises, with guidance split by case:
- *   * window ENTIRELY past raw retention (or no raw samples at all): the tie
- *     is unrecoverable — narrowing the window cannot help, so point to the
- *     untied aggregate readers instead;
+ * True only when the source ordinary planning selects has retained rollup
+ * coverage in the requested pre-raw slice. _pick_source() deliberately falls
+ * back to any nonempty source when no source reaches since; that fallback
+ * label alone is not evidence that forcing raw discards history. In
+ * particular, a young install's first rollup can cover only the same retained
+ * minute as its oldest raw sample.
+ *
+ * Compare at reader grain: a rollup row in the same minute as raw_start does
+ * not prove older coverage. This also composes with #163's pending distinction
+ * between the oldest physical sample and the usable raw boundary.
+ */
+create or replace function ash._exact_query_uses_coarser(
+  start_ts int4,
+  end_ts int4,
+  database name default null
+)
+returns boolean
+language plpgsql
+stable
+set search_path = pg_catalog, ash
+as $$
+declare
+  v_source text := ash._pick_source(ash.ts_to_timestamptz(start_ts));
+  v_raw_start timestamptz := ash._raw_oldest_sample();
+  v_pre_raw_end int8 := case
+    when v_raw_start is null then end_ts::int8
+    else least(
+      end_ts::int8,
+      ash.ts_from_timestamptz(date_trunc('minute', v_raw_start))::int8
+    )
+  end;
+begin
+  if v_pre_raw_end <= start_ts::int8 then
+    return false;
+  end if;
+
+  if v_source = 'rollup_1m' then
+    return exists (
+      select
+      from ash.rollup_1m as rollup_minute
+      left join pg_database as db
+        on db.oid = rollup_minute.datid
+      where rollup_minute.ts::int8 < v_pre_raw_end
+        and rollup_minute.ts::int8 + 60 > start_ts::int8
+        and (
+          _exact_query_uses_coarser.database is null
+          or db.datname = _exact_query_uses_coarser.database
+        )
+    );
+  elsif v_source = 'rollup_1h' then
+    return exists (
+      select
+      from ash.rollup_1h as rollup_hour
+      left join pg_database as db
+        on db.oid = rollup_hour.datid
+      where rollup_hour.ts::int8 < v_pre_raw_end
+        and rollup_hour.ts::int8 + 3600 > start_ts::int8
+        and (
+          _exact_query_uses_coarser.database is null
+          or db.datname = _exact_query_uses_coarser.database
+        )
+        and (
+          not ash._minute_counts_valid(
+            rollup_hour.minute_counts,
+            rollup_hour.wait_counts
+          )
+          or exists (
+            select
+            from unnest(rollup_hour.minute_counts)
+              with ordinality as minute_count(cnt, idx)
+            where minute_count.cnt is not null
+              and rollup_hour.ts::int8
+                    + (minute_count.idx - 1) * 60 < v_pre_raw_end
+              and rollup_hour.ts::int8
+                    + minute_count.idx * 60 > start_ts::int8
+          )
+        )
+    );
+  end if;
+
+  return false;
+end;
+$$;
+
+/*
+ * Raw-retention guard for exact query attribution. Explicit query_id filters
+ * and wait<->query tie drills need raw samples because compacted rollups cannot
+ * distinguish a true zero from attribution that was not preserved. Returns
+ * silently when raw covers the window start; otherwise raises, with guidance
+ * split by case:
+ *   * window ENTIRELY past raw retention (or no raw samples at all): exact
+ *     attribution is unrecoverable — narrowing cannot help, so point to an
+ *     untied / unfiltered aggregate read instead;
  *   * PARTIAL overlap (window starts before raw retention but ends inside
  *     it): narrowing the window to the raw-covered part recovers the drill.
  * start_ts / end_ts are the reader's minute-FLOORED window bounds (the guard
@@ -3649,16 +3753,15 @@ declare
 begin
   if raw_start is not null
      and ash.ts_to_timestamptz(start_ts) >= raw_start then
-    return;  -- raw covers the window start: the tie drill can proceed
+    return;  -- raw covers the window start: exact attribution can proceed
   end if;
   if raw_start is null or ash.ts_to_timestamptz(end_ts) <= raw_start then
     raise exception
-      'pg_ash: this drill needs the raw wait<->query tie, but the requested '
-      'window (% to %) is entirely outside raw retention (%). The tie is '
-      'unrecoverable for that window — narrowing it will not help. Use the '
-      'untied aggregate readers instead: drop either the wait filter or '
-      'query_id (e.g. ash.aas(), ash.timeline(), ash.top() with one of the '
-      'two).',
+      'pg_ash: this drill needs exact raw query attribution, but the requested '
+      'window (% to %) is entirely outside raw retention (%). Exact query '
+      'attribution is unrecoverable for that window — narrowing it will not '
+      'help. Use the untied aggregate readers instead: remove query_id (or '
+      'drop the wait filter when drilling queries by wait).',
       since,
       ash.ts_to_timestamptz(end_ts),
       coalesce('raw retention starts at ' || raw_start, 'no raw samples exist');
@@ -3674,10 +3777,10 @@ begin
     else date_trunc('minute', raw_start) + interval '1 minute'
   end;
   raise exception
-    'pg_ash: this drill needs raw samples; raw retention starts at % but the '
-    'requested window starts at %. Narrow the window to start at or after % '
-    '(the window end is still inside raw retention), or drill without the '
-    'query/event tie.',
+    'pg_ash: this drill needs exact raw query attribution; raw retention '
+    'starts at % but the requested window starts at %. Narrow the window '
+    'to start at or after % (the window end is still inside raw retention), '
+    'or remove query_id.',
     raw_start, since, v_next_boundary;
 end;
 $$;
@@ -3687,10 +3790,11 @@ $$;
  * / rollup_1m, hour for rollup_1h) over [start_ts, end_ts), with uniform
  * filters. One row per grain timestamp that EXISTS in the source (cnt may be 0
  * when nothing matched) so callers can distinguish measured-zero from no-data.
- * 'raw' supports the wait<->query tie (both a wait filter and query_id);
- * the rollup sources cannot and must not be asked for it (caller routes such
- * requests to 'raw'). grain_secs is 60 (raw / rollup_1m / rollup_1h_minutes)
- * or 3600 (rollup_1h and legacy/incomplete rollup_1h detail).
+ * 'raw' supports exact query_id filters (including wait<->query ties); rollup
+ * query_counts are compacted and must not be used to prove an exact match or
+ * zero (callers route those requests to 'raw'). grain_secs is 60 (raw /
+ * rollup_1m / rollup_1h_minutes) or 3600 (rollup_1h and legacy/incomplete
+ * rollup_1h detail).
  * 'rollup_1h_minutes' is the internal minute-capable view used for
  * unfiltered/database-only totals; invalid detail emits one hourly row.
  */
@@ -3786,10 +3890,10 @@ begin
      * Internal minute-grain view of rollup_1h via the preserved minute_counts
      * arrays, so peak_aas / p99_aas survive the rollup_1m -> rollup_1h seam
      * (same values a rollup_1m read of the window would produce). Totals only:
-     * wait/query filters need the hour-grain arrays, so callers route filtered
-     * reads to 'rollup_1h'. Legacy/incomplete arrays emit one exact hourly
-     * datum: callers detect that case up front, normalize the whole window to
-     * hour grain, and publish source = rollup_1h_flat.
+     * wait filters need hour-grain arrays, while exact query filters are routed
+     * to raw. Legacy/incomplete arrays emit one exact hourly datum: callers
+     * detect that case up front, normalize the whole window to hour grain, and
+     * publish source = rollup_1h_flat.
      */
     if wait_event_type is not null or wait_event is not null
        or query_id is not null then
@@ -3914,8 +4018,8 @@ $$;
  * window average; peak_aas / p99_aas are the max and 99th percentile of per
  * bucket AAS (zero-filled within data coverage) so a short spike is not hidden
  * by the average. backend_seconds is the absolute secondary. The window is
- * snapped to minute boundaries. Combining a wait filter with query_id needs
- * the raw wait<->query tie and raises past raw retention.
+ * snapped to minute boundaries. Every explicit query_id filter needs exact
+ * raw attribution and raises when only compacted history covers the window.
  */
 create or replace function ash.aas(
   since timestamptz default null,
@@ -3955,6 +4059,8 @@ declare
   v_source text;
   v_read_source text;
   v_tie boolean;
+  v_exact_query boolean;
+  v_coarser_query_history boolean;
   v_extrema_supported boolean;
   v_raw_start timestamptz;
 begin
@@ -3977,11 +4083,40 @@ begin
 
   v_tie := query_id is not null
            and (wait_event_type is not null or wait_event is not null);
+  v_exact_query := query_id is not null;
 
-  if v_tie then
+  if v_exact_query then
     v_source := 'raw';
-    v_raw_start := ash._raw_retention_start();
-    perform ash._raise_tie_retention(v_raw_start, v_start_ts, v_end_ts, v_from);
+    /*
+     * Preserve the existing tie guard. For the broader query_id-only case,
+     * raise only when ordinary source selection names a coarser source AND it
+     * has retained coverage in the requested pre-raw slice. A young install's
+     * first rollup can cover only raw's first retained minute, so forcing raw
+     * loses no attribution and must not raise even though _pick_source()'s
+     * fallback names the rollup.
+     */
+    v_coarser_query_history := ash._exact_query_uses_coarser(
+      v_start_ts,
+      v_end_ts,
+      database
+    );
+    if v_tie or v_coarser_query_history then
+      /*
+       * #163 gives the existing tie guard a logical ring boundary. When a
+       * selected rollup proves a physical raw-coverage gap, pass the physical
+       * oldest sample instead so the guard cannot approve silent data loss.
+       */
+      v_raw_start := case
+        when v_coarser_query_history then ash._raw_oldest_sample()
+        else ash._raw_retention_start()
+      end;
+      perform ash._raise_tie_retention(
+        v_raw_start,
+        v_start_ts,
+        v_end_ts,
+        v_from
+      );
+    end if;
     v_grain_secs := 60;
   else
     v_source := ash._pick_source_agg(ash.ts_to_timestamptz(v_start_ts),
@@ -3994,7 +4129,7 @@ begin
    * Genuine minute_counts keep unfiltered/database-only reads at minute
    * grain. If any contributing hour has legacy/incomplete detail, disclose
    * rollup_1h_flat and conservatively plan the whole window at hour grain.
-   * Wait/query filters always need the hour-grain arrays.
+   * Wait filters use hour-grain arrays; exact query filters already forced raw.
    */
   if v_source = 'rollup_1h' and wait_event_type is null
      and wait_event is null and query_id is null then
@@ -4097,7 +4232,9 @@ $$;
  * p99_aas is the 99th percentile of the per-grain AAS. Genuine rollup_1h
  * minute_counts preserve minute grain for unfiltered/database-only reads.
  * Hour-grain reads widen partial bounds and buckets; peak/p99 are NULL when
- * that retained grain exceeds the bucket the caller requested.
+ * that retained grain exceeds the bucket the caller requested. Explicit
+ * query_id filters force raw and raise only when coarser retained history
+ * would otherwise be discarded (apart from the existing wait-query tie guard).
  */
 create or replace function ash.timeline(
   since timestamptz default null,
@@ -4134,6 +4271,8 @@ declare
   v_source text;
   v_read_source text;
   v_tie boolean;
+  v_exact_query boolean;
+  v_coarser_query_history boolean;
   v_extrema_supported boolean;
   v_raw_start timestamptz;
 begin
@@ -4163,10 +4302,26 @@ begin
 
   v_tie := query_id is not null
            and (wait_event_type is not null or wait_event is not null);
-  if v_tie then
+  v_exact_query := query_id is not null;
+  if v_exact_query then
     v_source := 'raw';
-    v_raw_start := ash._raw_retention_start();
-    perform ash._raise_tie_retention(v_raw_start, v_start_ts, v_end_ts, v_from);
+    v_coarser_query_history := ash._exact_query_uses_coarser(
+      v_start_ts,
+      v_end_ts,
+      database
+    );
+    if v_tie or v_coarser_query_history then
+      v_raw_start := case
+        when v_coarser_query_history then ash._raw_oldest_sample()
+        else ash._raw_retention_start()
+      end;
+      perform ash._raise_tie_retention(
+        v_raw_start,
+        v_start_ts,
+        v_end_ts,
+        v_from
+      );
+    end if;
     v_grain_secs := 60;
   else
     v_source := ash._pick_source_agg(ash.ts_to_timestamptz(v_start_ts),
@@ -4345,8 +4500,10 @@ $$;
  * Per-key backend-count per grain row for a breakdown dimension, with uniform
  * filters. Companion to _grain_counts. key is the dimension value (text);
  * key_num carries the numeric query_id for the 'query_id' dimension (null
- * otherwise) so the caller can join query text. 'raw' supports the
- * wait<->query tie; rollup sources must not be asked for it.
+ * otherwise) so the caller can join query text. 'raw' supports exact query
+ * filters and wait<->query ties. An unfiltered rollup query breakdown returns
+ * retained query IDs plus a NULL residual for uncaptured / compacted-away
+ * attribution, keeping its total consistent with the source's wait counts.
  */
 create or replace function ash._grain_by(
   start_ts int4,
@@ -4556,15 +4713,75 @@ begin
 
   elsif dimension = 'query_id' then
     return query execute format($q$
-      select rollup.ts, rollup.query_counts[pos]::text as key,
-             rollup.query_counts[pos]::bigint as key_num,
-             sum(rollup.query_counts[pos + 1])::numeric as cnt
+      /*
+       * Per source row, one grouped query-array pass emits every named query
+       * plus a grand-total grouping set. The grand total becomes the
+       * non-negative wait-total difference: query_counts intentionally omits
+       * below-threshold IDs and an hourly row retains only its top 100.
+       *
+       * Writer-produced arrays are one-based pairs whose non-negative query
+       * totals do not exceed their wait totals. This keeps the residual in the
+       * same stream as named rows without the former second query_counts scan
+       * or a window-wide materialized expansion. Explicit query_id filters
+       * never reach this public rollup path; the residual predicate also keeps
+       * direct helper calls honest.
+       */
+      select
+        rollup.ts,
+        keyed.query_id::text as key,
+        keyed.query_id::bigint as key_num,
+        sum(keyed.cnt)::numeric as cnt
       from %s as rollup
-      cross join generate_subscripts(rollup.query_counts, 1) as pos
-      where pos %% 2 = 1 and rollup.ts >= $1 and rollup.ts < $2
+      cross join lateral (
+        select coalesce(
+          sum(rollup.wait_counts[pair_pos + 1]),
+          0
+        )::numeric as cnt
+        from generate_series(
+          1,
+          coalesce(cardinality(rollup.wait_counts), 0),
+          2
+        ) as pair_pos
+      ) as wait_total
+      cross join lateral (
+        select
+          case
+            when grouping(query_pair.query_id) = 0
+              then query_pair.query_id
+          end as query_id,
+          case
+            when grouping(query_pair.query_id) = 0
+              then sum(query_pair.cnt)
+            else greatest(
+              wait_total.cnt - coalesce(sum(query_pair.cnt), 0),
+              0
+            )
+          end::numeric as cnt,
+          grouping(query_pair.query_id) = 1 as is_residual
+        from (
+          select
+            rollup.query_counts[pair_pos] as query_id,
+            rollup.query_counts[pair_pos + 1]::numeric as cnt
+          from generate_series(
+            1,
+            coalesce(cardinality(rollup.query_counts), 0),
+            2
+          ) as pair_pos
+        ) as query_pair
+        group by grouping sets ((query_pair.query_id), ())
+      ) as keyed
+      where rollup.ts >= $1
+        and rollup.ts < $2
         and ($3 is null or rollup.datid = $3)
-        and ($4 is null or rollup.query_counts[pos] = $4)
-      group by rollup.ts, rollup.query_counts[pos]
+        and keyed.cnt > 0
+        and (
+          (keyed.is_residual and $4 is null)
+          or (
+            not keyed.is_residual
+            and ($4 is null or keyed.query_id = $4)
+          )
+        )
+      group by rollup.ts, keyed.query_id
     $q$, v_tbl)
     using start_ts, end_ts, v_datid, query_id;
 
@@ -4613,10 +4830,10 @@ $$;
 /*
  * The single vertical drill: AAS broken down by one dimension, every row
  * carrying avg/peak/p99 plus its share (pct) of the window total. Filters
- * compose with the dimension. Crossing the wait<->query tie (query_id
- * dimension with a wait filter, or a wait dimension with query_id) needs raw
- * samples and raises past raw retention. query_text is filled only for the
- * query_id dimension with pg_stat_statements present. order_by picks the
+ * compose with the dimension. Every explicit query_id filter needs exact raw
+ * attribution. An unfiltered rollup query breakdown carries unpreserved
+ * attribution in its NULL key. query_text is filled only for the query_id
+ * dimension with pg_stat_statements present. order_by picks the
  * ranking metric BEFORE the top-n cut: 'avg' (default; sustained load),
  * 'peak' or 'p99' (spike-first — a query dominant for one minute of an
  * incident ranks above cosmetic baseline rows that beat it on average).
@@ -4666,6 +4883,8 @@ declare
   v_source text;
   v_read_source text;
   v_tie boolean;
+  v_exact_query boolean;
+  v_coarser_query_history boolean;
   v_extrema_supported boolean;
   v_raw_start timestamptz;
   v_has_pgss boolean := false;
@@ -4702,11 +4921,34 @@ begin
             and (wait_event_type is not null or wait_event is not null))
         or (dimension = 'database' and query_id is not null
             and (wait_event_type is not null or wait_event is not null));
+  v_exact_query := query_id is not null
+                   or (
+                     dimension = 'query_id'
+                     and (
+                       wait_event_type is not null
+                       or wait_event is not null
+                     )
+                   );
 
-  if v_tie then
+  if v_exact_query then
     v_source := 'raw';
-    v_raw_start := ash._raw_retention_start();
-    perform ash._raise_tie_retention(v_raw_start, v_start_ts, v_end_ts, v_from);
+    v_coarser_query_history := ash._exact_query_uses_coarser(
+      v_start_ts,
+      v_end_ts,
+      database
+    );
+    if v_tie or v_coarser_query_history then
+      v_raw_start := case
+        when v_coarser_query_history then ash._raw_oldest_sample()
+        else ash._raw_retention_start()
+      end;
+      perform ash._raise_tie_retention(
+        v_raw_start,
+        v_start_ts,
+        v_end_ts,
+        v_from
+      );
+    end if;
     v_grain_secs := 60;
   else
     -- non-tie breakdown is an aggregate read: prefer rollup for wide windows.
@@ -4986,7 +5228,7 @@ declare
   v_grain2 int4;
   v_source1 text;
   v_source2 text;
-  v_top_tie boolean;
+  v_exact_query boolean;
   v_extrema_mismatch boolean;
 begin
   -- validate here, in compare's own frame, so the error names ash.compare
@@ -5103,19 +5345,16 @@ begin
     v_end2 := least(v_start2::bigint + 60, 2147483647)::int4;
   end if;
 
-  v_top_tie := (
-    dimension in ('wait_event_type', 'wait_event')
-    and query_id is not null
-  ) or (
-    dimension = 'query_id'
-    and (wait_event_type is not null or wait_event is not null)
-  ) or (
-    dimension = 'database'
-    and query_id is not null
-    and (wait_event_type is not null or wait_event is not null)
-  );
+  v_exact_query := query_id is not null
+                   or (
+                     dimension = 'query_id'
+                     and (
+                       wait_event_type is not null
+                       or wait_event is not null
+                     )
+                   );
 
-  if v_top_tie then
+  if v_exact_query then
     v_source1 := 'raw';
     v_source2 := 'raw';
   else
@@ -5221,10 +5460,10 @@ begin
     window1.pct, window2.pct
   from window1
   /*
-   * NULL-safe: the unattributed-query bucket keeps a NULL key in both windows
-   * and must pair up like any other key. (FULL JOIN cannot use IS NOT
-   * DISTINCT FROM, so NULL is folded to an out-of-band sentinel for the join
-   * only.)
+   * NULL-safe: raw uncaptured attribution and the broader rollup residual both
+   * keep a NULL key and must pair like any named query. (FULL JOIN cannot use
+   * IS NOT DISTINCT FROM, so NULL is folded to an out-of-band sentinel for the
+   * join only.)
    */
   full outer join window2
     on coalesce(window1.key, chr(1)) = coalesce(window2.key, chr(1))
@@ -6270,9 +6509,9 @@ begin
     from ash.top('query_id', v_from, v_to, n => 3) as top_row
   loop
     v_rank := v_rank + 1;
-    -- a NULL key is the unattributed bucket (no query_id captured).
+    -- NULL is uncaptured attribution on raw or the broader residual on rollup.
     return query select 'top_query_' || v_rank,
-      coalesce(v_rec.key, '(unattributed)')
+      coalesce(v_rec.key, '(other / unattributed)')
       || coalesce(' — ' || left(v_rec.query_text, 60), '')
       || ' (avg_aas ' || v_rec.avg_aas || ', ' || v_rec.pct || '%)';
   end loop;
@@ -6291,16 +6530,16 @@ comment on function ash.periods(timestamptz) is
 $$START HERE (US-1 triage): AAS for six standard trailing windows (1m, 5m, 1h, 1d, 1w, 1mo) requested to end at until (default now()), one row each. Columns (period, period_start, period_end, source, bucket, buckets_with_data, avg_aas, peak_aas, p99_aas): period bounds are effective and may snap outward for hour-only reads; peak/p99 vs avg distinguishes a spike from sustained load; buckets_with_data counts covered buckets at the effective grain named by bucket. Genuine rollup_1h.minute_counts keeps minute grain; legacy/incomplete detail on a minute-capable plan reports source = rollup_1h_flat, bucket = 1 hour, and NULL sub-hour peak/p99 instead of fabricated minute extremes. Next: locate the spike in time with ash.timeline(), then drill with ash.top().$$;
 
 comment on function ash.aas(timestamptz, timestamptz, text, text, bigint, name, interval) is
-$$Scalar AAS summary for one requested window [since, until) (defaults: last 1 hour). Optional uniform filters wait_event_type/wait_event/query_id/database. Columns (period_start, period_end, source, effective_bucket, buckets_expected, buckets_with_data, avg_aas, peak_aas, p99_aas, backend_seconds). period_start/period_end are effective bounds: hour-only rollup_1h reads snap partial bounds outward, and avg/backend_seconds are exact for those disclosed bounds. peak/p99 are NULL when retained grain exceeds the requested bucket, never hour averages presented as minute extremes. Genuine minute_counts preserves minute grain for unfiltered/database-only reads; legacy/incomplete detail on that minute-capable plan reports source = rollup_1h_flat. Combining a wait filter with query_id needs raw samples and raises past raw retention. source = raw|rollup_1m|rollup_1h|rollup_1h_flat|none. Next: ash.top('query_id', wait_event => ...).$$;
+$$Scalar AAS summary for one requested window [since, until) (defaults: last 1 hour). Optional uniform filters wait_event_type/wait_event/query_id/database. Columns (period_start, period_end, source, effective_bucket, buckets_expected, buckets_with_data, avg_aas, peak_aas, p99_aas, backend_seconds). period_start/period_end are effective bounds: hour-only rollup_1h reads snap partial bounds outward, and avg/backend_seconds are exact for those disclosed bounds. peak/p99 are NULL when retained grain exceeds the requested bucket, never hour averages presented as minute extremes. Genuine minute_counts preserves minute grain for unfiltered/database-only reads; legacy/incomplete detail on that minute-capable plan reports source = rollup_1h_flat. Every explicit query_id filter forces raw; it raises only when ordinary planning selects a rollup with coverage in the requested pre-raw slice, while a young query filter reads available raw rows when the first rollup covers only raw's first retained minute. source = raw|rollup_1m|rollup_1h|rollup_1h_flat|none. Next: ash.top('query_id', wait_event => ...).$$;
 
 comment on function ash.timeline(timestamptz, timestamptz, interval, text, text, bigint, name) is
-$$AAS time series (US-2 locate / US-6 capacity): one row per effective bucket. bucket => null auto-selects requested grain by span (<= 6h: 1 minute, <= 7d: 1 hour, else 1 day); hour-only rollup_1h reads widen partial bounds/buckets instead of falling through to missing rollup_1m data. Columns (bucket_start, source, data_points, avg_aas, peak_aas, p99_aas). data_points counts retained-grain rows, not one-second samples; 0 with NULL AAS means no stored observation. take_sample() also writes no row for a sampled idle tick, so idle and uncovered time remain indistinguishable until #137. Genuine minute_counts preserves minute extremes; legacy/incomplete detail on a minute-capable plan reports source = rollup_1h_flat. peak/p99 are NULL whenever retained grain exceeds the requested bucket. Order by peak_aas desc nulls last, then drill with ash.top().$$;
+$$AAS time series (US-2 locate / US-6 capacity): one row per effective bucket. bucket => null auto-selects requested grain by span (<= 6h: 1 minute, <= 7d: 1 hour, else 1 day); hour-only rollup_1h reads widen partial bounds/buckets instead of falling through to missing rollup_1m data. Columns (bucket_start, source, data_points, avg_aas, peak_aas, p99_aas). data_points counts retained-grain rows, not one-second samples; 0 with NULL AAS means no stored observation. take_sample() also writes no row for a sampled idle tick, so idle and uncovered time remain indistinguishable until #137. Genuine minute_counts preserves minute extremes; legacy/incomplete detail on a minute-capable plan reports source = rollup_1h_flat. peak/p99 are NULL whenever retained grain exceeds the requested bucket. Every explicit query_id filter follows aas()'s exact-raw/coarser-history rule. Order by peak_aas desc nulls last, then drill with ash.top().$$;
 
 comment on function ash.top(text, timestamptz, timestamptz, text, text, bigint, name, int, interval, text) is
-$$The single vertical drill (US-3): AAS broken down by wait_event_type|wait_event|query_id|database. Columns (key, query_text, source, period_start, period_end, effective_bucket, avg_aas, peak_aas, p99_aas, backend_seconds, pct). Hour-only rollup_1h dimensions snap partial bounds outward; the effective bounds/bucket disclose that degradation and peak/p99 are NULL when retained grain exceeds the requested bucket. Plain database breakdowns retain minute precision through per-(hour,datid) minute_counts; database plus wait/query filters remains hour-grain. order_by in avg|peak|p99 applies before n; when the requested extreme is unavailable it falls back to avg ordering. A NULL query_id key is real unattributed load. The wait<->query tie reads raw and raises past raw retention. source = raw|rollup_1m|rollup_1h|rollup_1h_flat|none.$$;
+$$The single vertical drill (US-3): AAS broken down by wait_event_type|wait_event|query_id|database. Columns (key, query_text, source, period_start, period_end, effective_bucket, avg_aas, peak_aas, p99_aas, backend_seconds, pct). Hour-only rollup_1h dimensions snap partial bounds outward; the effective bounds/bucket disclose that degradation and peak/p99 are NULL when retained grain exceeds the requested bucket. Plain database breakdowns retain minute precision through per-(hour,datid) minute_counts; database plus a wait filter remains hour-grain. order_by in avg|peak|p99 applies before n; when the requested extreme is unavailable it falls back to avg ordering. For query_id, raw NULL means uncaptured attribution; rollup NULL is the exact uncaptured/compacted-away residual and competes for n. Every explicit query_id filter forces raw and uses the coarser-history retention guard; a query breakdown plus wait filter needs the raw tie. source = raw|rollup_1m|rollup_1h|rollup_1h_flat|none.$$;
 
 comment on function ash.compare(timestamptz, timestamptz, timestamptz, timestamptz, text, int, text, text, bigint, name, interval) is
-$$Before/after comparison of two windows (US-7). dimension => null gives one overall row; a dimension gives top keys by abs(avg_delta). Columns (key, query_text, source_1, source_2, period_start_1, period_end_1, period_start_2, period_end_2, effective_bucket_1, effective_bucket_2, avg_aas_1, avg_aas_2, avg_delta, peak_aas_1, peak_aas_2, p99_aas_1, p99_aas_2, pct_1, pct_2). Sources and effective plans are disclosed per window. If retained read grains differ, both peak values and both p99 values are NULL as incomparable even when explicit effective buckets match; honest averages/delta remain. No-coverage sides and avg_delta are NULL plus a NOTICE; within a covered window an absent key is a true zero.$$;
+$$Before/after comparison of two windows (US-7). dimension => null gives one overall row; a dimension gives top keys by abs(avg_delta). Columns (key, query_text, source_1, source_2, period_start_1, period_end_1, period_start_2, period_end_2, effective_bucket_1, effective_bucket_2, avg_aas_1, avg_aas_2, avg_delta, peak_aas_1, peak_aas_2, p99_aas_1, p99_aas_2, pct_1, pct_2). Sources and effective plans are disclosed per window. If retained read grains differ, both peak values and both p99 values are NULL as incomparable even when explicit effective buckets match; honest averages/delta remain. No-coverage sides and avg_delta are NULL plus a NOTICE; within a covered window an absent key is a true zero. Explicit query_id filters force raw on both sides; unfiltered rollup query comparisons include and NULL-safe-pair each side's compacted-attribution residual.$$;
 
 comment on function ash.samples(timestamptz, timestamptz, int, text, text, bigint, name) is
 $$Decoded raw sample rows, newest first (US-5 raw evidence) over [since, until) (default last 1 hour), up to n. Uniform filters wait_event_type/wait_event/query_id/database. Columns (sample_time, database_name, active_backends, wait_event, query_id, query_text). query_text needs pg_stat_statements AND that the caller holds pg_read_all_stats (e.g. via pg_monitor membership); it is null otherwise — a plain ash.grant_reader() role without pg_read_all_stats sees null even with pgss installed, because pgss restricts query text to the owning role. When pgss lives outside public, the caller also needs USAGE on that schema, else query_text is null. Reads ash.sample directly (raw retention only).$$;

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -6205,12 +6205,34 @@ declare
   v_aas record;
   v_rec record;
   v_rank int;
+  v_drill_source text;
+  v_drill_period_start timestamptz;
+  v_drill_period_end timestamptz;
+  v_drill_effective_bucket interval;
 begin
   select * into v_aas from ash.aas(v_from, v_to);
   if v_aas.buckets_with_data = 0 then
     return query select 'status'::text, 'no data in this time range'::text;
     return;
   end if;
+
+  /*
+   * The headline can use rollup_1h minute_counts while the embedded
+   * wait/query drills necessarily use hourly arrays. Capture that shared
+   * dimensional plan so a widened drill is never presented under the
+   * headline's narrower bounds.
+   */
+  select
+    top_row.source,
+    top_row.period_start,
+    top_row.period_end,
+    top_row.effective_bucket
+  into
+    v_drill_source,
+    v_drill_period_start,
+    v_drill_period_end,
+    v_drill_effective_bucket
+  from ash.top('wait_event', v_from, v_to, n => 1) as top_row;
 
   return query select 'period_start'::text, v_aas.period_start::text;
   return query select 'period_end'::text, v_aas.period_end::text;
@@ -6220,6 +6242,12 @@ begin
   return query select 'peak_aas'::text, v_aas.peak_aas::text;
   return query select 'p99_aas'::text, v_aas.p99_aas::text;
   return query select 'backend_seconds'::text, v_aas.backend_seconds::text;
+  return query select 'drill_source'::text, v_drill_source;
+  return query
+    select 'drill_period_start'::text, v_drill_period_start::text;
+  return query select 'drill_period_end'::text, v_drill_period_end::text;
+  return query
+    select 'drill_effective_bucket'::text, v_drill_effective_bucket::text;
 
   return query
   select 'databases_active'::text,
@@ -6284,7 +6312,7 @@ comment on function ash.chart(timestamptz, timestamptz, interval, int, int, bool
 $$Human render helper: stacked ASCII per-bucket AAS chart over [since, until) (default last 1 hour). Series/legend = the window-wide top n wait events PLUS any event that is top-1 in at least one bucket, plus Other. bucket => null auto-selects grain by span. On rollup_1h the chart snaps partial bounds/buckets outward and emits a NOTICE naming source and effective plan; it never silently falls through to unavailable rollup_1m data. Presentation-only (bucket_start, aas, detail, chart); for typed data use ash.timeline(). Enable ANSI color with color => true or "set ash.color = on".$$;
 
 comment on function ash.summary(timestamptz, timestamptz) is
-$$Human render helper: key/value AAS overview for one window [since, until) (default last 1 hour) — the companion to ash.periods(). Returns (metric, value): effective period bounds, source, buckets_with_data, avg/peak/p99 AAS, backend_seconds, databases_active, and top waits/queries. Presentation-only; source = rollup_1h_flat means the bucket count is hourly. For typed data use ash.aas() and ash.top().$$;
+$$Human render helper: key/value AAS overview for one window [since, until) (default last 1 hour) — the companion to ash.periods(). Returns (metric, value): headline effective period bounds/source, buckets_with_data, avg/peak/p99 AAS, backend_seconds, databases_active, and top waits/queries. drill_source, drill_period_start/end, and drill_effective_bucket separately disclose the shared wait/query drill plan, which may widen beyond the headline's minute-precise window on rollup_1h. Presentation-only; source = rollup_1h_flat means the bucket count is hourly. For typed data use ash.aas() and ash.top().$$;
 
 /*
  * Schema-level map: one obj_description() lookup orients a human or agent on


### PR DESCRIPTION
## Stack / scope

Addresses #136. This reworks and supersedes the approach in #150; it does not modify #150's branch.

This PR is intentionally stacked on #182 (`agent/w2-b1` at `2af229a`). #182 is still open/draft, so this branch has **not** been rebased onto `main`; rebase it after #182 lands. Do not merge this PR before its base. This does not close #122, #156, or #163.

## What changed

- Rollup-backed, unfiltered `top('query_id')` now emits a positive `NULL` residual equal to `max(total wait counts - preserved named query counts, 0)` per source row. That residual enters the same ranking stream before `n`, so compacted-away load can win a top-N slot.
- The residual implementation scans each row's `query_counts` once with `GROUPING SETS` and its `wait_counts` once. It removes #150's second relation/query-array scan and window-wide materialized expansion.
- Every explicit `query_id` filter uses raw samples. The widened retention guard is deliberately narrow: it raises only when ordinary planning selects a rollup that has matching retained coverage in the requested slice before the physical oldest raw sample.
  - `_pick_source()` naming a fallback rollup is not sufficient.
  - The proof is scoped to the requested database.
  - Valid `rollup_1h.minute_counts` must contain a non-NULL pre-raw minute; legacy/incomplete hourly detail is handled conservatively.
  - Physical `_raw_oldest_sample()` is passed to the guard when real coarser history exists; tie-only calls without such history retain `_raw_retention_start()`. That composes with #163's pending logical/physical boundary split.
- `compare()` NULL-safely pairs rollup residuals, and `summary()` renders them as `(other / unattributed)` rather than claiming all compacted load was never captured.

## Five-minute install proof

The regression fixture holds one raw row with seven appearances of query 111, five minutes old. It also holds first-minute `rollup_1m` and valid-detail `rollup_1h` rows covering only that same retained raw minute. Even though `_pick_source(default-left-edge)` names a fallback rollup, the exact-query readers remain usable:

- `ash.aas(query_id => 111)`: `source=raw`, `buckets_with_data=1`, `backend_seconds=7.00`
- `ash.timeline(query_id => 111)`: 60 rows, one data row, `source=raw`, data-row `avg_aas=0.12`
- `ash.top('database', query_id => 111)`: `source=raw`, `backend_seconds=7.00`, `pct=100.00`
- `ash.compare(..., dimension => 'database', query_id => 111)`: `source_1=raw`, `source_2=raw`, `avg_delta=0.00`, both percentages `100.00`

The same fixture proves that unrelated database history does not raise, while a matching old rollup outside raw coverage does raise.

## Combined source-selection rule re-derived on #182

| Reader | Source selection | Query residual | peak / p99 rule |
|---|---|---|---|
| `aas` | Any explicit `query_id` forces `raw`; matching pre-raw rollup history raises. Wait+query retains the tie guard. Otherwise `_pick_source_agg()` applies: spans over one hour prefer `rollup_1m` when the requested start is within its retention; other calls fall through to `_pick_source()`. Unfiltered/database-only `rollup_1h` reads use valid minute detail, or disclose `rollup_1h_flat`; wait-filtered hourly reads use hour arrays. | None. | NULL whenever retained grain exceeds the requested bucket; otherwise computed at the retained/effective grain. |
| `timeline` | Same exact-query and aggregate rules as `aas`, independently for its window. | None. | Same retained-grain rule per effective timeline bucket. |
| `top` | Explicit `query_id`, or `dimension='query_id'` plus a wait filter, forces `raw`. Other breakdowns use `_pick_source_agg()`. Plain hourly database breakdowns may use valid minute detail; hourly wait/query dimensions remain hour-grain. | Emitted only for unfiltered rollup query breakdowns, before ranking and `n`; raw NULL remains genuinely uncaptured attribution. | Rollup-1m query rows retain minute extrema. Rollup-1h query/wait rows are hour-grain, so sub-hour peak/p99 are NULL. |
| `compare` | Coverage/retention comes from per-window `aas`; dimensional rows come from per-window `top`. Explicit query filters force both sides raw. A query dimension with a wait filter is raw. Otherwise each side independently selects its aggregate source. | Each rollup-backed query side emits its own residual; the full join pairs NULL keys exactly once. | Inherits `top`'s support rule, then NULLs peak and p99 on both sides when retained grains or effective buckets differ. |

There is no disagreement with #182: its effective bounds, disclosed bucket, `rollup_1h_flat`, and honest extrema NULLing remain authoritative. Exact query filters simply bypass compacted sources. The known `_pick_source_agg()` end-watermark/completeness gap remains #122 and is not claimed fixed here.

## RED / GREEN (verbatim)

### 1. Residual competes for top-N

RED:

```text
ERROR:  residual top-N mismatch: key=111 source=rollup_1m seconds=3.00 pct=100.00
CONTEXT:  PL/pgSQL function inline_code_block line 98 at ASSERT
```

GREEN:

```text
NOTICE:  issue #136 rollup_1m residual GREEN: named=3.00/11.54 residual=23.00/88.46 top1=NULL compare=NULL/0.00
DO
```

The same block exact-asserts two rows, `26.00` backend-seconds, `100.00%`, one NULL-safe compare residual with delta `0.00`, and the exact summary label/value.

### 2. `rollup_1h` top-100 compaction

RED:

```text
ERROR:  rollup_1h top-100 mismatch: rows=100 total=300.00 pct=100.00 residual=/ named=3.00/1.00 source= bucket= peak= p99=
CONTEXT:  PL/pgSQL function inline_code_block line 126 at ASSERT
```

GREEN:

```text
NOTICE:  issue #136 rollup_1h top-100 GREEN: rows=101 total=400.00 pct=100.00 residual=100.00/25.00
DO
```

The fixture stores 100 named rows / 300 seconds after hourly top-set truncation while wait totals remain 400 seconds. The final result is 101 rows / 400 seconds / 100%, with an exact 100-second residual and NULL peak/p99 at hour grain.

### 3. Narrowed exact-query widening

RED from the broad `query_id => guard` implementation (same-minute first rollup present):

```text
ERROR:  young-install query_id errors: aas=pg_ash: this drill needs exact raw query attribution; raw retention starts at 2026-07-27 18:20:00+00 but the requested window starts at 2026-07-27 17:25:53.654044+00. Narrow the window to start at or after 2026-07-27 18:20:00+00 (the window end is still inside raw retention), or remove query_id. timeline=pg_ash: this drill needs exact raw query attribution; raw retention starts at 2026-07-27 18:20:00+00 but the requested window starts at 2026-07-27 17:25:53.654044+00. Narrow the window to start at or after 2026-07-27 18:20:00+00 (the window end is still inside raw retention), or remove query_id. top=pg_ash: this drill needs exact raw query attribution; raw retention starts at 2026-07-27 18:20:00+00 but the requested window starts at 2026-07-27 17:25:53.654044+00. Narrow the window to start at or after 2026-07-27 18:20:00+00 (the window end is still inside raw retention), or remove query_id. compare=pg_ash: this drill needs exact raw query attribution; raw retention starts at 2026-07-27 18:20:00+00 but the requested window starts at 2026-07-27 18:15:00+00. Narrow the window to start at or after 2026-07-27 18:20:00+00 (the window end is still inside raw retention), or remove query_id.
CONTEXT:  PL/pgSQL function inline_code_block line 128 at ASSERT
```

GREEN:

```text
NOTICE:  issue #136 young-install GREEN: same-minute 1m/1h rollups ignored; aas=raw/7.00 timeline=raw/0.12 top=raw/7.00 compare=raw/raw; other-db allowed; old rollup rejected
DO
```

## Residual cost measurement

PostgreSQL 17.9; `shared_buffers=128MB`, `work_mem=4MB`, JIT off. Fixture: 43,200 `rollup_1m` rows (30 days × one database, 86 MiB table), each with 100 query pairs, 32 wait pairs, and a 75-count residual. Each variant was fully consumed with count/sum and run three times under `EXPLAIN (ANALYZE, BUFFERS, TIMING OFF)`.

| Variant | Three runs | Median | Relative |
|---|---:|---:|---:|
| #182 base, no residual | 22.700604s, 27.425866s, 41.263122s | 27.425866s | baseline |
| Straight #150 residual CTE / second query scan | 29.271280s, 44.815038s, 34.828003s | 34.828003s | 27.0% slower than base |
| Final per-row grouped stream | 4.261402s, 4.159544s, 3.967029s | 4.159544s | 88.1% faster than naive; 84.8% faster than base |

Naive #150 spilled 2,628,179 temp blocks read / 2,629,970 written (about 20.05 / 20.07 GiB; shared hit/read 800/20,928). Final spilled 10,172 / 10,192 temp blocks (about 79.5 / 79.6 MiB; shared hit/read 531/10,384). Naive and final outputs were identical: 4,363,200 rows and total count 29,160,000.

This is relevant to #156's rollup-prefix cost class, but it changes only the dimensional query-array work; it does not resolve or close #156.

## Validation

- PostgreSQL 17.9 fresh-path reapply and focused regression: GREEN.
- Existing rollup-source readers, 1h seam, #182 grain honesty, calendar/spike ordering, report/compare/retention/chart regressions on PostgreSQL 17.9: GREEN.
- Focused #136 fixture on PostgreSQL 14.23 and 18.4: GREEN.
- Simulated #163 logical/physical split: same-minute tie allowed; matching physical rollup gap rejected.
- Installer idempotent reapply: GREEN.
- Workflow YAML parse, docs guard, and `git diff --check`: GREEN.
- Two independent SQL reviews and one docs/test review: no blocker after fixes.

## Exact touched line ranges

Relative to #182 head, final-file line numbers:

- `.github/workflows/test.yml`: 4206-4892
- `README.md`: 231-246
- `blueprints/AAS_API.md`: 38-42, 124-125, 132-139, 172, 180-181, 219-240, 244-249, 251, 255-256, 289-293, 462, 464-478
- `blueprints/AAS_EXAMPLES.md`: 240-253, 320-322, 325, 328-330, 337-338, 341
- `blueprints/AAS_USER_STORIES.md`: 96-99, 169-170, 227-231
- `sql/ash-install.sql`: 191-192, 2574, 3496, 3500-3516, 3528, 3585-3589, 3611-3620, 3640-3732, 3756, 3760-3764, 3780-3783, 3793-3797, 3893-3896, 4021-4022, 4062-4063, 4086, 4088, 4090-4119, 4132, 4235-4237, 4274-4275, 4305-4306, 4308-4324, 4503-4506, 4716-4733, 4735-4774, 4776-4784, 4833-4836, 4886-4887, 4924-4933, 4935-4951, 5231, 5348-5355, 5357, 5463-5466, 6512, 6514, 6533, 6536, 6539, 6542

No sibling-owned reader-window validation, privilege, rotation, or production-container surface was changed.
