### PR TITLE
release: return processed grains from rollups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5667,6 +5667,200 @@ jobs:
             raise notice 'Rollup hour different-length arrays test PASSED';
           end;
           $$;
+
+          /*
+           * #191: return processed time grains, independently of the number of
+           * per-database rows written. Exercise both the historically invisible
+           * single-database case and the failing two-database case.
+           */
+          do $rollup_return_contract$
+          declare
+            v_anchor int4 := ash.ts_from_timestamptz(
+              date_trunc('hour', statement_timestamp()) - interval '1 hour'
+            );
+            v_datids bigint;
+            v_expected_datids int;
+            v_hour_result int;
+            v_hour_rows bigint;
+            v_hour_watermark int4;
+            v_minute_result int;
+            v_minute_rows bigint;
+            v_minute_watermark int4;
+            v_wait_id smallint;
+          begin
+            select ash._register_wait(
+              'active',
+              'Issue191',
+              'ReturnContract'
+            )
+            into v_wait_id;
+
+            for v_expected_datids in 1..2 loop
+              truncate table ash.sample;
+              truncate table ash.rollup_1m, ash.rollup_1h;
+              update ash.config
+              set current_slot = 0,
+                sample_interval = interval '1 second',
+                last_rollup_1m_ts = v_anchor,
+                last_rollup_1h_ts = null
+              where singleton;
+
+              with database_ids as (
+                select database_row.oid as datid
+                from pg_catalog.pg_database as database_row
+                order by
+                  (
+                    database_row.datname = pg_catalog.current_database()
+                  ) desc,
+                  database_row.oid
+                limit v_expected_datids
+              )
+              insert into ash.sample (
+                sample_ts,
+                datid,
+                active_count,
+                data,
+                slot
+              )
+              select
+                v_anchor,
+                database_ids.datid,
+                1,
+                array[-v_wait_id::int, 1, 0]::int4[],
+                0
+              from database_ids;
+
+              select pg_catalog.count(distinct sample_row.datid)
+              into v_datids
+              from ash.sample as sample_row;
+              select ash.rollup_minute(1)
+              into v_minute_result;
+              select pg_catalog.count(*)
+              into v_minute_rows
+              from ash.rollup_1m;
+              select last_rollup_1m_ts
+              into v_minute_watermark
+              from ash.config
+              where singleton;
+
+              update ash.config
+              set last_rollup_1m_ts = v_anchor + 3600,
+                last_rollup_1h_ts = v_anchor
+              where singleton;
+              select ash.rollup_hour()
+              into v_hour_result;
+              select pg_catalog.count(*)
+              into v_hour_rows
+              from ash.rollup_1h;
+              select last_rollup_1h_ts
+              into v_hour_watermark
+              from ash.config
+              where singleton;
+
+              assert v_datids = v_expected_datids
+                and v_minute_result = 1
+                and v_minute_rows = v_expected_datids
+                and v_minute_watermark = v_anchor + 60
+                and v_hour_result = 1
+                and v_hour_rows = v_expected_datids
+                and v_hour_watermark = v_anchor + 3600,
+                format(
+                  'ash.rollup return contract (#191, %s databases): expected '
+                  'datids=%s minute_result=1 minute_rows=%s '
+                  'minute_watermark_delta=60 hour_result=1 hour_rows=%s '
+                  'hour_watermark_delta=3600, got datids=%s minute_result=%s '
+                  'minute_rows=%s minute_watermark_delta=%s hour_result=%s '
+                  'hour_rows=%s hour_watermark_delta=%s',
+                  v_expected_datids,
+                  v_expected_datids,
+                  v_expected_datids,
+                  v_expected_datids,
+                  v_datids,
+                  v_minute_result,
+                  v_minute_rows,
+                  v_minute_watermark - v_anchor,
+                  v_hour_result,
+                  v_hour_rows,
+                  v_hour_watermark - v_anchor
+                );
+            end loop;
+
+            /*
+             * Empty completed periods still consume a batch slot and advance
+             * the watermark, so they count as processed grains despite writing
+             * no per-database rows.
+             */
+            truncate table ash.sample;
+            truncate table ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set last_rollup_1m_ts = v_anchor,
+              last_rollup_1h_ts = null
+            where singleton;
+            select ash.rollup_minute(1)
+            into v_minute_result;
+            select pg_catalog.count(*)
+            into v_minute_rows
+            from ash.rollup_1m;
+            select last_rollup_1m_ts
+            into v_minute_watermark
+            from ash.config
+            where singleton;
+
+            update ash.config
+            set last_rollup_1m_ts = v_anchor + 3600,
+              last_rollup_1h_ts = v_anchor
+            where singleton;
+            select ash.rollup_hour()
+            into v_hour_result;
+            select pg_catalog.count(*)
+            into v_hour_rows
+            from ash.rollup_1h;
+            select last_rollup_1h_ts
+            into v_hour_watermark
+            from ash.config
+            where singleton;
+
+            assert v_minute_result = 1
+              and v_minute_rows = 0
+              and v_minute_watermark = v_anchor + 60
+              and v_hour_result = 1
+              and v_hour_rows = 0
+              and v_hour_watermark = v_anchor + 3600,
+              format(
+                'ash.rollup empty-grain contract (#191): expected '
+                'minute_result=1 minute_rows=0 minute_watermark_delta=60 '
+                'hour_result=1 hour_rows=0 hour_watermark_delta=3600, got '
+                'minute_result=%s minute_rows=%s minute_watermark_delta=%s '
+                'hour_result=%s hour_rows=%s hour_watermark_delta=%s',
+                v_minute_result,
+                v_minute_rows,
+                v_minute_watermark - v_anchor,
+                v_hour_result,
+                v_hour_rows,
+                v_hour_watermark - v_anchor
+              );
+
+            update ash.config
+            set last_rollup_1m_ts = ash.ts_from_timestamptz(
+              date_trunc('minute', statement_timestamp())
+            )
+            where singleton;
+            select ash.rollup_minute(1000000)
+            into v_minute_result;
+            assert v_minute_result = 0,
+              format(
+                'already-caught-up rollup_minute(1000000) expected 0, got %s',
+                v_minute_result
+              );
+
+            truncate table ash.sample;
+            truncate table ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set last_rollup_1m_ts = null,
+              last_rollup_1h_ts = null
+            where singleton;
+          end
+          $rollup_return_contract$;
           EOF
 
       - name: "Critical: rollup_hour waits for complete minute coverage"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -66,6 +66,10 @@ AAS-oriented 2.0 API:
   `revoke_reader()`. Other reader-function grants remain preserved, and
   complete reader bundles still gain newly introduced reader helpers.
   (issue #166; [PR #181](https://github.com/NikolayS/pg_ash/pull/181))
+- **Rollup return values now count time grains.** `ash.rollup_minute()` and
+  `ash.rollup_hour()` return processed minutes and hours rather than
+  per-database rows upserted, so activity from multiple databases no longer
+  inflates scheduler-visible results. (issue #191)
 
 ## Retired tooling
 

--- a/blueprints/CONFIGURABLE_PARTITIONS_AND_ROLLUP.md
+++ b/blueprints/CONFIGURABLE_PARTITIONS_AND_ROLLUP.md
@@ -584,7 +584,7 @@ create or replace function ash.rollup_minute(
                                  -- rotate() call: rotation_period_seconds / 60
                                  -- e.g., 1-day rotation → pass 1440
 )
-returns int  -- total rollup rows upserted
+returns int  -- total minute grains processed
 language plpgsql
 as $$
 declare
@@ -594,7 +594,6 @@ declare
   v_minute_end int4;
   v_batch_limit int;
   v_total int := 0;
-  v_count int;
   v_min_samples smallint;
 begin
   v_batch_limit := p_batch_limit;
@@ -658,8 +657,7 @@ begin
 
     -- ... (full SQL implementation TBD at coding time) ...
 
-    get diagnostics v_count = row_count;
-    v_total := v_total + v_count;
+    v_total := v_total + 1;
 
     -- Advance watermark transactionally
     update ash.config
@@ -692,7 +690,6 @@ declare
   v_hour_end int4;
   v_batch_limit int := 24;  -- catch up at most 24 hours per call
   v_total int := 0;
-  v_count int;
 begin
   select last_rollup_1h_ts into v_last_ts
   from ash.config where singleton;
@@ -730,8 +727,7 @@ begin
       wait_counts = excluded.wait_counts,
       query_counts = excluded.query_counts;
 
-    get diagnostics v_count = row_count;
-    v_total := v_total + v_count;
+    v_total := v_total + 1;
 
     update ash.config
     set last_rollup_1h_ts = v_hour_end

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -3556,7 +3556,8 @@ begin
       end if;
     end if;
 
-    v_total := v_total + v_count;
+    -- One loop iteration processes one minute, independent of datid row count.
+    v_total := v_total + 1;
 
     -- Advance watermark transactionally.
     update ash.config
@@ -3588,7 +3589,6 @@ declare
   v_hour_end int4;
   v_batch_limit int := 24;
   v_total int := 0;
-  v_count int;
 begin
   /*
    * Wait for the shared rollup lock instead of skipping. The hourly pg_cron
@@ -3677,8 +3677,8 @@ begin
       query_counts = excluded.query_counts,
       minute_counts = excluded.minute_counts;
 
-    get diagnostics v_count = row_count;
-    v_total := v_total + v_count;
+    -- One loop iteration processes one hour, independent of datid row count.
+    v_total := v_total + 1;
 
     update ash.config
     set last_rollup_1h_ts = v_hour_end

--- a/sql/migrations/ash-1.5-to-2.0.sql
+++ b/sql/migrations/ash-1.5-to-2.0.sql
@@ -24,7 +24,9 @@
  *     with `select ash.revoke_reader('pg_monitor')`), and
  *   * stamps ash.config.version = '2.0-beta1' (and the column default).
  *
- * Sampling, storage, rollups, and admin/lifecycle functions are unchanged.
+ * Sampling and storage are unchanged. Other admin/lifecycle behavior and
+ * rollup scheduling remain compatible; rollup_minute()/rollup_hour() correct
+ * only their return values to count time grains instead of per-database rows.
  * Re-apply-safe: the installer is idempotent (CREATE OR REPLACE / IF NOT
  * EXISTS plus the deterministic drop block), so running this script again is
  * a no-op.


### PR DESCRIPTION
Fixes #191.

Unblocks #192.

## Contract decision

`ash.rollup_minute(integer)` and `ash.rollup_hour()` now return the number of completed time grains processed, independent of how many `(grain, datid)` rows are upserted. This matches their catalog comments, the batch-limit model, and the operator-visible meaning of catch-up progress.

Each completed loop iteration counts once, including an empty grain: it consumes one batch slot and advances its watermark. A call with an already-caught-up watermark still returns exactly `0` because it processes no loop iterations.

## Changes

- increment rollup results once per processed minute/hour rather than by DML `ROW_COUNT`
- add exact CI assertions for one and two databases, physical row counts, watermark deltas, empty grains, and already-caught-up `rollup_minute(1000000)`
- align the historical rollup blueprint and 1.5-to-2.0 upgrade comment with the corrected contract
- disclose the user-visible return correction in `RELEASE_NOTES.md`

## Call-site audit

- `ash.rotate()` stores the minute-rollup result but never reads or compares it. Exceptions and its independent `(minute, datid)` completeness query remain authoritative, so #185's truncation safety is unchanged.
- `ash.rollup_cleanup()` does not consume either return value; it only shares the rollup advisory lock and continues returning physical deletion counts.
- `ash.status()` does not call either rollup function; it reports physical table rows and watermarks directly.
- pg_cron and documented external scheduler bodies execute bare `SELECT` statements and do not branch on the scalar.
- existing tests either discard results, assert `0` on no-work/busy/incomplete paths, assert `> 0`, or assert `1` for a single grain/database. Those expectations remain valid. PR #192's retained two-database assertion changes from RED to GREEN.

## Validation

After the required hand rebase onto main `3af54a7`:

- exact issue #191 RED on main: two datids produced two physical rows and returned `2` for one minute/hour grain
- exact issue #191 GREEN on this head: two physical rows remain, both functions return `1`, and watermarks advance by 60/3600 seconds
- exact added contract block: PASS for one/two datids, empty grains, and already-caught-up `0`
- complete #185/#162 cleanup and rotation regression: PASS
- independent static caller/contract review: no blocker
- composed with #192: all four feature-bearing surfaces PASS on both PG17 and PG14 (8/8)
- workflow YAML parse and `git diff --check`: PASS

The migration header was also corrected during rebase so it no longer broadly claims all admin/lifecycle functions are unchanged while documenting this intentional return-value correction.
