### PR TITLE
release: keep stale rollups honest without losing fast path

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7081,6 +7081,126 @@ jobs:
         run: |
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f devel/tests/query_attribution_assert.sql
 
+      - name: "Test 2.0: stale and rounded-up rollup source selection"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          -- A wide aggregate read may prefer rollup_1m only when that rollup
+          -- covers the requested end. If raw covers the whole window while the
+          -- rollup worker lags, choosing rollup silently drops the recent load.
+          -- Conversely, a healthy rollup must keep the fast path when a
+          -- dashboard rounds until up to the next minute boundary.
+          do $$
+          declare
+            v_wait smallint;
+            v_start timestamptz := date_trunc('minute', now()) - interval '2 hours';
+            v_end timestamptz := date_trunc('minute', now());
+            v_start_ts int4;
+            v_recent_ts int4;
+            v_config record;
+            a record;
+          begin
+            select
+              current_slot,
+              num_partitions,
+              sample_interval,
+              rotation_period,
+              rotated_at,
+              last_rollup_1m_ts,
+              last_rollup_1h_ts
+            into v_config
+            from ash.config
+            where singleton;
+
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set current_slot = 0,
+                num_partitions = 3,
+                sample_interval = interval '1 second',
+                rotation_period = interval '1 day',
+                rotated_at = v_end,
+                last_rollup_1m_ts = ash.ts_from_timestamptz(
+                  v_start + interval '1 minute'
+                ),
+                last_rollup_1h_ts = null
+            where singleton;
+
+            select ash._register_wait('active', 'IO', 'StaleRollupProof')
+            into v_wait;
+            v_start_ts := ash.ts_from_timestamptz(v_start);
+            v_recent_ts := ash.ts_from_timestamptz(v_end - interval '1 minute');
+
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values (
+              v_start_ts, 0::oid, 1, 1,
+              array[v_wait, 1]::int4[], '{}'::int8[]
+            );
+            insert into ash.sample (
+              sample_ts, datid, active_count, data, slot
+            ) values
+              (v_start_ts, 0::oid, 1, array[-v_wait, 1, 0]::int4[], 0),
+              (v_recent_ts, 0::oid, 1, array[-v_wait, 1, 0]::int4[], 0);
+
+            select * into a from ash.aas(v_start, v_end);
+            assert a.source = 'raw',
+              'stale rollup must fall back to raw, got ' || a.source;
+            assert a.buckets_with_data = 2,
+              'raw fallback should retain both covered minutes, got '
+              || a.buckets_with_data;
+            assert a.backend_seconds = 2.00,
+              'raw fallback should retain both backend-seconds, got '
+              || a.backend_seconds;
+
+            truncate ash.rollup_1m;
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            )
+            select
+              ash.ts_from_timestamptz(minute_ts),
+              0::oid,
+              1,
+              1,
+              array[v_wait, 1]::int4[],
+              '{}'::int8[]
+            from generate_series(
+              v_start,
+              v_end - interval '1 minute',
+              interval '1 minute'
+            ) as minute_ts;
+            update ash.config
+            set last_rollup_1m_ts = ash.ts_from_timestamptz(v_end)
+            where singleton;
+
+            select * into a
+            from ash.aas(v_start, v_end + interval '1 minute');
+            assert a.source = 'rollup_1m',
+              'healthy rollup must keep the fast path for a rounded-up until, '
+              'got ' || a.source;
+            assert a.buckets_with_data = 120,
+              'healthy rollup should cover 120 complete minutes, got '
+              || a.buckets_with_data;
+            assert a.backend_seconds = 120.00,
+              'healthy rollup should retain 120 backend-seconds, got '
+              || a.backend_seconds;
+
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set current_slot = v_config.current_slot,
+                num_partitions = v_config.num_partitions,
+                sample_interval = v_config.sample_interval,
+                rotation_period = v_config.rotation_period,
+                rotated_at = v_config.rotated_at,
+                last_rollup_1m_ts = v_config.last_rollup_1m_ts,
+                last_rollup_1h_ts = v_config.last_rollup_1h_ts
+            where singleton;
+            raise notice 'stale/rounded-up rollup source selection PASSED';
+          end $$;
+          EOF
+
       - name: "Test 2.0: minute-grain peak/p99 survive the rollup_1h seam"
         env:
           PGPASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7110,6 +7110,7 @@ jobs:
                 num_partitions = 3,
                 sample_interval = interval '1 second',
                 rotation_period = interval '1 day',
