### PR TITLE
fix(ci): anchor v1.5 upgrade seed to completed minute

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9592,8 +9592,10 @@ jobs:
             v_wait_id smallint;
             v_query_map_id int4;
             v_slot smallint := ash.current_slot();
+            -- Use an exact completed-minute boundary: ts_from_timestamptz()
+            -- rounds fractional seconds to int4.
             v_sample_ts int4 := ash.ts_from_timestamptz(
-              now() - interval '1 minute'
+              date_trunc('minute', now()) - interval '1 minute'
             );
           begin
             select ash._register_wait('active', 'UpgradeProbe', 'Preserved')


### PR DESCRIPTION
Restores main after the PostgreSQL 15 release-upgrade gate hit a deterministic minute-boundary race.

The fixture previously passed `now() - interval '1 minute'` through `ash.ts_from_timestamptz()`. At second 59.5 or later, PostgreSQL rounds the fractional epoch value into the still-open current minute, so `rollup_minute()` correctly skips it and `ash.report()` correctly returns no coverage. The failed main job seeded at 21:01:59.565, exactly matching that boundary.

This anchors the seed at the exact prior-minute boundary. The assertion is not weakened or changed: before and after this PR, `coverage.minutes_with_data` must equal exactly 1. There is no product behavior change and therefore no release-note entry.

Evidence:
- Failed main Test run: https://github.com/NikolayS/pg_ash/actions/runs/30305008698
- Identical PR tree had passed minutes earlier: https://github.com/NikolayS/pg_ash/actions/runs/30304779707
- Isolated PostgreSQL 15 RED reproduced the rounding, zero rollup rows, and NULL report; the anchored fixture produced one rollup row and coverage 1.
- Workflow YAML parse and `git diff --check`: PASS.
- `codex review --commit`: no actionable findings.