### PR TITLE
fix: preserve reader grants across ash.rebuild_partitions() (#213)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3000,6 +3000,262 @@ jobs:
           $$;
           EOF
 
+      - name: "Issue #213: rebuild_partitions preserves reader grants"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          # A rebuild drops and recreates query_map_all plus every sample_N /
+          # query_map_N relation. The outage used to be latent: empty storage
+          # let readers appear healthy until the first sample made status()
+          # touch the freshly-created, ungranted query_map_all view. Drive that
+          # path before inspecting ACLs so this test fails on the user-visible
+          # bug, not only on a catalog difference.
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          do $$
+          begin
+            if not exists (
+              select from pg_roles where rolname = 'cx213_rebuild_reader'
+            ) then
+              create role cx213_rebuild_reader;
+            end if;
+            if not exists (
+              select from pg_roles where rolname = 'cx213_rebuild_partial'
+            ) then
+              create role cx213_rebuild_partial;
+            end if;
+            if not exists (
+              select from pg_roles where rolname = 'cx213_rebuild_none'
+            ) then
+              create role cx213_rebuild_none;
+            end if;
+          end $$;
+
+          select ash.grant_reader('cx213_rebuild_reader');
+          grant select on ash.query_map_0 to cx213_rebuild_partial
+            with grant option;
+          grant select on ash.sample_1 to cx213_rebuild_partial;
+
+          do $$
+          declare
+            v_acl text[];
+            v_full_acl constant text[] := array[
+              'query_map_0:false', 'query_map_1:false',
+              'query_map_2:false', 'query_map_all:false',
+              'sample_0:false', 'sample_1:false', 'sample_2:false'
+            ];
+            v_role constant name[] := array[
+              'cx213_rebuild_reader'::name, 'pg_monitor'::name,
+              'cx213_rebuild_partial'::name, 'cx213_rebuild_none'::name
+            ];
+            v_expected text[];
+          begin
+            for i in 1 .. cardinality(v_role) loop
+              v_expected := case
+                when i <= 2 then v_full_acl
+                when i = 3 then array['query_map_0:true', 'sample_1:false']
+                else array[]::text[]
+              end;
+              select coalesce(
+                       array_agg(
+                         relation.relname || ':' || acl.is_grantable
+                         order by relation.relname
+                       ),
+                       array[]::text[]
+                     )
+              into v_acl
+              from pg_class as relation
+              join pg_namespace as nsp on nsp.oid = relation.relnamespace
+              cross join lateral aclexplode(relation.relacl) as acl
+              join pg_roles as grantee on grantee.oid = acl.grantee
+              where nsp.nspname = 'ash'
+                and (relation.relname = 'query_map_all'
+                     or relation.relname ~ '^query_map_[0-9]+$'
+                     or relation.relname ~ '^sample_[0-9]+$')
+                and acl.privilege_type = 'SELECT'
+                and grantee.rolname = v_role[i];
+              assert v_acl = v_expected,
+                format('%s pre-rebuild ACL: expected %s, got %s',
+                       v_role[i], v_expected, v_acl);
+            end loop;
+          end $$;
+
+          select ash.rebuild_partitions(4, 'yes');
+          update ash.config set sampling_enabled = true where singleton;
+          EOF
+
+          PGAPPNAME=cx213_rebuild_probe \
+            psql -h localhost -U postgres -d postgres \
+              -c "select pg_sleep(30)" >/dev/null 2>&1 &
+          probe_pid=$!
+          trap 'kill "$probe_pid" 2>/dev/null || true; wait "$probe_pid" 2>/dev/null || true' EXIT
+
+          active_probe=0
+          for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20; do
+            active_probe=$(psql -h localhost -U postgres -d postgres -tAX \
+              -c "select count(*) from pg_stat_activity
+                  where application_name = 'cx213_rebuild_probe'
+                    and state = 'active'")
+            if [ "$active_probe" = "1" ]; then
+              break
+            fi
+            sleep 0.25
+          done
+          if [ "$active_probe" != "1" ]; then
+            echo "Expected exactly one active sampler probe, got: $active_probe" >&2
+            exit 1
+          fi
+
+          sampled=$(psql -h localhost -U postgres -d postgres -tAX \
+            -v ON_ERROR_STOP=1 -c "select ash.take_sample()")
+          if [ "$sampled" != "1" ]; then
+            echo "Expected ash.take_sample() to insert exactly 1 row, got: $sampled" >&2
+            exit 1
+          fi
+          terminated=$(psql -h localhost -U postgres -d postgres -tAX \
+            -v ON_ERROR_STOP=1 \
+            -c "select count(*)
+                from (
+                  select pg_terminate_backend(pid) as stopped
+                  from pg_stat_activity
+                  where application_name = 'cx213_rebuild_probe'
+                ) as probe
+                where stopped")
+          if [ "$terminated" != "1" ]; then
+            echo "Expected to terminate exactly 1 sampler probe, got: $terminated" >&2
+            exit 1
+          fi
+          wait "$probe_pid" 2>/dev/null || true
+          trap - EXIT
+
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          set role cx213_rebuild_reader;
+          do $$
+          declare
+            v_status_version text;
+            v_status_samples text;
+            v_status_partitions text;
+            v_sample record;
+          begin
+            select value into strict v_status_version
+            from ash.status() where metric = 'version';
+            assert v_status_version = '2.0-beta1',
+              format('named reader status version: expected 2.0-beta1, got %s',
+                     v_status_version);
+            select value into strict v_status_samples
+            from ash.status() where metric = 'samples_total';
+            assert v_status_samples = '1',
+              format('named reader status samples_total: expected 1, got %s',
+                     v_status_samples);
+            select value into strict v_status_partitions
+            from ash.status() where metric = 'num_partitions';
+            assert v_status_partitions = '4',
+              format('named reader status num_partitions: expected 4, got %s',
+                     v_status_partitions);
+
+            select count(*) as rows,
+                   min(database_name) as database_name,
+                   min(active_backends) as active_backends,
+                   min(wait_event) as wait_event
+            into v_sample
+            from ash.samples(
+              now() - interval '1 hour', now() + interval '1 second'
+            );
+            assert v_sample.rows = 1,
+              format('named reader samples(): expected 1 row, got %s',
+                     v_sample.rows);
+            assert v_sample.database_name = 'postgres',
+              format('named reader samples(): expected database postgres, got %s',
+                     v_sample.database_name);
+            assert v_sample.active_backends = 1,
+              format('named reader samples(): expected active_backends 1, got %s',
+                     v_sample.active_backends);
+            assert v_sample.wait_event = 'Timeout:PgSleep',
+              format('named reader samples(): expected Timeout:PgSleep, got %s',
+                     v_sample.wait_event);
+          end $$;
+          reset role;
+
+          set role pg_monitor;
+          do $$
+          declare
+            v_status_version text;
+            v_status_samples text;
+            v_sample_count bigint;
+          begin
+            select value into strict v_status_version
+            from ash.status() where metric = 'version';
+            assert v_status_version = '2.0-beta1',
+              format('pg_monitor status version: expected 2.0-beta1, got %s',
+                     v_status_version);
+            select value into strict v_status_samples
+            from ash.status() where metric = 'samples_total';
+            assert v_status_samples = '1',
+              format('pg_monitor status samples_total: expected 1, got %s',
+                     v_status_samples);
+            select count(*) into v_sample_count
+            from ash.samples(
+              now() - interval '1 hour', now() + interval '1 second'
+            );
+            assert v_sample_count = 1,
+              format('pg_monitor samples(): expected 1 row, got %s',
+                     v_sample_count);
+          end $$;
+          reset role;
+
+          do $$
+          declare
+            v_acl text[];
+            v_full_acl constant text[] := array[
+              'query_map_0:false', 'query_map_1:false',
+              'query_map_2:false', 'query_map_3:false',
+              'query_map_all:false', 'sample_0:false',
+              'sample_1:false', 'sample_2:false', 'sample_3:false'
+            ];
+            v_role constant name[] := array[
+              'cx213_rebuild_reader'::name, 'pg_monitor'::name,
+              'cx213_rebuild_partial'::name, 'cx213_rebuild_none'::name
+            ];
+            v_expected text[];
+          begin
+            for i in 1 .. cardinality(v_role) loop
+              v_expected := case
+                when i <= 2 then v_full_acl
+                when i = 3 then array['query_map_0:true', 'sample_1:false']
+                else array[]::text[]
+              end;
+              select coalesce(
+                       array_agg(
+                         relation.relname || ':' || acl.is_grantable
+                         order by relation.relname
+                       ),
+                       array[]::text[]
+                     )
+              into v_acl
+              from pg_class as relation
+              join pg_namespace as nsp on nsp.oid = relation.relnamespace
+              cross join lateral aclexplode(relation.relacl) as acl
+              join pg_roles as grantee on grantee.oid = acl.grantee
+              where nsp.nspname = 'ash'
+                and (relation.relname = 'query_map_all'
+                     or relation.relname ~ '^query_map_[0-9]+$'
+                     or relation.relname ~ '^sample_[0-9]+$')
+                and acl.privilege_type = 'SELECT'
+                and grantee.rolname = v_role[i];
+              assert v_acl = v_expected,
+                format('%s post-rebuild ACL: expected %s, got %s',
+                       v_role[i], v_expected, v_acl);
+            end loop;
+          end $$;
+
+          select ash.rebuild_partitions(3, 'yes');
+          update ash.config set sampling_enabled = true where singleton;
+          drop owned by cx213_rebuild_reader, cx213_rebuild_partial,
+            cx213_rebuild_none;
+          drop role cx213_rebuild_reader;
+          drop role cx213_rebuild_partial;
+          drop role cx213_rebuild_none;
+          EOF
+
       - name: "Test v1.4: array merge helpers"
         env:
           PGPASSWORD: postgres

--- a/README.md
+++ b/README.md
@@ -373,9 +373,13 @@ select ash.rebuild_partitions(9, 'yes');
 select ash.start();
 ```
 
-`rebuild_partitions()` drops all raw samples and query-map partitions. Rollups
-survive. Re-run `ash.grant_reader()` for monitoring roles afterward because
-new partitions need fresh grants.
+`rebuild_partitions()` drops and recreates all raw-sample and query-map
+relations, including the `query_map_all` view. Rollups survive. Existing
+reader bundles are preserved automatically, including the installer's default
+`pg_monitor` grant; partial manual grants are restored only on the same
+relation names and are not widened. Older 2.0-beta1 builds did not preserve
+these grants: after a rebuild on one of those builds, re-run
+`ash.grant_reader()` for each reader role, including `pg_monitor`.
 
 Typical storage at 1-second sampling:
 

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -1483,6 +1483,7 @@ as $$
 declare
   v_old_n int;
   v_new_n int;
+  v_rec record;
 begin
   /*
    * Destructive: drops all raw sample partitions. Require explicit
@@ -1571,21 +1572,117 @@ begin
     end if;
   end;
 
-  -- Step 5: drop the query_map_all view first (depends on query_map tables).
+  /*
+   * Step 5: preserve SELECT grants across the drop/recreate below (#213).
+   * DROP destroys relation ACLs, so snapshot every explicit non-owner grant
+   * on the view and per-slot relations that this function replaces. The
+   * matching restore after the rebuild replays each grant on the exact same
+   * relation name, including WITH GRANT OPTION. Roles holding only a manual,
+   * partial set therefore keep that same narrow set and are never widened.
+   */
+  drop table if exists pg_temp._ash_rebuild_rel_acl;
+  create temp table _ash_rebuild_rel_acl (
+    relname   name not null,
+    grantee   name not null,
+    grantable bool not null,
+    primary key (relname, grantee)
+  );
+  insert into pg_temp._ash_rebuild_rel_acl (
+    relname, grantee, grantable
+  )
+  select relation.relname, grantee.rolname, bool_or(acl.is_grantable)
+  from pg_catalog.pg_class as relation
+  join pg_catalog.pg_namespace as nsp on nsp.oid = relation.relnamespace
+  cross join lateral pg_catalog.aclexplode(relation.relacl) as acl
+  join pg_catalog.pg_roles as grantee on grantee.oid = acl.grantee
+  where nsp.nspname = 'ash'
+    and relation.relkind in ('r', 'p', 'v')
+    and (relation.relname = 'query_map_all'
+         or relation.relname ~ '^query_map_[0-9]+$'
+         or relation.relname ~ '^sample_[0-9]+$')
+    and acl.privilege_type = 'SELECT'
+    and acl.grantee <> relation.relowner
+  group by relation.relname, grantee.rolname;
+
+  /*
+   * Exact replay alone cannot cover a changed partition count: a legitimate
+   * grant_reader() role needs SELECT on every newly-numbered relation too.
+   * Detect those roles from the complete explicit bundle that grant_reader()
+   * installs — schema USAGE, every non-admin function, and every reader
+   * relation. As in the installer's #107 preservation, catalog ACLs are used
+   * instead of has_*_privilege(), so superusers and membership do not qualify
+   * accidentally. A hand-narrowed role missing even one part of the bundle
+   * stays on the exact-name restore path above and is not broadened.
+   */
+  drop table if exists pg_temp._ash_rebuild_reader_roles;
+  create temp table _ash_rebuild_reader_roles (rolname name primary key);
+  insert into pg_temp._ash_rebuild_reader_roles (rolname)
+  select relation_acl.grantee
+  from pg_temp._ash_rebuild_rel_acl as relation_acl
+  join pg_catalog.pg_roles as candidate
+    on candidate.rolname = relation_acl.grantee
+  group by relation_acl.grantee, candidate.oid
+  having exists (
+    select 1
+    from pg_catalog.pg_namespace as reader_nsp
+    cross join lateral pg_catalog.aclexplode(reader_nsp.nspacl) as acl
+    where reader_nsp.nspname = 'ash'
+      and acl.grantee = candidate.oid
+      and acl.privilege_type = 'USAGE'
+  )
+  and not exists (
+    select 1
+    from pg_catalog.pg_proc as proc
+    join pg_catalog.pg_namespace as proc_nsp
+      on proc_nsp.oid = proc.pronamespace
+    where proc_nsp.nspname = 'ash'
+      and proc.prokind = 'f'
+      and proc.proname::text <> all (ash._admin_funcs())
+      and not exists (
+        select 1
+        from pg_catalog.aclexplode(proc.proacl) as acl
+        where acl.grantee = candidate.oid
+          and acl.privilege_type = 'EXECUTE'
+      )
+  )
+  and not exists (
+    select 1
+    from pg_catalog.pg_class as reader_relation
+    join pg_catalog.pg_namespace as reader_nsp
+      on reader_nsp.oid = reader_relation.relnamespace
+    where reader_nsp.nspname = 'ash'
+      and reader_relation.relkind in ('r', 'p', 'v')
+      and (
+        reader_relation.relname in (
+          'sample', 'query_map_all', 'config', 'wait_event_map',
+          'rollup_1m', 'rollup_1h'
+        )
+        or reader_relation.relname ~ '^query_map_[0-9]+$'
+        or reader_relation.relname ~ '^sample_[0-9]+$'
+      )
+      and not exists (
+        select 1
+        from pg_catalog.aclexplode(reader_relation.relacl) as acl
+        where acl.grantee = candidate.oid
+          and acl.privilege_type = 'SELECT'
+      )
+  );
+
+  -- Step 6: drop the query_map_all view first (depends on query_map tables).
   drop view if exists ash.query_map_all;
 
   -- Drop ALL existing sample partitions and query_maps.
   -- Uses catalog enumeration to catch orphaned tables.
   perform ash._drop_all_partitions();
 
-  -- Step 6: update config.
+  -- Step 7: update config.
   update ash.config
   set num_partitions = v_new_n,
     current_slot = 0,
     rotated_at = now()
   where singleton;
 
-  -- Step 7: create new partitions.
+  -- Step 8: create new partitions.
   for i in 0 .. v_new_n - 1 loop
     execute format(
       'create table ash.sample_%s '
@@ -1609,11 +1706,53 @@ begin
     );
   end loop;
 
-  -- Step 8: rebuild the query_map_all view.
+  -- Step 9: rebuild the query_map_all view.
   perform ash._rebuild_query_map_view();
 
   /*
-   * Step 9: leave sampling DISABLED. User must explicitly call ash.start() to
+   * Restore grants on every same-named relation first. This preserves manual
+   * partial grants and grant options exactly; roles or relation names that no
+   * longer exist are skipped, matching CREATE OR REPLACE-style preservation.
+   */
+  for v_rec in
+    select relation_acl.relname, relation_acl.grantee,
+           relation_acl.grantable
+    from pg_temp._ash_rebuild_rel_acl as relation_acl
+    join pg_catalog.pg_roles as grantee
+      on grantee.rolname = relation_acl.grantee
+    join pg_catalog.pg_class as relation
+      on relation.relname = relation_acl.relname
+    join pg_catalog.pg_namespace as nsp
+      on nsp.oid = relation.relnamespace
+    where nsp.nspname = 'ash'
+      and relation.relkind in ('r', 'p', 'v')
+  loop
+    execute format('grant select on table ash.%I to %I%s',
+                   v_rec.relname, v_rec.grantee,
+                   case when v_rec.grantable then ' with grant option'
+                        else '' end);
+  end loop;
+
+  /*
+   * Complete pre-rebuild reader bundles get the complete CURRENT relation
+   * set, including new partition numbers. grant_reader() is idempotent and
+   * excludes admin functions, so this refresh cannot escalate past reader
+   * access. The exact replay above retains any pre-existing grant options.
+   */
+  for v_rec in
+    select reader_role.rolname
+    from pg_temp._ash_rebuild_reader_roles as reader_role
+    join pg_catalog.pg_roles as role_row
+      on role_row.rolname = reader_role.rolname
+  loop
+    perform ash.grant_reader(v_rec.rolname);
+  end loop;
+
+  drop table pg_temp._ash_rebuild_rel_acl;
+  drop table pg_temp._ash_rebuild_reader_roles;
+
+  /*
+   * Step 10: leave sampling DISABLED. User must explicitly call ash.start() to
    * resume. Prevents accidental data collection into a partially-built schema.
    */
   return format(
@@ -5811,7 +5950,7 @@ comment on function ash.rollup_cleanup() is
 $$Admin: delete rollup rows past retention (rollup_1m_retention_days / rollup_1h_retention_days in ash.config; the daily job scheduled by ash.start()). Returns a summary of rows deleted.$$;
 
 comment on function ash.rebuild_partitions(int, text) is
-$$Admin, DESTRUCTIVE: drop and recreate the sample/query-map partitions with num_partitions slots (3-32; raw retention = slots x rotation_period). Requires confirm => 'yes'. DELETES ALL RAW SAMPLES (rollups are kept). Re-run ash.grant_reader() for every monitoring role afterwards — the new partitions carry no grants.$$;
+$$Admin, DESTRUCTIVE: drop and recreate the sample/query-map partitions with num_partitions slots (3-32; raw retention = slots x rotation_period). Requires confirm => 'yes'. DELETES ALL RAW SAMPLES (rollups are kept). Preserves complete ash.grant_reader() bundles across changed partition counts and restores partial manual SELECT grants on recreated same-name relations without widening them.$$;
 
 comment on function ash.set_debug_logging(bool) is
 $$Admin: toggle debug logging for the sampler and rollup jobs (null argument reports the current setting). Returns the resulting state.$$;
@@ -6190,7 +6329,7 @@ end;
 $$;
 
 comment on function ash.grant_reader(name) is
-  'Grants the minimum privileges (USAGE on schema ash, EXECUTE on all reader functions AND the internal helpers they depend on, SELECT on reader tables incl. partitions) to a monitoring role. This is the supported way to grant reader access: reader functions are SECURITY INVOKER and call shared internal helpers (also revoked from PUBLIC), so granting EXECUTE on an individual reader function alone is not sufficient. Idempotent. Inverse: ash.revoke_reader(name). Caveat: ash.rebuild_partitions(N, ''yes'') creates new partition tables that previously-granted readers cannot access; re-run ash.grant_reader() for each monitoring role after any rebuild_partitions() call.';
+  'Grants the minimum privileges (USAGE on schema ash, EXECUTE on all reader functions AND the internal helpers they depend on, SELECT on reader tables incl. partitions) to a monitoring role. This is the supported way to grant reader access: reader functions are SECURITY INVOKER and call shared internal helpers (also revoked from PUBLIC), so granting EXECUTE on an individual reader function alone is not sufficient. Idempotent. Inverse: ash.revoke_reader(name). Complete reader bundles are preserved automatically by ash.rebuild_partitions(N, ''yes'').';
 
 create or replace function ash.revoke_reader(role name)
 returns void
@@ -6263,7 +6402,7 @@ end;
 $$;
 
 comment on function ash.revoke_reader(name) is
-  'Revokes the privileges granted by ash.grant_reader(): USAGE on schema ash, EXECUTE on all reader functions, SELECT on reader tables. Idempotent. Inverse: ash.grant_reader(name). Caveat: ash.rebuild_partitions(N, ''yes'') creates new partition tables that previously-granted readers cannot access; re-run ash.grant_reader() for each monitoring role after any rebuild_partitions() call.';
+  'Revokes the privileges granted by ash.grant_reader(): USAGE on schema ash, EXECUTE on all reader functions, SELECT on reader tables. Idempotent. Inverse: ash.grant_reader(name).';
 
 -- Lock down the helpers themselves: only the schema owner may hand out
 -- (or take back) privileges. PUBLIC must not be able to call them.


### PR DESCRIPTION
Fixes #213 — `ash.rebuild_partitions()` silently strips every reader's grants.

Found by the pre-tag audit (#160), and independently rediscovered during the PG 17 gate run.
**Draft on purpose**: needs REV and your explicit approval.

## The bug

`rebuild_partitions()` drops `ash.query_map_all`, recreates `sample_N` / `query_map_N`, and rebuilds
the view — replaying none of the grants. Afterwards, as a reader:

    select * from ash.status();
    ERROR:  permission denied for view query_map_all
    CONTEXT:  SQL statement "select count(*) from ash.query_map_all"
              PL/pgSQL function status() line 31 at SQL statement

`aas()`, `summary()`, `samples()`, `top()`, `chart()`, `timeline()` all fail the same way. A plain
`pg_monitor` member is hit too, since 2.0 grants it the reader bundle by default.

**Onset is delayed**, which is what makes it nasty: right after the rebuild, raw storage is empty
and every reader returns fine. The outage lands minutes later when the first samples arrive — so
the obvious smoke test passes. The regression test here therefore rebuilds, *then samples*, *then
reads as the reader role*.

## The fix

Snapshots explicit SELECT ACLs for every recreated relation, then restores them:

- Complete reader bundles → re-run `ash.grant_reader()`, so newly numbered partitions are covered
- Partial / hand-narrowed grants → restored **by exact relation name**, including grant options,
  never widened to the full bundle
- Roles with no grants → get nothing

Also fixes README:376-378, which attributed the loss to "new partitions" when the recreated *view*
is the first blocker, and never warned that a rebuild destroys the default `pg_monitor` grant.

## Verification

RED against unpatched SQL, after `take_sample()` inserted exactly one row — the real error above,
reproduced through the delayed-onset path rather than an ACL-only check.

GREEN on **PG 18.3 and PG 17**, through a 3→4→3 rebuild cycle:
- named reader and `pg_monitor` both call `ash.status()` and `ash.samples()` successfully after sampling
- both receive all 14 reader relations after 3→4
- partial role stays exactly `query_map_0:true, sample_1:false` — not widened
- no-access role stays `{}`
- decoded sample is exactly one `Timeout:PgSleep` row; `samples_total = 1`, `num_partitions = 4`

Fresh install, double re-apply, and the full 1.0→2.0 chain all clean with zero errors or warnings.

## Review note

**No shared helper was factored out** with the installer's equivalent #107 block (`:6283-6360`),
deliberately: that path spans a script-wide function-recreation cycle while this one is
transaction-local and relation-specific, and unifying them would drag install-order and hardening
dependencies into an already-verified path. Reasonable, but it does mean two places now implement
grant preservation — worth a look if you'd rather they converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HzBGzjFyN8dXZHbdWmYBj