+                rollup_1m_retention_days = 30,
                 rotated_at = v_end,
                 last_rollup_1m_ts = ash.ts_from_timestamptz(
                   v_start + interval '1 minute'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7086,6 +7086,8 @@ jobs:
           PGPASSWORD: postgres
         run: |
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          begin;
+
           -- A wide aggregate read may prefer rollup_1m only when that rollup
           -- covers the requested end. If raw covers the whole window while the
           -- rollup worker lags, choosing rollup silently drops the recent load.
@@ -7096,23 +7098,11 @@ jobs:
             v_wait smallint;
             v_start timestamptz := date_trunc('minute', now()) - interval '2 hours';
             v_end timestamptz := date_trunc('minute', now());
+            v_historical_end timestamptz := v_end - interval '30 minutes';
             v_start_ts int4;
             v_recent_ts int4;
-            v_config record;
             a record;
           begin
-            select
-              current_slot,
-              num_partitions,
-              sample_interval,
-              rotation_period,
-              rotated_at,
-              last_rollup_1m_ts,
-              last_rollup_1h_ts
-            into v_config
-            from ash.config
-            where singleton;
-
             truncate ash.sample_0, ash.sample_1, ash.sample_2;
             truncate ash.rollup_1m, ash.rollup_1h;
             update ash.config
@@ -7171,9 +7161,23 @@ jobs:
               interval '1 minute'
             ) as minute_ts;
             update ash.config
-            set last_rollup_1m_ts = ash.ts_from_timestamptz(v_end)
+            set last_rollup_1m_ts = ash.ts_from_timestamptz(v_historical_end)
             where singleton;
 
+            select * into a from ash.aas(v_start, v_historical_end);
+            assert a.source = 'rollup_1m',
+              'healthy historical rollup must use its covered watermark, got '
+              || a.source;
+            assert a.buckets_with_data = 90,
+              'historical rollup should cover 90 complete minutes, got '
+              || a.buckets_with_data;
+            assert a.backend_seconds = 90.00,
+              'historical rollup should retain 90 backend-seconds, got '
+              || a.backend_seconds;
+
+            update ash.config
+            set last_rollup_1m_ts = ash.ts_from_timestamptz(v_end)
+            where singleton;
             select * into a
             from ash.aas(v_start, v_end + interval '1 minute');
             assert a.source = 'rollup_1m',
@@ -7186,19 +7190,10 @@ jobs:
               'healthy rollup should retain 120 backend-seconds, got '
               || a.backend_seconds;
 
-            truncate ash.sample_0, ash.sample_1, ash.sample_2;
-            truncate ash.rollup_1m, ash.rollup_1h;
-            update ash.config
-            set current_slot = v_config.current_slot,
-                num_partitions = v_config.num_partitions,
-                sample_interval = v_config.sample_interval,
-                rotation_period = v_config.rotation_period,
-                rotated_at = v_config.rotated_at,
-                last_rollup_1m_ts = v_config.last_rollup_1m_ts,
-                last_rollup_1h_ts = v_config.last_rollup_1h_ts
-            where singleton;
             raise notice 'stale/rounded-up rollup source selection PASSED';
           end $$;
+
+          rollback;
           EOF
 
       - name: "Test 2.0: minute-grain peak/p99 survive the rollup_1h seam"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7088,9 +7088,10 @@ jobs:
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
           begin;
 
