### PR TITLE
fix: separate raw retention boundary from oldest held sample (#212)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3987,6 +3987,233 @@ jobs:
           end $$;
           EOF
 
+      - name: "Regression #212: raw retention boundary preserves the first minute"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          do $$
+          declare
+            v_minute timestamptz := date_trunc('minute', now());
+            v_oldest timestamptz := date_trunc('minute', now())
+                                      - interval '1 minute' + interval '11 seconds';
+            v_boundary timestamptz := date_trunc('minute', now())
+                                        - interval '11 minutes';
+            v_aged_sample timestamptz := date_trunc('minute', now())
+                                          - interval '20 minutes'
+                                          + interval '11 seconds';
+            v_aged_boundary timestamptz := date_trunc('minute', now())
+                                             - interval '10 minutes';
+            v_wait smallint;
+            v_query_map_id int4;
+            v_datid oid;
+            v_status_boundary timestamptz;
+            v_count int;
+            v_key text;
+            v_source text;
+            v_avg numeric;
+            v_peak numeric;
+            v_p99 numeric;
+            v_seconds numeric;
+            v_pct numeric;
+            v_message text;
+            v_state text;
+            v_rotate_result text;
+          begin
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.query_map_0, ash.query_map_1, ash.query_map_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            alter table ash.query_map_0 alter column id restart;
+
+            update ash.config
+            set current_slot = 0,
+                num_partitions = 3,
+                sample_interval = interval '1 second',
+                rotation_period = interval '10 minutes',
+                -- Mid-minute ring edge: the public boundary must floor this.
+                rotated_at = v_minute - interval '23 seconds'
+            where singleton;
+
+            select ash._register_wait('active', 'Lock', 'tuple') into v_wait;
+            insert into ash.query_map_0 (query_id) values (212212)
+            returning id into v_query_map_id;
+            select oid into v_datid
+            from pg_database
+            where datname = current_database();
+
+            -- A young install: eight one-second samples, all in the first
+            -- partial minute and all attributable to the same lock/query tie.
+            insert into ash.sample (
+              sample_ts, datid, active_count, data, slot
+            )
+            select ash.ts_from_timestamptz(v_oldest + i * interval '1 second'),
+                   v_datid, 1, array[-v_wait, 1, v_query_map_id]::int4[], 0
+            from generate_series(0, 7) as i;
+
+            -- README.md:193 verbatim: a young, fully-held install must not
+            -- reject the flagship query_id-by-wait drill.
+            v_message := null;
+            begin
+              select count(*), min(key), min(source), min(avg_aas),
+                     min(peak_aas), min(p99_aas), min(backend_seconds), min(pct)
+                into v_count, v_key, v_source, v_avg,
+                     v_peak, v_p99, v_seconds, v_pct
+              from ash.top(
+                'query_id',
+                since => now() - interval '5 minutes',
+                wait_event => 'Lock:tuple',
+                order_by => 'peak',
+                n => 5
+              );
+            exception when others then
+              v_message := sqlerrm;
+            end;
+            assert v_message is null,
+              'README:193 raised on a young install: ' || v_message;
+            assert (v_count, v_key, v_source) = (1, '212212', 'raw'),
+              format('README:193 identity: count=%s key=%s source=%s',
+                     v_count, v_key, v_source);
+            assert (v_avg, v_peak, v_p99, v_seconds, v_pct)
+                   = (0.03, 0.13, 0.13, 8.00, 100.00),
+              format('README:193 metrics: avg=%s peak=%s p99=%s seconds=%s pct=%s',
+                     v_avg, v_peak, v_p99, v_seconds, v_pct);
+
+            select value::timestamptz into v_status_boundary
+            from ash.status()
+            where metric = 'raw_retention_start';
+            assert v_status_boundary = v_boundary,
+              format('status boundary: expected %s, got %s (oldest sample %s)',
+                     v_boundary, v_status_boundary, v_oldest);
+
+            -- The documented status value must be directly reusable, without
+            -- the reader's minute floor moving it back across the guard.
+            select count(*), min(key), min(source), min(avg_aas),
+                   min(peak_aas), min(p99_aas), min(backend_seconds), min(pct)
+              into v_count, v_key, v_source, v_avg,
+                   v_peak, v_p99, v_seconds, v_pct
+            from ash.top(
+              'query_id', since => v_status_boundary,
+              wait_event => 'Lock:tuple', order_by => 'peak', n => 5
+            );
+            assert (v_count, v_key, v_source) = (1, '212212', 'raw'),
+              format('status boundary identity: count=%s key=%s source=%s',
+                     v_count, v_key, v_source);
+            assert (v_avg, v_peak, v_p99, v_seconds, v_pct)
+                   = (0.01, 0.13, 0.13, 8.00, 100.00),
+              format('status boundary metrics: avg=%s peak=%s p99=%s seconds=%s pct=%s',
+                     v_avg, v_peak, v_p99, v_seconds, v_pct);
+
+            -- A partial-overlap error must print the boundary rounded DOWN.
+            v_message := null;
+            begin
+              perform * from ash.top(
+                'query_id', since => v_boundary - interval '1 minute',
+                wait_event => 'Lock:tuple', order_by => 'peak', n => 5
+              );
+            exception when others then
+              v_message := sqlerrm;
+            end;
+            assert v_message = format(
+              'pg_ash: this drill needs raw samples; raw retention starts at %s '
+              'but the requested window starts at %s. Narrow the window to start '
+              'at or after %s (the window end is still inside raw retention), or '
+              'drill without the query/event tie.',
+              v_boundary, v_boundary - interval '1 minute', v_boundary
+            ), 'partial-overlap message mismatch: ' || coalesce(v_message, '<no error>');
+
+            -- Following that exact advice must preserve the first partial raw
+            -- minute and return the same eight backend-seconds, not zero rows.
+            select count(*), min(key), min(source), min(avg_aas),
+                   min(peak_aas), min(p99_aas), min(backend_seconds), min(pct)
+              into v_count, v_key, v_source, v_avg,
+                   v_peak, v_p99, v_seconds, v_pct
+            from ash.top(
+              'query_id', since => v_boundary,
+              wait_event => 'Lock:tuple', order_by => 'peak', n => 5
+            );
+            assert (v_count, v_key, v_source) = (1, '212212', 'raw'),
+              format('remediation identity: count=%s key=%s source=%s',
+                     v_count, v_key, v_source);
+            assert (v_avg, v_peak, v_p99, v_seconds, v_pct)
+                   = (0.01, 0.13, 0.13, 8.00, 100.00),
+              format('remediation metrics: avg=%s peak=%s p99=%s seconds=%s pct=%s',
+                     v_avg, v_peak, v_p99, v_seconds, v_pct);
+
+            -- Put one exact old row in the slot the next rotation truncates,
+            -- then prove it was genuinely aged out before testing the guard.
+            insert into ash.sample (
+              sample_ts, datid, active_count, data, slot
+            ) values (
+              ash.ts_from_timestamptz(v_aged_sample),
+              v_datid, 1, array[-v_wait, 1, 0]::int4[], 2
+            );
+            insert into ash.rollup_1m (
+              ts, datid, samples, peak_backends, wait_counts, query_counts
+            ) values (
+              ash.ts_from_timestamptz(date_trunc('minute', v_aged_sample)),
+              v_datid, 1, 1, array[v_wait, 1]::int4[], '{}'::int8[]
+            );
+            update ash.config
+            set rotated_at = now() - interval '11 minutes',
+                last_rollup_1m_ts = ash.ts_from_timestamptz(
+                  v_minute - interval '1 minute')
+            where singleton;
+            select ash.rotate() into v_rotate_result;
+            assert v_rotate_result =
+                   'rotated: slot 0 -> 1, truncated slot 2 (sample + query_map)',
+              'aged-out setup rotation: ' || v_rotate_result;
+            assert (
+              select count(*) from ash.sample
+              where sample_ts = ash.ts_from_timestamptz(v_aged_sample)
+            ) = 0, 'rotation did not remove the aged sample';
+            assert ash._raw_retention_boundary() = v_aged_boundary,
+              format('post-rotation boundary: expected %s, got %s',
+                     v_aged_boundary, ash._raw_retention_boundary());
+
+            -- A window that held the now-truncated row must still raise the
+            -- unrecoverable form: the boundary fix cannot weaken this guard.
+            v_message := null;
+            v_state := null;
+            begin
+              perform * from ash.top(
+                'query_id',
+                since => date_trunc('minute', v_aged_sample),
+                until => date_trunc('minute', v_aged_sample)
+                           + interval '1 minute',
+                wait_event => 'Lock:tuple', order_by => 'peak', n => 5
+              );
+            exception when others then
+              v_message := sqlerrm;
+              v_state := sqlstate;
+            end;
+            assert v_state = 'P0001',
+              'aged-out window SQLSTATE: expected P0001, got ' || coalesce(v_state, '<none>');
+            assert v_message = format(
+              'pg_ash: this drill needs the raw wait<->query tie, but the requested '
+              'window (%s to %s) is entirely outside raw retention (raw retention '
+              'starts at %s). The tie is unrecoverable for that window — narrowing '
+              'it will not help. Use the untied aggregate readers instead: drop '
+              'either the wait filter or query_id (e.g. ash.aas(), ash.timeline(), '
+              'ash.top() with one of the two).',
+              date_trunc('minute', v_aged_sample),
+              date_trunc('minute', v_aged_sample) + interval '1 minute',
+              v_aged_boundary
+            ), 'aged-out message mismatch: ' || coalesce(v_message, '<no error>');
+
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.query_map_0, ash.query_map_1, ash.query_map_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set current_slot = 0,
+                rotation_period = interval '1 day',
+                rotated_at = now(),
+                last_rollup_1m_ts = null,
+                last_rollup_1h_ts = null
+            where singleton;
+            raise notice 'issue #212 raw retention boundary tests PASSED';
+          end $$;
+          EOF
+
       - name: "Test 2.0: report attribution, compare coverage, retention error split, chart legend"
         env:
           PGPASSWORD: postgres
@@ -4017,8 +4244,11 @@ jobs:
             v_cpu smallint; v_io smallint; v_q1 int4; v_dp oid;
             v_end timestamptz := date_trunc('hour', now());
             j jsonb; r record; n int; v_raised boolean;
-            v_raw timestamptz; v_bound timestamptz; v_passed timestamptz; v_msg text;
+            v_bound timestamptz; v_passed timestamptz; v_msg text;
           begin
+            update ash.config
+            set rotation_period = interval '30 minutes', rotated_at = v_end
+            where singleton;
             select ash._register_wait('active','CPU*','CPU*') into v_cpu;
             select ash._register_wait('active','IO','DataFileRead') into v_io;
             insert into ash.query_map_0 (query_id) values (424242);
@@ -4094,19 +4324,10 @@ jobs:
             assert v_raised, 'entirely-past retention error mismatch';
             -- partial overlap (window END inside raw retention, START before it):
             -- the message must (a) echo the un-floored start the USER passed and
-            -- (b) advise a minute-aligned boundary that, once passed, actually
-            -- clears the guard. Readers floor since to the minute before the
-            -- guard runs, so a mid-minute raw_retention_start otherwise loops:
-            -- narrowing to exactly raw_start re-floors below it and re-raises.
-            -- Give raw retention a mid-minute start with one earlier sample.
-            insert into ash.sample (sample_ts, datid, active_count, data, slot)
-            values (ash.ts_from_timestamptz(v_end - interval '40 minutes' + interval '37 seconds'),
-                    v_dp, 1, array[-v_cpu, 1, 0]::integer[], 0);
-            v_raw := ash._raw_retention_start();
-            assert date_trunc('minute', v_raw) <> v_raw,
-              'test setup: raw_retention_start must be mid-minute, got ' || v_raw;
-            v_bound := date_trunc('minute', v_raw) + interval '1 minute';
-            v_passed := v_end - interval '2 hours' + interval '23 seconds';  -- mid-minute passed start
+            -- (b) advise the minute-aligned configured boundary, which is safe
+            -- to pass straight back through the readers' minute floor.
+            v_bound := v_end - interval '30 minutes';
+            v_passed := v_end - interval '40 minutes' + interval '23 seconds';
             v_raised := false;
             begin
               perform * from ash.aas(v_passed, v_end,
@@ -4119,23 +4340,17 @@ jobs:
             -- (a) echoes the un-floored start the user actually passed (not floored v_start_ts)
             assert v_msg like '%' || v_passed::text || '%',
               'message must echo the user''s passed start ' || v_passed || ', got: ' || v_msg;
-            -- (b) advises a minute-aligned boundary >= raw_start (followable, not a loop)
+            -- (b) advises the minute-aligned boundary (followable, not a loop)
             assert v_msg like '%start at or after ' || v_bound::text || '%',
               'hint must print minute-aligned boundary ' || v_bound || ', got: ' || v_msg;
             -- passing exactly that boundary now SUCCEEDS (the advice is actionable)
             select count(*) into n from ash.top('query_id', v_bound, v_end,
                                                 wait_event => 'DataFileRead');
             assert n = 1, 'following the hint boundary must return the 424242 row, got ' || n;
-            -- and passing raw_start itself re-floors below it and still raises (the loop we fixed)
-            v_raised := false;
-            begin
-              perform * from ash.aas(v_raw, v_end, wait_event => 'DataFileRead', query_id => 424242);
-            exception when others then v_raised := true; end;
-            assert v_raised, 'passing a mid-minute raw_start re-floors below it and still raises';
-            -- restore pre-test raw retention so downstream assertions see original state
-            delete from ash.sample
-              where sample_ts = ash.ts_from_timestamptz(v_end - interval '40 minutes' + interval '37 seconds');
-            raise notice 'retention error split PASSED (mid-minute hint is followable, echoes passed start)';
+            -- The boundary itself must also pass through another tie reader.
+            perform * from ash.aas(
+              v_bound, v_end, wait_event => 'DataFileRead', query_id => 424242);
+            raise notice 'retention error split PASSED (boundary hint is followable, echoes passed start)';
 
             -- ---- compare coverage honesty ----
             -- window 1 uncovered (4..3h back): NULL columns + NULL delta, overall mode.
@@ -4168,6 +4383,9 @@ jobs:
               if sqlerrm like 'ash.compare: unknown dimension%' then v_raised := true; else raise; end if;
             end;
             assert v_raised, 'compare dimension error must name ash.compare';
+            update ash.config
+            set rotation_period = interval '1 day', rotated_at = now()
+            where singleton;
             raise notice 'compare coverage honesty PASSED';
           end $$;
 
@@ -5236,6 +5454,8 @@ jobs:
               '#107: preserved reader must gain new internal helpers (ash._pgss_query_text)';
             assert has_function_privilege('ash_b1_reader', 'ash._raw_retention_start()', 'EXECUTE'),
               '#107: preserved reader must gain new internal helpers (ash._raw_retention_start)';
+            assert has_function_privilege('ash_b1_reader', 'ash._raw_retention_boundary()', 'EXECUTE'),
+              '#107: preserved reader must gain new internal helpers (ash._raw_retention_boundary)';
 
             -- No escalation: restoring grants must not widen the role's
             -- reach to admin functions or re-open PUBLIC.

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -2565,7 +2565,7 @@ begin
    * raw wait<->query drill stops. NULL when the source holds no data yet.
    */
   metric := 'raw_retention_start';
-  value := coalesce(ash._raw_retention_start()::text, 'no samples'); return next;
+  value := coalesce(ash._raw_retention_boundary()::text, 'no samples'); return next;
   metric := 'rollup_1m_retention_start';
   value := coalesce(ash._rollup_1m_retention_start()::text, 'no rollups'); return next;
   metric := 'rollup_1h_retention_start';
@@ -3423,9 +3423,10 @@ $$;
  */
 
 /*
- * Retention-start helpers: earliest timestamp each source can answer. Null
- * when the source holds no data. Used by source auto-selection and by the
- * raw-drill retention-boundary exception.
+ * Exact oldest timestamps currently held by each source. Null when the source
+ * holds no data. Used by source auto-selection and report attribution. Raw's
+ * configured retention boundary is separate: a fresh install or sampler
+ * outage can have a much newer oldest sample without having aged out data.
  */
 create or replace function ash._raw_retention_start()
 returns timestamptz
@@ -3434,6 +3435,40 @@ stable
 set search_path = pg_catalog, ash
 as $$
   select ash.ts_to_timestamptz(min(sample_ts)) from ash.sample
+$$;
+
+/*
+ * Earliest raw minute not lost to rotation. The completed-slot boundary is
+ * anchored at the last rotation, not at now(), because the current partial
+ * slot makes retention grow until the next rotation. If an older sample is
+ * still physically retained (for example after a delayed rotation), honor it.
+ * Keep the exact oldest sample separate for source selection and attribution.
+ */
+create or replace function ash._raw_retention_boundary()
+returns timestamptz
+language sql
+stable
+set search_path = pg_catalog, ash
+as $$
+  with oldest as (
+    select
+      ash._raw_retention_start() as sample_ts
+  )
+  select
+    case
+      when oldest.sample_ts is null then null
+      else date_trunc(
+        'minute',
+        least(
+          oldest.sample_ts,
+          config_row.rotated_at
+            - (config_row.num_partitions - 2) * config_row.rotation_period
+        )
+      )
+    end
+  from ash.config as config_row
+  cross join oldest
+  where config_row.singleton
 $$;
 
 create or replace function ash._rollup_1m_retention_start()
@@ -3536,13 +3571,28 @@ stable
 set search_path = pg_catalog, ash
 as $$
 declare
-  v_next_boundary timestamptz;
+  v_raw_boundary timestamptz;
+  v_window_start timestamptz;
+  v_window_end timestamptz;
 begin
-  if raw_start is not null
-     and ash.ts_to_timestamptz(start_ts) >= raw_start then
+  v_raw_boundary := date_trunc(
+    'minute',
+    raw_start
+  );
+  v_window_start := date_trunc(
+    'minute',
+    ash.ts_to_timestamptz(start_ts)
+  );
+  v_window_end := date_trunc(
+    'minute',
+    ash.ts_to_timestamptz(end_ts)
+  );
+
+  if v_raw_boundary is not null
+     and v_window_start >= v_raw_boundary then
     return;  -- raw covers the window start: the tie drill can proceed
   end if;
-  if raw_start is null or ash.ts_to_timestamptz(end_ts) <= raw_start then
+  if v_raw_boundary is null or v_window_end <= v_raw_boundary then
     raise exception
       'pg_ash: this drill needs the raw wait<->query tie, but the requested '
       'window (% to %) is entirely outside raw retention (%). The tie is '
@@ -3551,25 +3601,23 @@ begin
       'query_id (e.g. ash.aas(), ash.timeline(), ash.top() with one of the '
       'two).',
       since,
-      ash.ts_to_timestamptz(end_ts),
-      coalesce('raw retention starts at ' || raw_start, 'no raw samples exist');
+      v_window_end,
+      coalesce(
+        'raw retention starts at ' || v_raw_boundary,
+        'no raw samples exist'
+      );
   end if;
   /*
-   * The reader floors since to the minute BEFORE this guard runs, so a user
-   * who narrows to exactly raw_start (when it is mid-minute) re-floors below
-   * it and loops on this same error. Advise the first minute-aligned instant
-   * at or after raw retention start — a value that actually clears the guard.
+   * The readers query minute grains, so remediation must preserve the partial
+   * first retained minute. The boundary and queried start are both floored;
+   * printing that same boundary is directly reusable by the caller.
    */
-  v_next_boundary := case
-    when date_trunc('minute', raw_start) = raw_start then raw_start
-    else date_trunc('minute', raw_start) + interval '1 minute'
-  end;
   raise exception
     'pg_ash: this drill needs raw samples; raw retention starts at % but the '
     'requested window starts at %. Narrow the window to start at or after % '
     '(the window end is still inside raw retention), or drill without the '
     'query/event tie.',
-    raw_start, since, v_next_boundary;
+    v_raw_boundary, since, v_raw_boundary;
 end;
 $$;
 
@@ -3862,7 +3910,7 @@ begin
 
   if v_tie then
     v_source := 'raw';
-    v_raw_start := ash._raw_retention_start();
+    v_raw_start := ash._raw_retention_boundary();
     perform ash._raise_tie_retention(v_raw_start, v_start_ts, v_end_ts, v_from);
     v_grain_secs := 60;
   else
@@ -4027,7 +4075,7 @@ begin
            and (wait_event_type is not null or wait_event is not null);
   if v_tie then
     v_source := 'raw';
-    v_raw_start := ash._raw_retention_start();
+    v_raw_start := ash._raw_retention_boundary();
     perform ash._raise_tie_retention(v_raw_start, v_start_ts, v_end_ts, v_from);
     v_grain_secs := 60;
   else
@@ -4461,7 +4509,7 @@ begin
 
   if v_tie then
     v_source := 'raw';
-    v_raw_start := ash._raw_retention_start();
+    v_raw_start := ash._raw_retention_boundary();
     perform ash._raise_tie_retention(v_raw_start, v_start_ts, v_end_ts, v_from);
     v_grain_secs := 60;
   else


### PR DESCRIPTION
Fixes #212 — the README's flagship drill hard-errors on any fresh install, and
`ash.status().raw_retention_start` is unusable as the planning boundary it is documented to be.

Found by the pre-tag audit (#160). **Draft on purpose**: needs REV and your explicit approval.

## The bug

`ash._raw_retention_start()` returns `min(sample_ts)` — the *oldest sample currently held* — but
`_raise_tie_retention()` treats it as a *retention boundary*, and `status()` publishes it under a
name documented for window planning. On a young install with the data 100% present:

    -- README.md:193, verbatim
    ERROR: this drill needs raw samples; raw retention starts at 22:34:51 but the
           requested window starts at 22:30:01. Narrow the window to start at or after 22:35:00

Feed it `status().raw_retention_start` and it *still* raises (the reader floors `since` to the
minute before the guard runs). Follow the error's own printed advice and you get **0 rows** — the
whole partial first minute discarded. With `ash.start()`'s 1s default this fires 59/60 of the time.

## The fix

Splits the two conflated concepts rather than fudging one:

- **`ash._raw_retention_boundary()`** (new) — the configured ring boundary,
  `rotated_at - (num_partitions - 2) * rotation_period`, floored to the minute, honouring an older
  sample if one is still physically retained. Used by `status()` and every tie guard.
- **`ash._raw_retention_start()`** (unchanged) — still the exact oldest held sample. Still used by
  source selection and report attribution, where "what data exists" is the right question.
- Both sides of the tie comparison are floored consistently, so a window starting exactly at the
  boundary is accepted.
- The remediation hint in the error is rounded **down**, so following it returns data.

## Verification

RED against unpatched SQL — the real README:193 failure, reproduced:

    ERROR: README:193 raised on a young install: pg_ash: this drill needs raw samples...

GREEN, with exact-value assertions rather than "returns rows":

- README:193 → `1 / 212212 / raw`, metrics `(0.03, 0.13, 0.13, 8.00, 100.00)`
- passing `status().raw_retention_start` straight back in → same eight backend-seconds
- following the printed remediation verbatim → same non-empty result
- **genuine age-out still raises**: a row is inserted into slot 2, `rotate()` truncates it, its
  count is asserted to be exactly zero, and the old window raises SQLSTATE `P0001` with the exact
  unrecoverable message. That is the control proving the guard was fixed, not disabled.

Fresh install, double re-apply, full 1.0→2.0 chain, and fresh-vs-chain schema/ACL equivalence all
pass on PG 18.3.

## ⚠️ Merge order and a required edit to #129

**#129 must merge first, then this.** Composition was tested against #129 head `2006159`, not
assumed.

The code cherry-picks with **no textual conflict** — but **one of #129's own test assertions
becomes wrong** once this lands. #129 asserts that `status().raw_retention_start` equals the exact
oldest retained sample; this PR redefines that field as the configured ring boundary. Whoever
merges must update that assertion to compute the boundary from `rotated_at`, `num_partitions` and
`rotation_period`. Verified composed and green after exactly that change:

    NOTICE: raw retention excludes the oldest ring slot PASSED
    NOTICE: issue #212 raw retention boundary tests PASSED
    NOTICE: retention error split PASSED (boundary hint is followable, echoes passed start)

This branch deliberately remains one clean commit on `37a0e2a`; the composition was validated on a
scratch branch and not included here.

## Review note

`raw_retention_start` now means **two different things** on two user-facing surfaces:
`status()` reports the *planning boundary*, while `report().coverage.raw_retention_start` keeps
the *exact oldest sample* (it describes attribution availability, not planning). Each choice is
defensible on its own; sharing the name is the wart. Worth renaming one before this ships —
`report()`'s payload contract is frozen per 2.0 minor line, so it is easier to change now than later.

Related but distinct: #217 introduces a geometry constraint using `(num_partitions - 1)`. That is
not an inconsistency with the `- 2` used here — `-1` bounds the physical age of rows in the slot
about to be truncated, `-2` is the user-visible retention window. Both PRs would benefit from a
comment saying so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HzBGzjFyN8dXZHbdWmYBj
