### PR TITLE
fix(ci): quiesce release-upgrade scheduler fixture

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7847,6 +7847,42 @@ jobs:
           select set_config('pg_ash.expected_version', :'expected_version', false);
           \i /tmp/ash-v1.5-install.sql
 
+          /*
+           * Earlier matrix steps can leave a pg_cron worker already
+           * dispatched even after uninstall unschedules its job. Hold all
+           * scheduler locks through this fixture before manually inserting a
+           * backdated sample: otherwise a delayed worker can advance the
+           * watermark past that row, or make the explicit rollup below return
+           * 0 on its try-lock. Acquire in dependency order (rotate may take
+           * rollup; rollup may take sampler), clear any state a worker wrote
+           * during the non-transactional v1.5 install, and release in reverse
+           * below.
+           */
+          select ash.stop();
+          select pg_advisory_lock(
+            hashtext('pg_ash')::int4,
+            hashtext('pg_ash_rotate')::int4
+          );
+          select pg_advisory_lock(
+            hashtext('pg_ash')::int4,
+            hashtext('pg_ash_rollup')::int4
+          );
+          select pg_advisory_lock(
+            hashtext('pg_ash')::int4,
+            hashtext('pg_ash_sampler')::int4
+          );
+          truncate ash.sample, ash.rollup_1m, ash.rollup_1h;
+          truncate
+            ash.query_map_0,
+            ash.query_map_1,
+            ash.query_map_2
+          restart identity;
+          truncate ash.wait_event_map restart identity;
+          update ash.config
+          set last_rollup_1m_ts = null,
+              last_rollup_1h_ts = null
+          where singleton;
+
           do $$
           begin
             assert (select version from ash.config where singleton) = '1.5',
@@ -7872,7 +7908,8 @@ jobs:
           update ash.config
           set missed_samples = 42,
               sample_interval = interval '7 seconds',
-              include_bg_workers = true
+              include_bg_workers = true,
+              sampling_enabled = true
           where singleton;
 
           do $$
@@ -8247,6 +8284,18 @@ jobs:
           reset role;
 
           drop table public.v15_acl_before;
+          select pg_advisory_unlock(
+            hashtext('pg_ash')::int4,
+            hashtext('pg_ash_sampler')::int4
+          );
+          select pg_advisory_unlock(
+            hashtext('pg_ash')::int4,
+            hashtext('pg_ash_rollup')::int4
+          );
+          select pg_advisory_unlock(
+            hashtext('pg_ash')::int4,
+            hashtext('pg_ash_rotate')::int4
+          );
           select ash.uninstall('yes');
           drop role ash_b1_reader;
           EOF


### PR DESCRIPTION
## Summary

Restore deterministic `main` CI after #185 exposed a pre-existing scheduler race in the #107 real-v1.5 upgrade fixture.

- call `ash.stop()` after installing the pinned v1.5 payload
- hold the ASH scheduler locks for the full fixture in dependency order (`rotate -> rollup -> sampler`)
- clear raw, rollup, dictionary, and watermark state after the locks are held, so a worker that ran during the non-transactional v1.5 install cannot contaminate the fixture
- release the locks in reverse after all #107 assertions
- explicitly restore the representative fixture state `sampling_enabled = true`

## Assertion integrity

The failing assertion is **unchanged**:

- before: `ash.report(...).coverage.minutes_with_data = 1`
- after: `ash.report(...).coverage.minutes_with_data = 1`

The assertion was not wrong and no product behavior changed. Earlier matrix steps can leave an already-dispatched pg_cron worker after its job is unscheduled. That worker could advance the rollup watermark past the fixture's backdated seed or win the explicit rollup's try-lock. The patch fixes fixture isolation instead of weakening coverage.

## Evidence

- Main failure: https://github.com/NikolayS/pg_ash/actions/runs/30299639538 (PG17/18 failed at the exact one-covered-minute assertion; PG19's service image pull failed independently)
- RED: with an intentionally delayed pre-existing rollup backend, the old fixture advanced the watermark and the explicit rollup returned `0`, leaving zero rows for the seeded minute
- GREEN: the revised held-lock + reset fixture passed the complete real-v1.5-to-current #107 step on PostgreSQL 17 + pg_cron
- adversarial GREEN: pre-lock contamination was removed; a post-lock delayed backend remained unable to advance the watermark; same-session v1.5/current `rollup_minute()` and `take_sample()` re-entered their locks successfully; all reverse unlocks returned true
- `git diff --check`, workflow YAML parse, and `actionlint` pass

This PR changes only `.github/workflows/test.yml`.