-          -- A wide aggregate read may prefer rollup_1m only when that rollup
-          -- covers the requested end. If raw covers the whole window while the
-          -- rollup worker lags, choosing rollup silently drops the recent load.
+          -- When raw covers a wide aggregate window, rollup_1m may replace it
+          -- only if that rollup covers the requested end. Otherwise a lagging
+          -- worker would silently drop recent raw load. Completeness for a
+          -- stalled rollup older than physical raw coverage remains #122.
           -- Conversely, a healthy rollup must keep the fast path when a
           -- dashboard rounds until up to the next minute boundary.
           do $$

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -70,6 +70,13 @@ AAS-oriented 2.0 API:
   `ash.rollup_hour()` return processed minutes and hours rather than
   per-database rows upserted, so activity from multiple databases no longer
   inflates scheduler-visible results. (issue #191)
+- **Wide aggregate readers now reject stale rollup coverage without losing the
+  fast path.** When raw is the canonical source for a wide window, readers fall
+  back to it if `rollup_1m` has not reached the requested end, clamped at the
+  latest complete-minute boundary; a dashboard `until` rounded up to the next
+  minute no longer makes a healthy rollup fall back to raw. Completeness when a
+  window starts before physical raw coverage remains tracked by issue #122.
+  ([PR #199](https://github.com/NikolayS/pg_ash/pull/199))
 
 ## Retired tooling
 

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -4041,16 +4041,15 @@ $$;
  * grain, so for anything wider than ~1 hour whose requested start is within
  * rollup_1m retention we prefer rollup_1m (a raw decode of a wide window spills
  * hundreds of MB — the last-24h read cost ~4.5s and ~500MB before this).
- * The rollup watermark must
- * also reach the latest complete minute whenever raw covers the window start;
- * otherwise a stalled rollup worker would hide newer raw load. Narrow windows
- * still fall through to _pick_source (raw preferred) so the freshest partial
- * minute is captured. When raw covers the window start, a rollup that is
- * disabled, cannot cover it, or lags the requested end falls back through
- * _pick_source. Completeness for a stalled rollup when the window starts
- * before physical raw coverage remains tracked by #122. Exact-query drills
- * and samples bypass this and force raw. The source column stays honest — it
- * names whatever was actually read.
+ * also reach the latest complete minute whenever raw is the preferred source
+ * at the window start; otherwise a stalled rollup worker would hide newer raw
+ * load. Narrow windows still fall through to _pick_source (raw preferred) so
+ * the freshest partial minute is captured. When raw covers the window start,
+ * a rollup that is disabled, cannot cover it, or lags the requested end falls
+ * back through _pick_source. Completeness for a stalled rollup when the window
+ * starts before physical raw coverage remains tracked by #122. Exact-query
+ * drills and samples bypass this and force raw. The source column stays honest
+ * — it names whatever was actually read.
  */
 create or replace function ash._pick_source_agg(
   since timestamptz,
@@ -4061,13 +4060,15 @@ language sql
 stable
 set search_path = pg_catalog, ash
 as $$
+  with fallback as (
+    select ash._pick_source(since) as source
+  )
   select case
     when extract(epoch from (until - since)) > 3600
          and ash._rollup_1m_retention_start() is not null
          and since >= ash._rollup_1m_retention_start()
          and (
-           ash._raw_retention_start() is null
-           or since < ash._raw_retention_start()
+           fallback.source <> 'raw'
            or coalesce(
                 (
                   select ash.ts_to_timestamptz(last_rollup_1m_ts)
@@ -4081,8 +4082,9 @@ as $$
                 false
               )
          ) then 'rollup_1m'
-    else ash._pick_source(since)
+    else fallback.source
   end
+  from fallback
 $$;
 
 /*

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -4041,15 +4041,15 @@ $$;
  * grain, so for anything wider than ~1 hour whose requested start is within
  * rollup_1m retention we prefer rollup_1m (a raw decode of a wide window spills
  * hundreds of MB — the last-24h read cost ~4.5s and ~500MB before this).
- * also reach the latest complete minute whenever raw is the preferred source
- * at the window start; otherwise a stalled rollup worker would hide newer raw
- * load. Narrow windows still fall through to _pick_source (raw preferred) so
- * the freshest partial minute is captured. When raw covers the window start,
- * a rollup that is disabled, cannot cover it, or lags the requested end falls
- * back through _pick_source. Completeness for a stalled rollup when the window
- * starts before physical raw coverage remains tracked by #122. Exact-query
- * drills and samples bypass this and force raw. The source column stays honest
- * — it names whatever was actually read.
+ * The rollup watermark must also reach the latest complete minute whenever raw
+ * is the preferred source at the window start; otherwise a stalled rollup
+ * worker would hide newer raw load. Narrow windows still fall through to
+ * _pick_source (raw preferred) so the freshest partial minute is captured.
+ * When raw covers the window start, a rollup that is disabled, cannot cover it,
+ * or lags the requested end falls back through _pick_source. Completeness for a
+ * stalled rollup when the window starts before physical raw coverage remains
+ * tracked by #122. Exact-query drills and samples bypass this and force raw.
+ * The source column stays honest — it names whatever was actually read.
  */
 create or replace function ash._pick_source_agg(
   since timestamptz,

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -4041,12 +4041,16 @@ $$;
  * grain, so for anything wider than ~1 hour whose requested start is within
  * rollup_1m retention we prefer rollup_1m (a raw decode of a wide window spills
  * hundreds of MB — the last-24h read cost ~4.5s and ~500MB before this).
- * #122 tracks the separate end-watermark/completeness gap. Narrow windows
+ * The rollup watermark must
+ * also reach the latest complete minute whenever raw covers the window start;
+ * otherwise a stalled rollup worker would hide newer raw load. Narrow windows
  * still fall through to _pick_source (raw preferred) so the freshest partial
- * minute is captured, and windows rollup can't cover (or where rollup is
- * disabled/lagging) still fall to raw / rollup_1h. Exact-query drills and
- * samples bypass this and force raw. The source column stays honest — it names
- * whatever was actually read.
+ * minute is captured. When raw covers the window start, a rollup that is
+ * disabled, cannot cover it, or lags the requested end falls back through
+ * _pick_source. Completeness for a stalled rollup when the window starts
+ * before physical raw coverage remains tracked by #122. Exact-query drills
+ * and samples bypass this and force raw. The source column stays honest — it
+ * names whatever was actually read.
  */
 create or replace function ash._pick_source_agg(
   since timestamptz,
@@ -4060,7 +4064,23 @@ as $$
   select case
     when extract(epoch from (until - since)) > 3600
          and ash._rollup_1m_retention_start() is not null
-         and since >= ash._rollup_1m_retention_start() then 'rollup_1m'
+         and since >= ash._rollup_1m_retention_start()
+         and (
+           ash._raw_retention_start() is null
+           or since < ash._raw_retention_start()
+           or coalesce(
+                (
+                  select ash.ts_to_timestamptz(last_rollup_1m_ts)
+                           >= least(
+                                until,
+                                date_trunc('minute', now())
+                              )
+                  from ash.config
+                  where singleton
+                ),
+                false
+              )
+         ) then 'rollup_1m'
     else ash._pick_source(since)
   end
 $$;


### PR DESCRIPTION
## Summary

Relates to #122. Supersedes and reworks #123; this deliberately does **not** close #122.

#123 correctly prevented a lagging `rollup_1m` from hiding newer raw load, but compared its watermark with the unclamped `until`. A standard dashboard boundary of `date_trunc('minute', now()) + interval '1 minute'` is unreachable by that watermark, forcing a healthy wide read onto raw data.

This rework:

- delegates canonical fallback selection to `_pick_source(since)`;
- when that fallback is `raw`, requires the rollup watermark to reach `least(until, date_trunc('minute', now()))`;
- otherwise preserves the established picker result instead of duplicating B3's physical/logical raw-boundary logic.

## Measured performance

Five runs per implementation on the same local PostgreSQL 17.9 fixture: 21,600 one-second raw rows over six hours, 40 active backends per row, 6,096 kB raw table, and 360 healthy minute-rollup rows. Each call used the rounded-up dashboard boundary.

| Implementation / chosen source | Runs (ms) | Median |
| --- | --- | ---: |
| #123 (`6123780`), `raw` | 1494.746, 1345.164, 1386.175, 1364.884, 1351.251 | **1364.884 ms** |
| This branch (`100e95c`), `rollup_1m` | 7.521, 2.193, 1.980, 1.961, 1.914 | **1.980 ms** |

The rejected #123 path was **689.3× slower** on this reproduction. Both paths returned 360 covered buckets and `864000.00` backend-seconds; the discriminating difference was the selected source.

## Exact regression coverage

`Test 2.0: stale and rounded-up rollup source selection` runs in an isolated `BEGIN`/`ROLLBACK` fixture and asserts:

- stalled rollup with complete raw coverage: `source = 'raw'`, `buckets_with_data = 2`, `backend_seconds = 2.00`;
- healthy historical rollup: `source = 'rollup_1m'`, `buckets_with_data = 90`, `backend_seconds = 90.00`;
- healthy rollup with `until` rounded up one minute: `source = 'rollup_1m'`, `buckets_with_data = 120`, `backend_seconds = 120.00`.

The literal final test block is RED on untouched #123 head `6123780`:

```text
BEGIN
ERROR:  healthy rollup must keep the fast path for a rounded-up until, got raw
CONTEXT:  PL/pgSQL function inline_code_block line 89 at ASSERT
```

It is GREEN on this rebased branch:

```text
BEGIN
NOTICE:  stale/rounded-up rollup source selection PASSED
DO
ROLLBACK
```

## Explicit non-goal

A stalled rollup for a window beginning before physical raw coverage can still return a silently truncated rollup answer. The post-rebase probe remains:

```text
NOTICE:  older-than-raw stalled rollup: source=rollup_1m, buckets=1, backend_seconds=1.00
```

Completeness disclosure for that case is intentionally out of scope here and remains tracked by #122, which stays open.

## Post-rebase validation

Rebased immediately before push onto `origin/main` `3af54a7e552ad3f29225a1f7278138de4570ac78`, including #189, #182, #197, #180, and the later #186 documentation update.

- Fresh install and idempotent installer reapply: passed on PostgreSQL 17.9.
- Exact selector fixture: passed with the GREEN output above.
- Full #180 `until`-only/inverted-window fixture: passed (`B5 until-only reader windows PASSED`, `B5 inverted-window validation PASSED`, and `B5 #63 cross-horizon clamp PASSED`).
- `git diff --check`, workflow YAML parsing, and changed shell-block syntax: passed.
- Independent final diff review after the last rebase: no actionable blockers.
