### PR TITLE
fix: prevent rollup cleanup from permanently freezing rotation (#211)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3578,6 +3578,316 @@ jobs:
 
           echo "Critical bug #81 regression tests PASSED"
 
+      - name: "Critical bug #211: rollup cleanup must not freeze rotation"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          -- Recreate the legacy geometry that made cleanup and rotation
+          -- deadlock. The new constraint is removed only in this transaction;
+          -- ROLLBACK restores it and every fixture below.
+          begin;
+          alter table ash.config
+            drop constraint if exists config_raw_rollup_geometry_check;
+
+          do $$
+          declare
+            v_minute_ts int4;
+            v_wait_id smallint;
+            v_rollup_result int;
+            v_cleanup_result text;
+            v_rotate_result text;
+            v_current_slot smallint;
+            v_raw_rows bigint;
+            v_rollup_rows bigint;
+          begin
+            perform ash.stop();
+            truncate ash.sample;
+            truncate ash.rollup_1m;
+            truncate ash.rollup_1h;
+            truncate ash.wait_event_map restart identity cascade;
+            truncate ash.query_map_0 restart identity;
+            truncate ash.query_map_1 restart identity;
+            truncate ash.query_map_2 restart identity;
+
+            v_minute_ts := ash.ts_from_timestamptz(
+              date_trunc('minute', now() - interval '36 hours')
+            );
+            select ash._register_wait('active', 'Issue211', 'ExpiredRollup')
+            into v_wait_id;
+
+            update ash.config
+            set current_slot = 0,
+              rotated_at = now() - interval '2 days',
+              rotation_period = interval '1 day',
+              rollup_1m_retention_days = 1,
+              last_rollup_1m_ts = ash.ts_from_timestamptz(
+                date_trunc('minute', now())
+              ),
+              last_rollup_1h_ts = null,
+              sampling_enabled = true
+            where singleton;
+
+            insert into ash.sample (
+              sample_ts, datid, active_count, data, slot
+            ) values (
+              v_minute_ts,
+              0::oid,
+              1::smallint,
+              array[-v_wait_id, 1, 0]::integer[],
+              2::smallint
+            );
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values (
+              v_minute_ts,
+              0::oid,
+              1::smallint,
+              1::smallint,
+              array[v_wait_id, 1]::int4[],
+              '{}'::int8[]
+            );
+
+            -- Shipped job order: the forward-only watermark cannot revisit
+            -- this minute, then cleanup removes its already-built rollup.
+            select ash.rollup_minute(1000000) into v_rollup_result;
+            assert v_rollup_result = 0,
+              format('expired minute rollup result should be 0, got %s',
+                     v_rollup_result);
+
+            select ash.rollup_cleanup() into v_cleanup_result;
+            assert v_cleanup_result =
+              'cleanup: deleted 1 minute rows, 0 hourly rows',
+              format('unexpected cleanup result: %s', v_cleanup_result);
+            select count(*) into v_rollup_rows
+            from ash.rollup_1m
+            where ts = v_minute_ts and datid = 0::oid;
+            assert v_rollup_rows = 0,
+              format('expired minute should have 0 rollups, got %s',
+                     v_rollup_rows);
+
+            select ash.rotate() into v_rotate_result;
+            assert v_rotate_result =
+              'rotated: slot 0 -> 1, truncated slot 2 (sample + query_map)',
+              format('rotation did not recover after cleanup: %s',
+                     v_rotate_result);
+
+            select current_slot into v_current_slot
+            from ash.config where singleton;
+            select count(*) into v_raw_rows from ash.sample_2;
+            assert v_current_slot = 1,
+              format('current_slot should advance to 1, got %s',
+                     v_current_slot);
+            assert v_raw_rows = 0,
+              format('recovered rotation should leave 0 rows in slot 2, got %s',
+                     v_raw_rows);
+
+            raise notice 'issue #211 expired-rollup rotation recovery PASSED';
+          end $$;
+          rollback;
+
+          -- Preserve issue #81: a still-retained raw group whose watermark is
+          -- already past it must keep blocking truncation until its rollup is
+          -- genuinely complete. Also verify consecutive failures and reset.
+          begin;
+          do $$
+          declare
+            v_minute_ts int4;
+            v_wait_id smallint;
+            v_rotate_result text;
+            v_current_slot smallint;
+            v_raw_rows bigint;
+            v_status_values text[];
+          begin
+            perform ash.stop();
+            truncate ash.sample;
+            truncate ash.rollup_1m;
+            truncate ash.rollup_1h;
+            truncate ash.wait_event_map restart identity cascade;
+            truncate ash.query_map_0 restart identity;
+            truncate ash.query_map_1 restart identity;
+            truncate ash.query_map_2 restart identity;
+
+            v_minute_ts := ash.ts_from_timestamptz(
+              date_trunc('minute', now() - interval '2 minutes')
+            );
+            select ash._register_wait('active', 'Issue211', 'RetainedUnrolled')
+            into v_wait_id;
+
+            update ash.config
+            set current_slot = 0,
+              rotated_at = now() - interval '2 days',
+              rotation_period = interval '1 day',
+              rollup_1m_retention_days = 30,
+              last_rollup_1m_ts = ash.ts_from_timestamptz(
+                date_trunc('minute', now())
+              ),
+              last_rollup_1h_ts = null,
+              sampling_enabled = true
+            where singleton;
+            if exists (
+              select from information_schema.columns
+              where table_schema = 'ash'
+                and table_name = 'config'
+                and column_name = 'consecutive_rotate_failures'
+            ) then
+              execute 'update ash.config '
+                'set consecutive_rotate_failures = 0 where singleton';
+            end if;
+
+            insert into ash.sample (
+              sample_ts, datid, active_count, data, slot
+            ) values (
+              v_minute_ts,
+              0::oid,
+              1::smallint,
+              array[-v_wait_id, 1, 0]::integer[],
+              2::smallint
+            );
+
+            select ash.rotate() into v_rotate_result;
+            assert v_rotate_result =
+              'failed: pre-truncation rollup incomplete for 1 group(s) '
+              'in slot 2; slot not truncated',
+              format('retained unrolled group should block rotation, got: %s',
+                     v_rotate_result);
+            select current_slot into v_current_slot
+            from ash.config where singleton;
+            select count(*) into v_raw_rows from ash.sample_2;
+            assert v_current_slot = 0,
+              format('failed rotation should leave current_slot 0, got %s',
+                     v_current_slot);
+            assert v_raw_rows = 1,
+              format('failed rotation should preserve 1 raw row, got %s',
+                     v_raw_rows);
+            select array_agg(value order by value) into v_status_values
+            from ash.status()
+            where metric = 'consecutive_rotate_failures';
+            assert v_status_values = array['1']::text[],
+              format('status failure metric should be exactly {1}, got %s',
+                     coalesce(v_status_values::text, 'NULL'));
+
+            select ash.rotate() into v_rotate_result;
+            assert v_rotate_result =
+              'failed: pre-truncation rollup incomplete for 1 group(s) '
+              'in slot 2; slot not truncated',
+              format('second retained-group failure changed: %s',
+                     v_rotate_result);
+            select array_agg(value order by value) into v_status_values
+            from ash.status()
+            where metric = 'consecutive_rotate_failures';
+            assert v_status_values = array['2']::text[],
+              format('status failure metric should be exactly {2}, got %s',
+                     coalesce(v_status_values::text, 'NULL'));
+
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values (
+              v_minute_ts,
+              0::oid,
+              1::smallint,
+              1::smallint,
+              array[v_wait_id, 1]::int4[],
+              '{}'::int8[]
+            );
+            select ash.rotate() into v_rotate_result;
+            assert v_rotate_result =
+              'rotated: slot 0 -> 1, truncated slot 2 (sample + query_map)',
+              format('rotation should recover after complete rollup, got: %s',
+                     v_rotate_result);
+            select array_agg(value order by value) into v_status_values
+            from ash.status()
+            where metric = 'consecutive_rotate_failures';
+            assert v_status_values = array['0']::text[],
+              format('successful rotation should reset metric to {0}, got %s',
+                     coalesce(v_status_values::text, 'NULL'));
+
+            raise notice 'issue #211 retained-group gate and status PASSED';
+          end $$;
+          rollback;
+
+          -- Geometry must be rejected before rebuild_partitions() changes any
+          -- state, and direct writes to each participating config column must
+          -- be covered by the named cross-column constraint.
+          do $$
+          declare
+            v_result text := '<accepted>';
+            v_constraint text;
+            v_num_partitions smallint;
+            v_sampling_enabled bool;
+          begin
+            begin
+              perform ash.rebuild_partitions(32, 'yes');
+            exception when raise_exception then
+              get stacked diagnostics v_result = message_text;
+            end;
+            assert v_result =
+              'rebuild_partitions: 32 partitions at rotation_period 1 day '
+              'exceed rollup_1m retention 30 days; require '
+              '(num_partitions - 1) * rotation_period '
+              '<= rollup_1m_retention_days',
+              format('unexpected rebuild geometry result: %s', v_result);
+            select num_partitions, sampling_enabled
+            into v_num_partitions, v_sampling_enabled
+            from ash.config where singleton;
+            assert v_num_partitions = 3,
+              format('rejected rebuild should leave 3 partitions, got %s',
+                     v_num_partitions);
+            assert v_sampling_enabled = true,
+              format('rejected rebuild should leave sampling enabled, got %s',
+                     v_sampling_enabled);
+
+            begin
+              update ash.config
+              set rollup_1m_retention_days = 1
+              where singleton;
+              v_constraint := '<accepted retention>';
+            exception when check_violation then
+              get stacked diagnostics v_constraint = constraint_name;
+            end;
+            assert v_constraint = 'config_raw_rollup_geometry_check',
+              format('retention update constraint should be exact, got %s',
+                     coalesce(v_constraint, 'NULL'));
+
+            begin
+              update ash.config
+              set rotation_period = interval '16 days'
+              where singleton;
+              v_constraint := '<accepted rotation>';
+            exception when check_violation then
+              get stacked diagnostics v_constraint = constraint_name;
+            end;
+            assert v_constraint = 'config_raw_rollup_geometry_check',
+              format('rotation update constraint should be exact, got %s',
+                     coalesce(v_constraint, 'NULL'));
+
+            begin
+              update ash.config
+              set num_partitions = 32
+              where singleton;
+              v_constraint := '<accepted partitions>';
+            exception when check_violation then
+              get stacked diagnostics v_constraint = constraint_name;
+            end;
+            assert v_constraint = 'config_raw_rollup_geometry_check',
+              format('partition update constraint should be exact, got %s',
+                     coalesce(v_constraint, 'NULL'));
+
+            update ash.config
+            set rollup_1m_retention_days = 2
+            where singleton;
+            assert (
+              select rollup_1m_retention_days from ash.config where singleton
+            ) = 2,
+              'exact-boundary geometry should set retention to 2 days';
+            update ash.config
+            set rollup_1m_retention_days = 30
+            where singleton;
+
+            raise notice 'issue #211 geometry validation PASSED';
+          end $$;
+          EOF
+
       - name: "Test 2.0 readers over rollup sources"
         env:
           PGPASSWORD: postgres

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -268,7 +268,13 @@ create table if not exists ash.config (
   -- M-BUG-4: rows silently dropped by take_sample()'s inner exception handler.
   insert_errors              bigint not null default 0,
   -- M-BUG-6 / H-SEC-3: _register_wait dictionary-cap hit counter.
-  register_wait_cap_hits     bigint not null default 0
+  register_wait_cap_hits     bigint not null default 0,
+  -- Consecutive rotate() failure returns; reset only by a real rotation.
+  consecutive_rotate_failures bigint not null default 0,
+  constraint config_raw_rollup_geometry_check check (
+    (num_partitions - 1) * rotation_period
+      <= rollup_1m_retention_days * interval '1 day'
+  )
 );
 
 -- Insert initial row if not exists.
@@ -300,14 +306,17 @@ alter table ash.config
    * registrations are being silently dropped for that sample (those sessions
    * won't appear in encoded data for this tick). Surfaced by ash.status().
    */
-  add column if not exists register_wait_cap_hits bigint not null default 0;
+  add column if not exists register_wait_cap_hits bigint not null default 0,
+  add column if not exists consecutive_rotate_failures bigint not null default 0;
 
 /*
- * Ensure retention CHECK constraints exist for both fresh and upgrade paths.
+ * Ensure config CHECK constraints exist for both fresh and upgrade paths.
  * ADD COLUMN IF NOT EXISTS above doesn't apply CHECKs to pre-existing columns,
- * so add them explicitly here (guarded by a not-exists probe for idempotency).
+ * so add them explicitly here (guarded by not-exists probes for idempotency).
  */
 do $$
+declare
+  v_required_rollup_days numeric;
 begin
   if not exists (
     select from pg_constraint
@@ -324,6 +333,55 @@ begin
     alter table ash.config
       add constraint config_rollup_1h_retention_days_check
       check (rollup_1h_retention_days >= 1);
+  end if;
+
+  if not exists (
+    select from pg_constraint
+    where conname = 'config_raw_rollup_geometry_check'
+      and conrelid = 'ash.config'::regclass
+  ) then
+    /*
+     * Existing 2.0-beta1 installs may already have the unsafe geometry this
+     * check closes. Raising minute-rollup retention is the only non-destructive
+     * repair: reducing num_partitions would drop raw data, while rejecting the
+     * installer would prevent affected systems from receiving the rotate fix.
+     * Round up because retention is configured in whole days.
+     */
+    select ceil(
+      extract(epoch from ((num_partitions - 1) * rotation_period)) / 86400
+    )
+    into v_required_rollup_days
+    from ash.config
+    where singleton;
+
+    if v_required_rollup_days > 32767 then
+      raise exception
+        'pg_ash: existing raw retention geometry requires % days of '
+        'rollup_1m retention, beyond the smallint limit; reduce '
+        'num_partitions or rotation_period before reinstalling',
+        v_required_rollup_days;
+    end if;
+
+    if exists (
+      select from ash.config
+      where singleton
+        and (num_partitions - 1) * rotation_period
+          > rollup_1m_retention_days * interval '1 day'
+    ) then
+      raise warning
+        'pg_ash: raising rollup_1m_retention_days to % so existing raw '
+        'retention does not exceed minute-rollup retention',
+        v_required_rollup_days;
+      update ash.config
+      set rollup_1m_retention_days = v_required_rollup_days::smallint
+      where singleton;
+    end if;
+
+    alter table ash.config
+      add constraint config_raw_rollup_geometry_check check (
+        (num_partitions - 1) * rotation_period
+          <= rollup_1m_retention_days * interval '1 day'
+      );
   end if;
 end $$;
 
@@ -1323,6 +1381,8 @@ declare
   v_truncate_slot smallint;
   v_num_partitions smallint;
   v_rotation_period interval;
+  v_rollup_1m_retention_days smallint;
+  v_rollup_1m_cutoff int4;
   v_rotated_at timestamptz;
   v_rotation_minutes int;
   v_rollup_result int;
@@ -1346,8 +1406,10 @@ begin
 
   begin
     -- Get current config.
-    select current_slot, num_partitions, rotation_period, rotated_at
-    into v_old_slot, v_num_partitions, v_rotation_period, v_rotated_at
+    select current_slot, num_partitions, rotation_period,
+           rollup_1m_retention_days, rotated_at
+    into v_old_slot, v_num_partitions, v_rotation_period,
+         v_rollup_1m_retention_days, v_rotated_at
     from ash.config
     where singleton;
 
@@ -1379,6 +1441,9 @@ begin
            hashtext('pg_ash')::int4,
            hashtext('pg_ash_rollup')::int4
          ) then
+        update ash.config
+        set consecutive_rotate_failures = consecutive_rotate_failures + 1
+        where singleton;
         return format(
           'failed: pre-truncation rollup busy; slot %s not truncated',
           v_truncate_slot
@@ -1391,6 +1456,9 @@ begin
       begin
         select ash.rollup_minute(v_rotation_minutes) into v_rollup_result;
       exception when undefined_function then
+        update ash.config
+        set consecutive_rotate_failures = consecutive_rotate_failures + 1
+        where singleton;
         return format(
           'failed: rollup_minute() unavailable; slot %s not truncated',
           v_truncate_slot
@@ -1398,6 +1466,9 @@ begin
       when others then
         raise warning 'ash.rotate: rollup_minute failed [%]: %',
           sqlstate, sqlerrm;
+        update ash.config
+        set consecutive_rotate_failures = consecutive_rotate_failures + 1
+        where singleton;
         return format(
           'failed: pre-truncation rollup failed [%s]; slot %s not truncated',
           sqlstate,
@@ -1405,12 +1476,25 @@ begin
         );
       end;
 
+      v_rollup_1m_cutoff := ash.ts_from_timestamptz(
+        now() - v_rollup_1m_retention_days * interval '1 day'
+      );
+
+      /*
+       * Only retained minute groups need proof. Once a minute is past
+       * rollup_1m retention, rolling it up now would merely create a row that
+       * rollup_cleanup() deletes on its next pass. There is nothing left to
+       * preserve, so blocking rotation would protect data the operator has
+       * already configured away. Groups still inside retention keep the full
+       * issue #81 completeness gate below.
+       */
       execute format(
         'with raw as ('
         '  select (sample_ts / 60) * 60 as ts, datid,'
         '         count(distinct sample_ts)::smallint as samples,'
         '         max(active_count)::smallint as peak_backends'
         '  from ash.sample_%1$s'
+        '  where (sample_ts / 60) * 60 >= $1'
         '  group by 1, 2'
         ') '
         'select count(*) '
@@ -1421,9 +1505,12 @@ begin
         '   or rollup_min.samples < raw.samples '
         '   or rollup_min.peak_backends < raw.peak_backends',
         v_truncate_slot
-      ) into v_unrolled_groups;
+      ) into v_unrolled_groups using v_rollup_1m_cutoff;
 
       if v_unrolled_groups > 0 then
+        update ash.config
+        set consecutive_rotate_failures = consecutive_rotate_failures + 1
+        where singleton;
         return format(
           'failed: pre-truncation rollup incomplete for %s group(s) '
           'in slot %s; slot not truncated',
@@ -1436,7 +1523,8 @@ begin
     -- Advance current_slot first (before truncate).
     update ash.config
     set current_slot = v_new_slot,
-      rotated_at = now()
+      rotated_at = now(),
+      consecutive_rotate_failures = 0
     where singleton;
 
     /*
@@ -1457,6 +1545,9 @@ begin
       v_old_slot, v_new_slot, v_truncate_slot);
 
   exception when lock_not_available then
+    update ash.config
+    set consecutive_rotate_failures = consecutive_rotate_failures + 1
+    where singleton;
     return 'failed: lock timeout on partition truncate, will retry next cycle';
   when others then
     raise;
@@ -1483,6 +1574,8 @@ as $$
 declare
   v_old_n int;
   v_new_n int;
+  v_rotation_period interval;
+  v_rollup_1m_retention_days smallint;
 begin
   /*
    * Destructive: drops all raw sample partitions. Require explicit
@@ -1495,13 +1588,31 @@ begin
       'select ash.rebuild_partitions(%, ''yes'')', num_partitions;
   end if;
 
-  select config_row.num_partitions into v_old_n
+  select config_row.num_partitions, config_row.rotation_period,
+         config_row.rollup_1m_retention_days
+  into v_old_n, v_rotation_period, v_rollup_1m_retention_days
   from ash.config as config_row
   where config_row.singleton;
   v_new_n := coalesce(rebuild_partitions.num_partitions, v_old_n);
 
   if v_new_n < 3 or v_new_n > 32 then
     raise exception 'num_partitions must be between 3 and 32, got: %', v_new_n;
+  end if;
+
+  /*
+   * Validate before disabling sampling or touching partitions. Cleanup must
+   * retain every minute that can still reach rotate()'s completeness gate;
+   * otherwise the forward-only rollup watermark cannot recreate a deleted
+   * row and the ring can freeze permanently.
+   */
+  if (v_new_n - 1) * v_rotation_period
+       > v_rollup_1m_retention_days * interval '1 day' then
+    raise exception
+      'rebuild_partitions: % partitions at rotation_period % exceed '
+      'rollup_1m retention % days; require '
+      '(num_partitions - 1) * rotation_period '
+      '<= rollup_1m_retention_days',
+      v_new_n, v_rotation_period, v_rollup_1m_retention_days;
   end if;
 
   -- Step 1: mark sampling disabled. take_sample() checks this and returns
@@ -2488,6 +2599,9 @@ begin
   metric := 'rotated_at'; value := v_config.rotated_at::text; return next;
   metric := 'time_since_rotation';
   value := (now() - v_config.rotated_at)::text;
+  return next;
+  metric := 'consecutive_rotate_failures';
+  value := v_config.consecutive_rotate_failures::text;
   return next;
 
   if v_last_sample_ts is not null then


### PR DESCRIPTION
Fixes #211 — two of pg_ash's own scheduled jobs deadlock each other, permanently and silently.

Found by the pre-tag audit — see #160. **Draft on purpose**: needs REV and your explicit approval.

## The bug

`rollup_cleanup()` deletes the `ash.rollup_1m` rows that `rotate()`'s pre-truncation completeness
gate (#81) requires, and `rollup_minute()`'s watermark only walks forward — so those minutes can
never be re-rolled and the gate can never be satisfied again.

    failed: pre-truncation rollup incomplete for 1 group(s) in slot 2; slot not truncated

…forever. Rotation stops, so every new sample piles into the frozen current slot until the volume
fills — exactly the failure the ring exists to prevent. Reachable on **stock 30-day retention** via
the README's own "increase raw retention" runbook (`rebuild_partitions(32,'yes')`).

Worst part: it is **silent**. `rotate()` returns text on the failure path, so pg_cron records
SUCCESS and `ash.status()` showed nothing. Only `time_since_rotation` crept up.

## Three parts

1. **Break the deadlock** — the gate now ignores raw minute groups already past
   `rollup_1m_retention_days`. Rolling those up would only create rows `rollup_cleanup()` deletes
   on its next pass, so there is nothing left to protect. Groups still *inside* retention keep the
   full #81 check.
2. **Make the bad geometry unreachable** — new `config_raw_rollup_geometry_check` constraint:
   `(num_partitions - 1) * rotation_period <= rollup_1m_retention_days * interval '1 day'`,
   enforced both as a table CHECK and in `rebuild_partitions()`. A table CHECK is used because
   there is no supported setter for these values — direct `UPDATE` is the interface.
3. **Make failure loud** — new `consecutive_rotate_failures` counter on `ash.config`, surfaced in
   `ash.status()`, incremented on every silent `failed:` return and reset by a real rotation.
   Neutral `skipped:` returns leave it alone.

## Verification

RED first against unpatched SQL, with exact-value assertions:

    ERROR:  rotation did not recover after cleanup: failed: pre-truncation rollup incomplete ...
    ERROR:  status failure metric should be exactly {1}, got NULL
    ERROR:  unexpected rebuild geometry result: <accepted>

Then GREEN, including that the **#81 gate still refuses** to truncate when a group inside retention
is genuinely unrolled (the control that proves the fix didn't just disable the guard), and that the
counter goes `{1}` → `{2}` across repeated failures and resets on success.

Fresh install, full 1.0→2.0 chain, double re-apply, fresh-vs-chain schema equivalence, and a
zero-argument smoke of every reader all clean.

## Two things I want a reviewer's eye on

- **`(num_partitions - 1)` is deliberately stricter than the `(num_partitions - 2)` retention
  formula used everywhere else** (`:2268`, `:2374`, `:2315`, `:2475`, README:364 — and documented
  by in-flight #152). The `-1` is correct *here*: it bounds the age of the oldest row in the slot
  about to be truncated, not the user-visible retention window. But the two formulas now differ in
  the same file with no comment saying why, so a later "consistency fix" to `-2` would silently
  reintroduce this deadlock for the boundary slot. **Worth adding that comment before merge.**
- **Upgrade path mutates operator config.** An existing install with unsafe geometry has its
  `rollup_1m_retention_days` raised to the minimum safe whole-day value so the constraint can be
  added. It emits `raise warning` first, and raising minute retention is the only non-destructive
  direction (reducing `num_partitions` would drop raw data, and rejecting the installer would deny
  affected systems the very fix they need) — but it does increase disk usage without asking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HzBGzjFyN8dXZHbdWmYBj
