### PR TITLE
fix: keep AAS extremes honest across rollup grains (#210)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3723,10 +3723,10 @@ jobs:
           -- p99_aas as a short (rollup_1m-backed) window containing the same spike.
           -- Invariants: (a) monotonic peak — widening the window never shrinks the
           -- peak; (b) seam consistency — identical peak/p99 from either source;
-          -- (c) p99_aas non-null over rollup_1h-backed windows. Also: rollup_hour()
-          -- computes minute_counts exactly, legacy NULL rows flat-fill to the hour
-          -- average (lower bound, never an invented spike), and wait-filtered reads
-          -- honestly stay hour-grain.
+          -- (c) p99_aas non-null over exact rollup_1h-backed windows. Also:
+          -- rollup_hour() computes minute_counts exactly, legacy NULL rows are
+          -- visibly marked as flat estimates, and wait-filtered reads NULL
+          -- minute peak/p99 when only hour-grain evidence survives.
           -- ============================================================================
           do $$
           declare
@@ -3796,35 +3796,42 @@ jobs:
             where data_points > 0;
             assert n = 6, 'timeline 10-min buckets with data over rollup_1h = 6, got ' || n;
 
-            -- wait-filtered long window has no per-minute detail and honestly stays
-            -- hour-grain: peak = IO hour average (59*20+60)/3600 = 0.34, timeline p99 null
+            -- wait-filtered long window has no per-minute detail. Its average
+            -- remains exact, but a requested minute peak/p99 is honestly NULL.
             select * into a from ash.aas(v_h - interval '2 hours', v_h + interval '1 hour',
                                          wait_event_type => 'IO');
-            assert a.source = 'rollup_1h' and a.peak_aas = 0.34,
-              format('filtered long window stays hour-grain: peak=%s (want 0.34)', a.peak_aas);
+            assert a.source = 'rollup_1h' and a.avg_aas = 0.11
+                   and a.peak_aas is null and a.p99_aas is null,
+              format('filtered long window source=%s avg=%s peak=%s p99=%s',
+                     a.source, a.avg_aas, a.peak_aas, a.p99_aas);
             select p99_aas into v_p99
             from ash.timeline(v_h - interval '2 hours', v_h + interval '1 hour', '1 hour',
                               wait_event_type => 'IO')
             where data_points > 0;
             assert v_p99 is null, 'filtered rollup_1h timeline p99 stays null, got ' || coalesce(v_p99::text, 'null');
 
-            -- legacy pre-2.0 row (minute_counts null): flat-fills to its hour average
-            -- (AAS 1.00/min) — peak keeps the real spike, p99 non-null, no fake spike
+            -- legacy pre-2.0 row (minute_counts null): the compatibility path
+            -- still flat-fills averages, but marks the whole read and NULLs the
+            -- minute extremes because the legacy hour's distribution is unknown.
             insert into ash.rollup_1h (ts, datid, samples, peak_backends, wait_counts, query_counts, minute_counts)
             values (ash.ts_from_timestamptz(v_h - interval '1 hour'), 0::oid, 3600, 9,
                     array[v_cpu, 3600]::int4[], '{}'::int8[], null);
             select * into a from ash.aas(v_h - interval '2 hours', v_h + interval '1 hour');
-            assert a.peak_aas = 11.30 and a.p99_aas = 1.00 and a.buckets_with_data = 120,
-              format('legacy mix: peak=%s p99=%s bwd=%s (want 11.30 1.00 120)',
-                     a.peak_aas, a.p99_aas, a.buckets_with_data);
+            assert a.source = 'rollup_1h_flat'
+                   and a.peak_aas is null and a.p99_aas is null
+                   and a.buckets_with_data = 120,
+              format('legacy mix: source=%s peak=%s p99=%s bwd=%s',
+                     a.source, a.peak_aas, a.p99_aas,
+                     a.buckets_with_data);
 
-            -- periods(): the long windows (1w, 1mo) carry the true minute peak and a
-            -- non-null p99 (US-6 capacity planning works past rollup_1m retention)
+            -- periods() propagates the legacy marker and does not re-label the
+            -- flat estimate as a measured minute peak/p99.
             for r in select * from ash.periods(v_h + interval '1 hour') loop
               if r.period in ('1w', '1mo') then
-                assert r.peak_aas = 11.30 and r.p99_aas is not null,
-                  format('periods %s: peak=%s p99=%s (want 11.30, non-null)',
-                         r.period, r.peak_aas, r.p99_aas);
+                assert r.source = 'rollup_1h_flat'
+                       and r.peak_aas is null and r.p99_aas is null,
+                  format('periods %s: source=%s peak=%s p99=%s',
+                         r.period, r.source, r.peak_aas, r.p99_aas);
               end if;
             end loop;
 
@@ -3834,6 +3841,706 @@ jobs:
               where singleton;
 
             raise notice 'rollup_1h seam minute-grain peak/p99 PASSED';
+          end $$;
+          EOF
+
+      - name: "Issue #210: honest peak/p99 grain across every AAS reader"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          -- B1a: an hour-grain wait breakdown must not label its hour average
+          -- as a one-minute peak/p99. Average, seconds, and pct remain exact.
+          do $$
+          declare
+            v_h timestamptz := date_trunc('hour', now()) - interval '48 hours';
+            v_datid oid;
+            v_cpu smallint;
+            v_aas record;
+            v_top record;
+          begin
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set sample_interval = interval '1 second',
+                last_rollup_1m_ts = null, last_rollup_1h_ts = null
+            where singleton;
+            select oid into v_datid from pg_database
+            where datname = current_database();
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+
+            -- 59 minutes at AAS 1 and one minute at AAS 10:
+            -- total=4140 backend-seconds, avg=1.15, minute p99=4.69.
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            ) values (
+              ash.ts_from_timestamptz(v_h), v_datid, 3600, 10,
+              array[v_cpu, 4140]::int4[], '{}'::int8[],
+              array[600] || array_fill(60, array[59])
+            );
+
+            select * into v_aas
+            from ash.aas(v_h, v_h + interval '1 hour');
+            assert v_aas.source = 'rollup_1h'
+                   and v_aas.avg_aas = 1.15
+                   and v_aas.peak_aas = 10.00
+                   and v_aas.p99_aas = 4.69
+                   and v_aas.backend_seconds = 4140.00,
+              format('B1a aas source=%s avg=%s peak=%s p99=%s seconds=%s',
+                     v_aas.source, v_aas.avg_aas, v_aas.peak_aas,
+                     v_aas.p99_aas, v_aas.backend_seconds);
+
+            select * into v_top
+            from ash.top('wait_event', v_h, v_h + interval '1 hour');
+            assert v_top.key = 'CPU*' and v_top.source = 'rollup_1h'
+                   and v_top.avg_aas = 1.15
+                   and v_top.peak_aas is null
+                   and v_top.p99_aas is null
+                   and v_top.backend_seconds = 4140.00
+                   and v_top.pct = 100.00,
+              format('B1a top key=%s source=%s avg=%s peak=%s p99=%s '
+                     'seconds=%s pct=%s',
+                     v_top.key, v_top.source, v_top.avg_aas,
+                     v_top.peak_aas, v_top.p99_aas,
+                     v_top.backend_seconds, v_top.pct);
+            raise notice 'issue #210 B1a PASSED';
+          end $$;
+
+          -- B1b: a wait filter forces the surviving hour grain. The scalar
+          -- average is exact, but minute peak/p99 are unknowable and NULL.
+          do $$
+          declare
+            v_h timestamptz := date_trunc('hour', now()) - interval '48 hours';
+            v_datid oid;
+            v_cpu smallint;
+            v_io smallint;
+            v_all record;
+            v_io_aas record;
+            v_query_aas record;
+          begin
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            select oid into v_datid from pg_database
+            where datname = current_database();
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+            select ash._register_wait('active', 'IO', 'DataFileRead') into v_io;
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            ) values (
+              ash.ts_from_timestamptz(v_h), v_datid, 3600, 10,
+              array[v_cpu, 3540, v_io, 600]::int4[],
+              array[99::bigint, 600]::int8[],
+              array[600] || array_fill(60, array[59])
+            );
+
+            select * into v_all
+            from ash.aas(v_h, v_h + interval '1 hour');
+            select * into v_io_aas
+            from ash.aas(
+              v_h, v_h + interval '1 hour', wait_event_type => 'IO'
+            );
+            select * into v_query_aas
+            from ash.aas(
+              v_h, v_h + interval '1 hour', query_id => 99
+            );
+            assert v_all.source = 'rollup_1h'
+                   and v_all.peak_aas = 10.00
+                   and v_all.p99_aas = 4.69,
+              format('B1b unfiltered source=%s peak=%s p99=%s',
+                     v_all.source, v_all.peak_aas, v_all.p99_aas);
+            assert v_io_aas.source = 'rollup_1h'
+                   and v_io_aas.avg_aas = 0.17
+                   and v_io_aas.peak_aas is null
+                   and v_io_aas.p99_aas is null
+                   and v_io_aas.backend_seconds = 600.00,
+              format('B1b filtered source=%s avg=%s peak=%s p99=%s '
+                     'seconds=%s',
+                     v_io_aas.source, v_io_aas.avg_aas,
+                     v_io_aas.peak_aas, v_io_aas.p99_aas,
+                     v_io_aas.backend_seconds);
+            assert v_query_aas.source = 'rollup_1h'
+                   and v_query_aas.avg_aas = 0.17
+                   and v_query_aas.peak_aas is null
+                   and v_query_aas.p99_aas is null
+                   and v_query_aas.backend_seconds = 600.00,
+              format('B1b query source=%s avg=%s peak=%s p99=%s seconds=%s',
+                     v_query_aas.source, v_query_aas.avg_aas,
+                     v_query_aas.peak_aas, v_query_aas.p99_aas,
+                     v_query_aas.backend_seconds);
+            raise notice 'issue #210 B1b PASSED';
+          end $$;
+
+          -- B1c: identical wait load on an hourly baseline and a minute-grain
+          -- comparison window keeps avg_delta=0, discloses both sources, and
+          -- suppresses the entire unlike-grain peak/p99 pair.
+          do $$
+          declare
+            v_h1 timestamptz := date_trunc('hour', now()) - interval '48 hours';
+            v_h2 timestamptz := date_trunc('hour', now()) - interval '2 hours';
+            v_datid oid;
+            v_cpu smallint;
+            v_dim record;
+            v_all record;
+            v_db record;
+          begin
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            select oid into v_datid from pg_database
+            where datname = current_database();
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            ) values (
+              ash.ts_from_timestamptz(v_h1), v_datid, 3600, 10,
+              array[v_cpu, 4140]::int4[], '{}'::int8[],
+              array[600] || array_fill(60, array[59])
+            );
+            for i in 0..59 loop
+              insert into ash.rollup_1m (
+                ts, datid, samples, peak_backends,
+                wait_counts, query_counts
+              ) values (
+                ash.ts_from_timestamptz(
+                  v_h2 + (i || ' minutes')::interval
+                ),
+                v_datid, 60, case when i = 0 then 10 else 1 end,
+                array[v_cpu, case when i = 0 then 600 else 60 end]::int4[],
+                '{}'::int8[]
+              );
+            end loop;
+
+            select * into v_dim
+            from ash.compare(
+              v_h1, v_h1 + interval '1 hour',
+              v_h2, v_h2 + interval '1 hour',
+              dimension => 'wait_event_type'
+            );
+            assert v_dim.key = 'CPU*'
+                   and v_dim.source_1 = 'rollup_1h'
+                   and v_dim.source_2 = 'rollup_1m'
+                   and v_dim.avg_aas_1 = 1.15
+                   and v_dim.avg_aas_2 = 1.15
+                   and v_dim.avg_delta = 0.00
+                   and v_dim.peak_aas_1 is null
+                   and v_dim.peak_aas_2 is null
+                   and v_dim.p99_aas_1 is null
+                   and v_dim.p99_aas_2 is null
+                   and v_dim.pct_1 = 100.00 and v_dim.pct_2 = 100.00,
+              format('B1c dimension key=%s sources=%s/%s avg=%s/%s '
+                     'delta=%s peak=%s/%s p99=%s/%s pct=%s/%s',
+                     v_dim.key, v_dim.source_1, v_dim.source_2,
+                     v_dim.avg_aas_1, v_dim.avg_aas_2, v_dim.avg_delta,
+                     v_dim.peak_aas_1, v_dim.peak_aas_2,
+                     v_dim.p99_aas_1, v_dim.p99_aas_2,
+                     v_dim.pct_1, v_dim.pct_2);
+
+            -- Overall rollup_1h reads use real minute_counts, so these two
+            -- sources resolve to the same minute grain and keep the pair.
+            select * into v_all
+            from ash.compare(
+              v_h1, v_h1 + interval '1 hour',
+              v_h2, v_h2 + interval '1 hour'
+            );
+            assert v_all.key = 'overall'
+                   and v_all.source_1 = 'rollup_1h'
+                   and v_all.source_2 = 'rollup_1m'
+                   and v_all.avg_delta = 0.00
+                   and v_all.peak_aas_1 = 10.00
+                   and v_all.peak_aas_2 = 10.00
+                   and v_all.p99_aas_1 = 4.69
+                   and v_all.p99_aas_2 = 4.69,
+              format('B1c overall sources=%s/%s delta=%s peak=%s/%s '
+                     'p99=%s/%s',
+                     v_all.source_1, v_all.source_2, v_all.avg_delta,
+                     v_all.peak_aas_1, v_all.peak_aas_2,
+                     v_all.p99_aas_1, v_all.p99_aas_2);
+
+            -- Database is likewise minute-grain on the hourly side because
+            -- minute_counts is stored per datid; keep its comparable pair.
+            select * into v_db
+            from ash.compare(
+              v_h1, v_h1 + interval '1 hour',
+              v_h2, v_h2 + interval '1 hour',
+              dimension => 'database'
+            );
+            assert v_db.key = current_database()
+                   and v_db.source_1 = 'rollup_1h'
+                   and v_db.source_2 = 'rollup_1m'
+                   and v_db.avg_delta = 0.00
+                   and v_db.peak_aas_1 = 10.00
+                   and v_db.peak_aas_2 = 10.00
+                   and v_db.p99_aas_1 = 4.69
+                   and v_db.p99_aas_2 = 4.69,
+              format('B1c database key=%s sources=%s/%s delta=%s '
+                     'peak=%s/%s p99=%s/%s',
+                     v_db.key, v_db.source_1, v_db.source_2,
+                     v_db.avg_delta, v_db.peak_aas_1, v_db.peak_aas_2,
+                     v_db.p99_aas_1, v_db.p99_aas_2);
+            raise notice 'issue #210 B1c PASSED';
+          end $$;
+
+          -- Database is the precise dimensional exception: minute_counts is
+          -- stored per (hour, datid), so top(database) can retain real minute
+          -- peak/p99 and spike-first ordering on rollup_1h.
+          do $$
+          declare
+            v_h timestamptz := date_trunc('hour', now()) - interval '48 hours';
+            v_datid oid;
+            v_cpu smallint;
+            v_spike record;
+            v_steady record;
+            v_ranked record;
+          begin
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            select oid into v_datid from pg_database
+            where datname = current_database();
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            ) values
+              (
+                ash.ts_from_timestamptz(v_h), v_datid, 3600, 10,
+                array[v_cpu, 4140]::int4[], '{}'::int8[],
+                array[600] || array_fill(60, array[59])
+              ),
+              (
+                ash.ts_from_timestamptz(v_h), 0::oid, 3600, 2,
+                array[v_cpu, 7200]::int4[], '{}'::int8[],
+                array_fill(120, array[60])
+              );
+
+            select * into v_spike
+            from ash.top(
+              'database', v_h, v_h + interval '1 hour',
+              n => 10, order_by => 'peak'
+            )
+            where key = current_database();
+            select * into v_steady
+            from ash.top(
+              'database', v_h, v_h + interval '1 hour',
+              n => 10, order_by => 'peak'
+            )
+            where key = '<oid:0>';
+            select * into v_ranked
+            from ash.top(
+              'database', v_h, v_h + interval '1 hour',
+              n => 1, order_by => 'peak'
+            );
+
+            assert v_spike.source = 'rollup_1h'
+                   and v_spike.avg_aas = 1.15
+                   and v_spike.peak_aas = 10.00
+                   and v_spike.p99_aas = 4.69
+                   and v_spike.backend_seconds = 4140.00
+                   and v_spike.pct = 36.51,
+              format('database spike source=%s avg=%s peak=%s p99=%s '
+                     'seconds=%s pct=%s',
+                     v_spike.source, v_spike.avg_aas, v_spike.peak_aas,
+                     v_spike.p99_aas, v_spike.backend_seconds, v_spike.pct);
+            assert v_steady.avg_aas = 2.00
+                   and v_steady.peak_aas = 2.00
+                   and v_steady.p99_aas = 2.00
+                   and v_steady.backend_seconds = 7200.00
+                   and v_steady.pct = 63.49,
+              format('database steady avg=%s peak=%s p99=%s seconds=%s pct=%s',
+                     v_steady.avg_aas, v_steady.peak_aas,
+                     v_steady.p99_aas, v_steady.backend_seconds, v_steady.pct);
+            assert v_ranked.key = current_database()
+                   and v_ranked.peak_aas = 10.00,
+              format('database spike-first key=%s peak=%s',
+                     v_ranked.key, v_ranked.peak_aas);
+            raise notice 'issue #210 database precision PASSED';
+          end $$;
+
+          -- B1d: a legacy hour has only hour-grain evidence. Its historical
+          -- flat-minute compatibility expansion remains usable for averages,
+          -- but source=rollup_1h_flat marks it and minute peak/p99 are NULL.
+          do $$
+          declare
+            v_h timestamptz := date_trunc('hour', now()) - interval '48 hours';
+            v_datid oid;
+            v_cpu smallint;
+            v_aas record;
+            v_database_aas record;
+            v_top record;
+            v_rows int;
+            v_points bigint;
+            v_min_avg numeric;
+            v_max_avg numeric;
+            v_nonnull_peaks int;
+            v_nonnull_p99s int;
+            v_sources int;
+          begin
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            select oid into v_datid from pg_database
+            where datname = current_database();
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+
+            insert into ash.rollup_1h (
+              ts, datid, samples, peak_backends,
+              wait_counts, query_counts, minute_counts
+            ) values (
+              ash.ts_from_timestamptz(v_h), v_datid, 3600, 10,
+              array[v_cpu, 600]::int4[], '{}'::int8[], null
+            );
+
+            select * into v_aas
+            from ash.aas(v_h, v_h + interval '1 hour');
+            select * into v_database_aas
+            from ash.aas(
+              v_h, v_h + interval '1 hour',
+              database => current_database()
+            );
+            assert v_aas.source = 'rollup_1h_flat'
+                   and v_aas.buckets_expected = 60
+                   and v_aas.buckets_with_data = 60
+                   and v_aas.avg_aas = 0.17
+                   and v_aas.peak_aas is null
+                   and v_aas.p99_aas is null
+                   and v_aas.backend_seconds = 600.00,
+              format('B1d aas source=%s expected=%s with_data=%s avg=%s '
+                     'peak=%s p99=%s seconds=%s',
+                     v_aas.source, v_aas.buckets_expected,
+                     v_aas.buckets_with_data, v_aas.avg_aas,
+                     v_aas.peak_aas, v_aas.p99_aas,
+                     v_aas.backend_seconds);
+            assert v_database_aas.source = 'rollup_1h_flat'
+                   and v_database_aas.avg_aas = 0.17
+                   and v_database_aas.peak_aas is null
+                   and v_database_aas.p99_aas is null
+                   and v_database_aas.backend_seconds = 600.00,
+              format('B1d database filter source=%s avg=%s peak=%s p99=%s '
+                     'seconds=%s',
+                     v_database_aas.source, v_database_aas.avg_aas,
+                     v_database_aas.peak_aas, v_database_aas.p99_aas,
+                     v_database_aas.backend_seconds);
+
+            select count(*), sum(data_points), min(avg_aas), max(avg_aas),
+                   count(peak_aas), count(p99_aas),
+                   count(distinct source)
+              into v_rows, v_points, v_min_avg, v_max_avg,
+                   v_nonnull_peaks, v_nonnull_p99s, v_sources
+            from ash.timeline(
+              v_h, v_h + interval '1 hour', interval '1 minute'
+            );
+            assert v_rows = 60 and v_points = 60
+                   and v_min_avg = 0.17 and v_max_avg = 0.17
+                   and v_nonnull_peaks = 0 and v_nonnull_p99s = 0
+                   and v_sources = 1
+                   and (select min(source) from ash.timeline(
+                         v_h, v_h + interval '1 hour', interval '1 minute'
+                       )) = 'rollup_1h_flat',
+              format('B1d timeline rows=%s points=%s avg=%s..%s '
+                     'nonnull peak/p99=%s/%s sources=%s',
+                     v_rows, v_points, v_min_avg, v_max_avg,
+                     v_nonnull_peaks, v_nonnull_p99s, v_sources);
+
+            select * into v_top
+            from ash.top('database', v_h, v_h + interval '1 hour');
+            assert v_top.source = 'rollup_1h_flat'
+                   and v_top.avg_aas = 0.17
+                   and v_top.peak_aas is null
+                   and v_top.p99_aas is null
+                   and v_top.backend_seconds = 600.00
+                   and v_top.pct = 100.00,
+              format('B1d top source=%s avg=%s peak=%s p99=%s '
+                     'seconds=%s pct=%s',
+                     v_top.source, v_top.avg_aas,
+                     v_top.peak_aas, v_top.p99_aas,
+                     v_top.backend_seconds, v_top.pct);
+            raise notice 'issue #210 B1d PASSED';
+          end $$;
+
+          truncate ash.rollup_1m, ash.rollup_1h;
+          update ash.config
+          set last_rollup_1m_ts = null, last_rollup_1h_ts = null
+          where singleton;
+          EOF
+
+      - name: "Issue #210: cross-reader agreement + zero-argument readers"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 << 'EOF'
+          -- One fixed minute-grain window must tell the same numeric story in
+          -- aas, timeline, top, summary, and report.
+          do $$
+          declare
+            v_h timestamptz := date_trunc('hour', now()) - interval '2 hours';
+            v_datid oid;
+            v_cpu smallint;
+            v_aas record;
+            v_timeline record;
+            v_top record;
+            v_report jsonb;
+            v_summary_avg text;
+            v_summary_peak text;
+            v_summary_p99 text;
+            v_summary_seconds text;
+            v_summary_wait text;
+          begin
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config set sample_interval = interval '1 second'
+            where singleton;
+            select oid into v_datid from pg_database
+            where datname = current_database();
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+
+            for i in 0..59 loop
+              insert into ash.rollup_1m (
+                ts, datid, samples, peak_backends,
+                wait_counts, query_counts
+              ) values (
+                ash.ts_from_timestamptz(
+                  v_h + (i || ' minutes')::interval
+                ),
+                v_datid, 60, case when i = 0 then 10 else 1 end,
+                array[v_cpu, case when i = 0 then 600 else 60 end]::int4[],
+                array[4242::bigint,
+                      case when i = 0 then 600 else 60 end]::int8[]
+              );
+            end loop;
+
+            select * into v_aas
+            from ash.aas(v_h, v_h + interval '1 hour');
+            select * into v_timeline
+            from ash.timeline(
+              v_h, v_h + interval '1 hour', interval '1 hour'
+            );
+            select * into v_top
+            from ash.top(
+              'wait_event_type', v_h, v_h + interval '1 hour'
+            );
+            v_report := ash.report(v_h, v_h + interval '1 hour');
+            select value into v_summary_avg
+            from ash.summary(v_h, v_h + interval '1 hour')
+            where metric = 'avg_aas';
+            select value into v_summary_peak
+            from ash.summary(v_h, v_h + interval '1 hour')
+            where metric = 'peak_aas';
+            select value into v_summary_p99
+            from ash.summary(v_h, v_h + interval '1 hour')
+            where metric = 'p99_aas';
+            select value into v_summary_seconds
+            from ash.summary(v_h, v_h + interval '1 hour')
+            where metric = 'backend_seconds';
+            select value into v_summary_wait
+            from ash.summary(v_h, v_h + interval '1 hour')
+            where metric = 'top_wait_1';
+
+            assert v_aas.source = 'rollup_1m'
+                   and v_aas.avg_aas = 1.15
+                   and v_aas.peak_aas = 10.00
+                   and v_aas.p99_aas = 4.69
+                   and v_aas.backend_seconds = 4140.00,
+              format('agreement aas source=%s avg=%s peak=%s p99=%s sec=%s',
+                     v_aas.source, v_aas.avg_aas, v_aas.peak_aas,
+                     v_aas.p99_aas, v_aas.backend_seconds);
+            assert v_timeline.source = 'rollup_1m'
+                   and v_timeline.data_points = 60
+                   and v_timeline.avg_aas = 1.15
+                   and v_timeline.peak_aas = 10.00
+                   and v_timeline.p99_aas = 4.69,
+              format('agreement timeline source=%s points=%s avg=%s '
+                     'peak=%s p99=%s',
+                     v_timeline.source, v_timeline.data_points,
+                     v_timeline.avg_aas, v_timeline.peak_aas,
+                     v_timeline.p99_aas);
+            assert v_top.key = 'CPU*' and v_top.source = 'rollup_1m'
+                   and v_top.avg_aas = 1.15
+                   and v_top.peak_aas = 10.00
+                   and v_top.p99_aas = 4.69
+                   and v_top.backend_seconds = 4140.00
+                   and v_top.pct = 100.00,
+              format('agreement top key=%s source=%s avg=%s peak=%s '
+                     'p99=%s sec=%s pct=%s',
+                     v_top.key, v_top.source, v_top.avg_aas,
+                     v_top.peak_aas, v_top.p99_aas,
+                     v_top.backend_seconds, v_top.pct);
+            assert v_summary_avg = '1.15'
+                   and v_summary_peak = '10.00'
+                   and v_summary_p99 = '4.69'
+                   and v_summary_seconds = '4140.00'
+                   and v_summary_wait = 'CPU* (avg_aas 1.15, 100.00%)',
+              format('agreement summary avg=%s peak=%s p99=%s sec=%s wait=%s',
+                     v_summary_avg, v_summary_peak, v_summary_p99,
+                     v_summary_seconds, v_summary_wait);
+            assert v_report->'coverage'->>'source' = 'rollup_1m'
+                   and (v_report->'coverage'->>'minutes_expected')::int = 60
+                   and (v_report->'coverage'->>'minutes_with_data')::int = 60
+                   and (v_report->'aas_avg'->>'total')::numeric = 1.15
+                   and (v_report->'aas_worst1m'->>'total')::numeric = 10.00
+                   and (v_report->'aas_p99'->>'total')::numeric = 4.69,
+              format('agreement report coverage=%s avg=%s peak=%s p99=%s',
+                     v_report->'coverage', v_report->'aas_avg'->>'total',
+                     v_report->'aas_worst1m'->>'total',
+                     v_report->'aas_p99'->>'total');
+            raise notice 'issue #210 cross-reader agreement PASSED';
+          end $$;
+
+          -- Minimal/default invocations for the complete reader surface. The
+          -- fixture is steady AAS 1 for two hours, so every assertion is exact
+          -- and every now()-relative default is exercised without alignment
+          -- guards or special timestamps.
+          do $$
+          declare
+            v_end timestamptz := date_trunc('minute', now());
+            v_datid oid;
+            v_cpu smallint;
+            v_aas record;
+            v_compare record;
+            v_report jsonb;
+            v_count int;
+            v_sum numeric;
+            v_min numeric;
+            v_max numeric;
+            v_key text;
+            v_value text;
+          begin
+            truncate ash.sample_0, ash.sample_1, ash.sample_2;
+            truncate ash.rollup_1m, ash.rollup_1h;
+            select oid into v_datid from pg_database
+            where datname = current_database();
+            select ash._register_wait('active', 'CPU*', 'CPU*') into v_cpu;
+
+            for i in 1..120 loop
+              insert into ash.rollup_1m (
+                ts, datid, samples, peak_backends,
+                wait_counts, query_counts
+              ) values (
+                ash.ts_from_timestamptz(
+                  v_end - (i || ' minutes')::interval
+                ),
+                v_datid, 60, 1, array[v_cpu, 60]::int4[],
+                array[4242::bigint, 60]::int8[]
+              );
+            end loop;
+
+            select count(*) into v_count from ash.periods();
+            assert v_count = 6,
+              'zero-argument periods row count ' || v_count;
+            assert (select count(*) from ash.periods()
+                    where bucket = interval '1 minute') = 6,
+              'zero-argument periods must expose six minute-grain rows';
+
+            select * into v_aas from ash.aas();
+            assert v_aas.source = 'rollup_1m'
+                   and v_aas.buckets_expected = 60
+                   and v_aas.buckets_with_data = 60
+                   and v_aas.avg_aas = 1.00
+                   and v_aas.peak_aas = 1.00
+                   and v_aas.p99_aas = 1.00
+                   and v_aas.backend_seconds = 3600.00,
+              format('zero-argument aas source=%s expected=%s data=%s '
+                     'avg=%s peak=%s p99=%s sec=%s',
+                     v_aas.source, v_aas.buckets_expected,
+                     v_aas.buckets_with_data, v_aas.avg_aas,
+                     v_aas.peak_aas, v_aas.p99_aas,
+                     v_aas.backend_seconds);
+
+            select count(*), sum(data_points), min(avg_aas), max(avg_aas)
+              into v_count, v_sum, v_min, v_max
+            from ash.timeline();
+            assert v_count = 60 and v_sum = 60
+                   and v_min = 1.00 and v_max = 1.00,
+              format('zero-argument timeline rows=%s points=%s avg=%s..%s',
+                     v_count, v_sum, v_min, v_max);
+
+            select count(*), min(key) into v_count, v_key
+            from ash.top('wait_event_type');
+            assert v_count = 1 and v_key = 'CPU*',
+              format('minimal top(wait_event_type) rows=%s key=%s',
+                     v_count, v_key);
+            select count(*), min(key) into v_count, v_key
+            from ash.top('wait_event');
+            assert v_count = 1 and v_key = 'CPU*',
+              format('minimal top(wait_event) rows=%s key=%s',
+                     v_count, v_key);
+            select count(*), min(key) into v_count, v_key
+            from ash.top('query_id');
+            assert v_count = 1 and v_key = '4242',
+              format('minimal top(query_id) rows=%s key=%s',
+                     v_count, v_key);
+            select count(*), min(key) into v_count, v_key
+            from ash.top('database');
+            assert v_count = 1 and v_key = current_database(),
+              format('minimal top(database) rows=%s key=%s',
+                     v_count, v_key);
+
+            select * into v_compare
+            from ash.compare(
+              v_end - interval '2 hours', v_end - interval '1 hour',
+              v_end - interval '1 hour', v_end
+            );
+            assert v_compare.key = 'overall'
+                   and v_compare.source_1 = 'rollup_1m'
+                   and v_compare.source_2 = 'rollup_1m'
+                   and v_compare.avg_aas_1 = 1.00
+                   and v_compare.avg_aas_2 = 1.00
+                   and v_compare.avg_delta = 0.00
+                   and v_compare.peak_aas_1 = 1.00
+                   and v_compare.peak_aas_2 = 1.00
+                   and v_compare.p99_aas_1 = 1.00
+                   and v_compare.p99_aas_2 = 1.00,
+              format('minimal compare sources=%s/%s avg=%s/%s delta=%s '
+                     'peak=%s/%s p99=%s/%s',
+                     v_compare.source_1, v_compare.source_2,
+                     v_compare.avg_aas_1, v_compare.avg_aas_2,
+                     v_compare.avg_delta,
+                     v_compare.peak_aas_1, v_compare.peak_aas_2,
+                     v_compare.p99_aas_1, v_compare.p99_aas_2);
+
+            select count(*) into v_count from ash.samples();
+            assert v_count = 0,
+              'zero-argument samples row count ' || v_count;
+
+            v_report := ash.report();
+            assert v_report->'coverage'->>'source' = 'rollup_1m'
+                   and (v_report->'coverage'->>'minutes_expected')::int = 1440
+                   and (v_report->'coverage'->>'minutes_with_data')::int = 120
+                   and (v_report->'aas_avg'->>'total')::numeric = 1.00
+                   and (v_report->'aas_worst1m'->>'total')::numeric = 1.00
+                   and (v_report->'aas_p99'->>'total')::numeric = 1.00,
+              format('zero-argument report coverage=%s avg=%s peak=%s p99=%s',
+                     v_report->'coverage', v_report->'aas_avg'->>'total',
+                     v_report->'aas_worst1m'->>'total',
+                     v_report->'aas_p99'->>'total');
+
+            select count(*), sum(aas), min(aas), max(aas)
+              into v_count, v_sum, v_min, v_max
+            from ash.chart();
+            assert v_count = 61 and v_sum = 60.00
+                   and v_min = 1.00 and v_max = 1.00,
+              format('zero-argument chart rows=%s sum=%s aas=%s..%s',
+                     v_count, v_sum, v_min, v_max);
+
+            select count(*) into v_count from ash.summary();
+            select value into v_value from ash.summary()
+            where metric = 'peak_aas';
+            assert v_count = 11 and v_value = '1.00',
+              format('zero-argument summary rows=%s peak=%s',
+                     v_count, v_value);
+
+            select value into v_value from ash.status()
+            where metric = 'version';
+            assert v_value = '2.0-beta1',
+              'zero-argument status version ' || coalesce(v_value, 'null');
+
+            truncate ash.rollup_1m, ash.rollup_1h;
+            update ash.config
+            set last_rollup_1m_ts = null, last_rollup_1h_ts = null
+            where singleton;
+            raise notice 'issue #210 zero-argument reader sweep PASSED';
           end $$;
           EOF
 

--- a/README.md
+++ b/README.md
@@ -98,8 +98,12 @@ Full mapping: [`blueprints/AAS_EXAMPLES.md`](blueprints/AAS_EXAMPLES.md).
 ## Reader API
 
 Start with `ash.periods()`, then drill down with `ash.timeline()` and `ash.top()`.
-Every reader reports its data source: `raw`, `rollup_1m`, `rollup_1h`, or
-`none`.
+Every reader reports its data source: `raw`, `rollup_1m`, `rollup_1h`,
+`rollup_1h_flat`, or `none`; the `flat` value marks a legacy hour whose minute
+detail could not be backfilled. `ash.compare()` reports the pair as
+`source_1` / `source_2`.
+Peak/p99 are NULL whenever the surviving grain is coarser than the requested
+bucket, while averages and backend-seconds remain valid.
 
 | Function | Use it for |
 |---|---|

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,6 +26,18 @@ surface has been replaced by the AAS-oriented 2.0 API:
 - **AAS-first readers.** `periods`, `aas`, `timeline`, `top`, `compare`,
   `samples`, `report`, `chart`, and `summary` use consistent named filters and
   report whether data came from raw samples, 1-minute rollups, or 1-hour rollups.
+- **Grain-honest extremes across all eight aggregate/render readers.**
+  `periods`, `aas`, `timeline`, `top`, `compare`, `report`, `chart`, and
+  `summary` no longer tell contradictory peak stories at the hourly retention
+  seam. `aas` / `top` return NULL peak/p99 when the surviving grain is coarser
+  than the requested bucket; `compare` adds `source_1` / `source_2` and NULLs
+  both peak/p99 sides on a grain mismatch. The `database` dimension keeps real
+  minute extremes from per-`datid` `minute_counts`. Legacy hours whose arrays
+  could not be backfilled are labelled `rollup_1h_flat`, so their compatibility
+  flat expansion is distinguishable from measurement. `report` remains an
+  explicitly minute-grain `rollup_1m` contract; `chart` remains presentation-
+  only, while `periods` / `summary` propagate the same honest typed results.
+  (issue #210)
 - **Machine-readable report.** `ash.report()` returns a stable JSONB payload for
   incident automation, dashboards, and AI/database copilots. The 2.0 minor line
   may add keys, but existing keys are not renamed or removed.

--- a/blueprints/AAS_API.md
+++ b/blueprints/AAS_API.md
@@ -31,12 +31,12 @@ removed (see §8). Sampling, storage, rollups, and admin/lifecycle functions
    source by window (raw → `rollup_1m` → `rollup_1h`). Every over-time /
    breakdown reader (`periods`, `aas`, `timeline`, `top`, `chart`) reports the
    chosen source in a `source` column (`samples` reads raw only, by definition).
-   `compare()` and `report()`
-   surface provenance differently: `compare()` has no `source` column — a window
-   with no coverage yields NULL columns plus a NOTICE (never a fake zero
-   baseline, see §2.5); `report()` returns `jsonb`, so its source and coverage
-   live inside a `coverage` object (`coverage.source`, always `rollup_1m` — see
-   §4). When a request *cannot* be answered (the event↔query tie needs raw
+   `compare()` and `report()` surface provenance differently: `compare()` has
+   `source_1` / `source_2`; a window with no coverage yields NULL metric columns
+   plus a NOTICE (never a fake zero baseline, see §2.5). `report()` returns
+   `jsonb`, so its source and coverage live inside a `coverage` object
+   (`coverage.source`, always `rollup_1m` — see §4). When a request *cannot* be
+   answered (the event↔query tie needs raw
    samples but the window exceeds raw retention), the reader raises a clear
    exception naming the boundary — never a silent empty result.
 6. **Self-describing.** Every function carries a catalog `comment` stating the
@@ -79,6 +79,9 @@ bucket          interval    default '1 minute'  -- sub-bucket grain for peak/p99
 `percentile_cont(0.99)` over the same per-bucket AAS values, **zero-filled**
 for buckets with no activity within data coverage. Buckets with *no data*
 (sampler off) are excluded from percentiles and reported via coverage columns.
+If the effective read grain is coarser than the requested `bucket`, both
+extremes are **NULL**. An hour average is never emitted under a minute
+`peak_aas` / `p99_aas` contract; `avg_aas` and `backend_seconds` remain valid.
 
 ### 2.1 `ash.periods(until timestamptz default null)`
 
@@ -91,9 +94,11 @@ bucket interval, buckets_with_data bigint, avg_aas numeric, peak_aas numeric,
 p99_aas numeric)`
 
 `buckets_with_data` (renamed from `minutes_with_data`, to match `aas()`) counts
-the covered buckets at the grain named by the new `bucket` column. Every
-unfiltered read is minute-grain after the `rollup_1h` seam fix, so `bucket` is
+the covered buckets at the grain named by the new `bucket` column, which is
 always `'1 minute'` here — `43200 @ 1 minute` reads without cross-referencing.
+Exact `rollup_1h.minute_counts` preserves that grain. A legacy hour without the
+array reports `source = rollup_1h_flat` and NULL minute extremes instead of
+presenting its compatibility flat expansion as measured data.
 
 ### 2.2 `ash.aas(since, until, wait_event_type, wait_event, query_id, database, bucket)`
 
@@ -109,6 +114,14 @@ avg_aas numeric, peak_aas numeric, p99_aas numeric, backend_seconds numeric)`
 The per-`bucket` peak/p99 buckets are **calendar-aligned** (§2.3): floored to
 `bucket` on UTC/epoch boundaries, not anchored to `since`, so the same
 absolute window always yields the same buckets regardless of when the call runs.
+
+On `rollup_1h`, unfiltered and database-only reads use the per-`datid`
+`minute_counts` arrays and keep real minute peak/p99. Wait/query filters have
+only the hour-grain arrays: with the default `bucket = '1 minute'`,
+`peak_aas` and `p99_aas` are both NULL while `avg_aas` and `backend_seconds`
+remain exact. A legacy pre-2.0 hour whose array could not be backfilled reports
+`source = rollup_1h_flat`; its flat-minute compatibility expansion still
+supports averages/coverage, but its requested minute extremes are NULL.
 
 ### 2.3 `ash.timeline(since, until, bucket interval default null, filters…)`
 
@@ -135,11 +148,13 @@ Returns:
 `(bucket_start timestamptz, source text, data_points bigint,
 avg_aas numeric, peak_aas numeric, p99_aas numeric)`
 
-`peak_aas` and `p99_aas` are **per-minute even on `rollup_1h`-backed windows**:
-`rollup_hour()` preserves per-minute totals in `rollup_1h.minute_counts`, so a
-long-window read keeps minute-grain extremes across the hourly seam (US-6). The
-only case that returns null `p99_aas` is a **wait/query-filtered**
-`rollup_1h`-backed bucket, where the surviving grain is the hour.
+For rows created by 2.0, `peak_aas` and `p99_aas` remain **per-minute on
+unfiltered/database-only `rollup_1h` reads**: `rollup_hour()` preserves totals
+in `minute_counts`, so a long window keeps minute extremes across the seam
+(US-6). Wait/query-filtered reads retain only hour evidence; a percentile over
+hour averages would masquerade as a minute percentile. Legacy flat hours are
+labelled `rollup_1h_flat`, and both extremes are NULL when their surviving hour
+grain exceeds the requested timeline bucket.
 
 ### 2.4 `ash.top(dimension text, since, until, filters…, n int default 10, bucket, order_by text default 'avg')`
 
@@ -160,14 +175,18 @@ Returns:
 avg_aas numeric, peak_aas numeric, p99_aas numeric,
 backend_seconds numeric, pct numeric)`
 
-- **Every row carries avg + peak + p99** (US-3). `pct` is the row's share of
-  the window's total AAS.
+- **Every row carries avg plus nullable peak/p99** (US-3). `pct` is the row's
+  share of the window's total AAS. Peak/p99 are NULL when the source grain is
+  coarser than `bucket`; avg, `backend_seconds`, and `pct` remain exact.
 - **`order_by` ∈ `'avg' | 'peak' | 'p99'` (default `'avg'`)** picks the
   ranking metric applied **before** the `n` cut. This is how you surface a
   spiky-but-low-average row: `order_by => 'peak'` ranks by the per-bucket
   spike, so a query that spiked for one minute outranks steady background rows
   that a mean would keep on top (the spike-first triage recipe). An unknown
   value raises `ash.top: unknown order_by <v>; use avg|peak|p99`.
+  When the chosen source cannot supply that extreme at the requested grain,
+  the metric is NULL for every row and the deterministic secondary ordering is
+  total backend count. Widen `bucket` to the effective grain or use `avg`.
 - `query_text` is non-null only for `dimension = 'query_id'` with
   pg_stat_statements present **and** a caller that can read other roles'
   pgss text — i.e. holding `pg_read_all_stats` (e.g. via `pg_monitor`
@@ -195,11 +214,16 @@ backend_seconds numeric, pct numeric)`
     the exact boundary to move to: *"…raw retention starts at `<ts>` but the
     requested window starts at `<ts>`. Narrow the window to start at or after
     `<ts>` … or drill without the query/event tie."*
-- On a `rollup_1h`-backed window (`source = rollup_1h`), each row's `peak_aas`
-  and `p99_aas` collapse to **hour** grain — the per-dimension arrays are stored
-  per hour, so a one-minute spike is averaged into its hour. For a minute-grain
-  peak over a long window use `ash.timeline()`, whose unfiltered `peak_aas` stays
-  per-minute across the `rollup_1h` seam (§2.3).
+- On a `rollup_1h`-backed window, wait and query dimensions have only hour-grain
+  arrays. Their `peak_aas` / `p99_aas` are therefore NULL for the default
+  minute bucket, rather than hour averages under minute-extreme names.
+- **`database` is the precise exception.** `minute_counts` is stored on every
+  `(ts, datid)` row, not once for the whole hour. An unfiltered
+  `top('database')` therefore reads `rollup_1h_minutes` internally and keeps
+  real per-database minute peak/p99. Wait/query filters cannot use that path
+  because `minute_counts` does not preserve those associations.
+- A database breakdown that crosses a legacy NULL array reports
+  `source = rollup_1h_flat` and NULL minute extremes.
 
 ### 2.5 `ash.compare(since_1, until_1, since_2, until_2, dimension text default null, n int default 10, filters…, bucket)`
 
@@ -208,13 +232,21 @@ dimension: top rows by `abs(avg_delta)` (full outer across the two windows —
 a wait/query present in only one window still appears).
 
 Returns:
-`(key text, query_text text,
+`(key text, query_text text, source_1 text, source_2 text,
 avg_aas_1 numeric, avg_aas_2 numeric, avg_delta numeric,
 peak_aas_1 numeric, peak_aas_2 numeric,
 p99_aas_1 numeric, p99_aas_2 numeric,
 pct_1 numeric, pct_2 numeric)`
 
 (With `dimension => null` the single row's `key` is `overall`.)
+
+- **Source and grain honesty.** `source_1` / `source_2` disclose the source for
+  each window. If their effective grains differ, all four peak/p99 columns are
+  NULL: the function refuses to manufacture an "average flat, peak exploded"
+  signal from an hour/minute comparison. `avg_aas_1`, `avg_aas_2`, and
+  `avg_delta` remain valid. Different source names do not alone suppress the
+  pair: `raw` and `rollup_1m` are both minute grain, and an overall or database
+  `rollup_1h` read with exact `minute_counts` is minute grain too.
 
 - **Zero-coverage honesty.** A window with no data coverage (e.g. entirely past
   retention) reports **NULL** on its side and a **NULL `avg_delta`** — never a
@@ -394,11 +426,12 @@ function does any of that.
   rollups don't preserve that association; past raw retention they raise (§1
   rule 5) rather than return empty.
 - Each reader reports the source it used in the `source` column
-  (`raw` | `rollup_1m` | `rollup_1h` | `none`). Scalar readers and `top` pick a
-  single source per result (never mixing — no double-counting); `timeline`
-  reports its source per bucket, so a long series may show different sources
-  across rows. A window with no data at all reports `source = 'none'`
-  uniformly across readers.
+  (`raw` | `rollup_1m` | `rollup_1h` | `rollup_1h_flat` | `none`), while
+  `compare` reports `source_1` / `source_2`. `rollup_1h_flat` means at least one
+  legacy hour lacked backfilled `minute_counts`; averages remain available,
+  but the flat expansion is explicitly not minute measurement. Scalar readers
+  and `top` pick one source per result (never mixing — no double-counting). A
+  window with no data at all reports `source = 'none'` uniformly.
 - `ash.status()` gains rows for `raw_retention_start`,
   `rollup_1m_retention_start`, `rollup_1h_retention_start` so callers can
   plan windows before querying.

--- a/sql/ash-install.sql
+++ b/sql/ash-install.sql
@@ -2660,8 +2660,9 @@ create table if not exists ash.rollup_1h (
                                      -- true minute-grain AAS distribution so long
                                      -- (rollup_1h-backed) windows report the exact
                                      -- per-minute peak_aas / p99_aas. NULL column =
-                                     -- legacy pre-2.0 row (readers fall back to the
-                                     -- flat hour average for such hours).
+                                     -- legacy pre-2.0 row (readers label its flat
+                                     -- hour-average expansion rollup_1h_flat and do
+                                     -- not present it as a measured minute extreme).
   primary key (ts, datid)
 );
 
@@ -2672,8 +2673,10 @@ alter table ash.rollup_1h
 /*
  * Upgrade backfill: reconstruct minute_counts for legacy rollup_1h rows whose
  * hour is still covered by rollup_1m (per-minute detail survives there for
- * rollup_1m_retention_days). Older hours keep minute_counts NULL and readers
- * fall back to the flat hour average — a lower bound, never a wrong spike.
+ * rollup_1m_retention_days). Older hours keep minute_counts NULL. Readers
+ * retain the compatibility flat-hour expansion for averages, label it
+ * source=rollup_1h_flat, and NULL extremes finer than the surviving hour
+ * grain so the estimate cannot masquerade as minute measurement.
  * Idempotent: only touches rows where minute_counts is still NULL.
  */
 update ash.rollup_1h as rollup_hour
@@ -3574,6 +3577,39 @@ end;
 $$;
 
 /*
+ * True when a rollup_1h minute-detail read would cross at least one legacy
+ * pre-2.0 row whose minute_counts could not be backfilled. _grain_counts keeps
+ * those hours readable by expanding the hour total into 60 flat estimates,
+ * but callers must label that estimate separately from measured minute data.
+ * The -3540 overlap mirrors _grain_counts('rollup_1h_minutes'): a partial
+ * first hour is still evidence used by the requested window.
+ */
+create or replace function ash._rollup_1h_has_flat(
+  start_ts int4,
+  end_ts int4,
+  database name default null
+)
+returns boolean
+language sql
+stable
+set search_path = pg_catalog, ash
+as $$
+  select exists (
+    select
+    from ash.rollup_1h as rollup_hour
+    where rollup_hour.ts >= start_ts - 3540
+      and rollup_hour.ts < end_ts
+      and rollup_hour.minute_counts is null
+      and (
+        database is null
+        or rollup_hour.datid = (
+          select db.oid from pg_database as db where db.datname = database
+        )
+      )
+  )
+$$;
+
+/*
  * Workhorse: matching backend-count per underlying grain row (minute for raw
  * / rollup_1m, hour for rollup_1h) over [start_ts, end_ts), with uniform
  * filters. One row per grain timestamp that EXISTS in the source (cnt may be 0
@@ -3677,10 +3713,10 @@ begin
      * arrays, so peak_aas / p99_aas survive the rollup_1m -> rollup_1h seam
      * (same values a rollup_1m read of the window would produce). Totals only:
      * wait/query filters need the hour-grain arrays, so callers route filtered
-     * reads to 'rollup_1h'. Legacy pre-2.0 rows (minute_counts is null)
-     * flatten to their hour average per covered minute — a lower bound for the
-     * peak and an "hour was flat" assumption for percentiles, never an
-     * invented spike.
+     * reads to 'rollup_1h'. Legacy pre-2.0 rows (minute_counts is null) keep
+     * their compatibility flat-hour expansion for averages. Public callers
+     * detect those rows with _rollup_1h_has_flat, report rollup_1h_flat, and
+     * NULL extremes finer than one hour; the 60 estimates are not measurement.
      */
     if wait_event_type is not null or wait_event is not null
        or query_id is not null then
@@ -3799,9 +3835,11 @@ $$;
  * Scalar AAS load summary for one window, optionally filtered. avg_aas is the
  * window average; peak_aas / p99_aas are the max and 99th percentile of per
  * bucket AAS (zero-filled within data coverage) so a short spike is not hidden
- * by the average. backend_seconds is the absolute secondary. The window is
- * snapped to minute boundaries. Combining a wait filter with query_id needs
- * the raw wait<->query tie and raises past raw retention.
+ * by the average. When the surviving source grain is coarser than the requested
+ * bucket, both extremes are NULL rather than re-labelling a coarse average.
+ * backend_seconds is the absolute secondary. The window is snapped to minute
+ * boundaries. Combining a wait filter with query_id needs the raw wait<->query
+ * tie and raises past raw retention.
  */
 create or replace function ash.aas(
   since timestamptz default null,
@@ -3834,10 +3872,13 @@ declare
   v_start_ts int4;
   v_end_ts int4;
   v_bucket_secs int4;
+  v_requested_bucket_secs int4;
   v_grain_secs int4;
+  v_extreme_grain_secs int4;
   v_si numeric;
   v_source text;
   v_read_source text;
+  v_result_source text;
   v_tie boolean;
   v_raw_start timestamptz;
 begin
@@ -3845,6 +3886,7 @@ begin
   if v_bucket_secs is null or v_bucket_secs < 60 then
     raise exception 'bucket must be at least 1 minute, got %', bucket;
   end if;
+  v_requested_bucket_secs := v_bucket_secs;
 
   v_start_ts := (ash.ts_from_timestamptz(v_from) / 60) * 60;
   v_end_ts := (ash.ts_from_timestamptz(v_to) / 60) * 60;
@@ -3871,6 +3913,7 @@ begin
     v_grain_secs := case when v_source = 'rollup_1h' then 3600 else 60 end;
   end if;
   v_read_source := v_source;
+  v_result_source := v_source;
 
   /*
    * rollup_1h preserves the per-minute totals (minute_counts), so the
@@ -3878,12 +3921,27 @@ begin
    * rollup_1m -> rollup_1h seam: peak_aas / p99_aas stay per-minute and match
    * what a rollup_1m-backed window of the same span reports (wider window
    * never shrinks the peak). Wait/query filters still need the hour-grain
-   * arrays. The reported source stays 'rollup_1h' — that is what was read.
+   * arrays. Exact arrays report 'rollup_1h'; the legacy NULL-array case is
+   * relabelled 'rollup_1h_flat' below.
    */
   if v_source = 'rollup_1h' and wait_event_type is null
      and wait_event is null and query_id is null then
     v_read_source := 'rollup_1h_minutes';
     v_grain_secs := 60;
+  end if;
+  v_extreme_grain_secs := v_grain_secs;
+
+  /*
+   * A legacy hour has no measured minute distribution. Keep its historical
+   * flat expansion for averages and coverage compatibility, but name that
+   * estimate and retain 3600 as the honest extreme grain. That makes the
+   * default one-minute peak/p99 NULL instead of presenting 60 cloned hour
+   * averages as observations.
+   */
+  if v_read_source = 'rollup_1h_minutes'
+     and ash._rollup_1h_has_flat(v_start_ts, v_end_ts, database) then
+    v_result_source := 'rollup_1h_flat';
+    v_extreme_grain_secs := 3600;
   end if;
 
   /*
@@ -3931,15 +3989,19 @@ begin
   select
     ash.ts_to_timestamptz(v_start_ts),
     ash.ts_to_timestamptz(v_end_ts),
-    v_source,
+    v_result_source,
     (((v_end_ts - 1) / v_bucket_secs)
       - (v_start_ts / v_bucket_secs) + 1)::bigint,
     (select count(*) from per_bucket)::bigint,
     round((select coalesce(sum(cnt), 0) from per_bucket) * v_si
           / (v_end_ts - v_start_ts)::numeric, 2),
-    coalesce(round((select max(aas) from bucket_aas), 2), 0),
-    coalesce(round((select percentile_cont(0.99) within group (order by aas)
-                    from bucket_aas)::numeric, 2), 0),
+    case when v_extreme_grain_secs <= v_requested_bucket_secs then
+      coalesce(round((select max(aas) from bucket_aas), 2), 0)
+    end,
+    case when v_extreme_grain_secs <= v_requested_bucket_secs then
+      coalesce(round((select percentile_cont(0.99) within group (order by aas)
+                      from bucket_aas)::numeric, 2), 0)
+    end,
     round((select coalesce(sum(cnt), 0) from per_bucket) * v_si, 2);
 end;
 $$;
@@ -3948,10 +4010,10 @@ $$;
  * AAS time series: one row per bucket across the whole window (no-data buckets
  * included with data_points = 0 and null AAS). bucket => null auto-selects
  * grain by span. peak_aas is the worst underlying grain within the bucket;
- * p99_aas is the 99th percentile of the per-grain AAS. Unfiltered /
- * database-filtered reads are minute-grain on every source (rollup_1h keeps
- * per-minute totals in minute_counts); p99_aas is null only for wait/query-
- * filtered rollup_1h-backed buckets, which remain hour-grain.
+ * p99_aas is the 99th percentile of the per-grain AAS. New rollup_1h rows keep
+ * per-minute totals in minute_counts for unfiltered / database-filtered reads.
+ * Legacy rows without that array are labelled rollup_1h_flat, and extremes
+ * are NULL whenever their surviving hour grain exceeds the requested bucket.
  */
 create or replace function ash.timeline(
   since timestamptz default null,
@@ -3982,10 +4044,13 @@ declare
   v_end_ts int4;
   v_span int4;
   v_bucket_secs int4;
+  v_requested_bucket_secs int4;
   v_grain_secs int4;
+  v_extreme_grain_secs int4;
   v_si numeric;
   v_source text;
   v_read_source text;
+  v_result_source text;
   v_tie boolean;
   v_raw_start timestamptz;
 begin
@@ -4008,6 +4073,7 @@ begin
       raise exception 'bucket must be at least 1 minute, got %', bucket;
     end if;
   end if;
+  v_requested_bucket_secs := v_bucket_secs;
 
   /*
    * Bound the emitted-row count: one row per bucket, so an explicit fine
@@ -4039,7 +4105,8 @@ begin
        * rollup_1h preserves per-minute totals (minute_counts), so the
        * unfiltered / database-only read keeps minute grain: peak_aas /
        * p99_aas stay per-minute across the rollup_1m -> rollup_1h seam, and
-       * sub-hour buckets work. The reported source stays 'rollup_1h'.
+       * sub-hour buckets work. Exact arrays report 'rollup_1h'; legacy NULL
+       * arrays are relabelled 'rollup_1h_flat' below.
        */
       v_read_source := 'rollup_1h_minutes';
     elsif v_source = 'rollup_1h' and v_bucket_secs < 3600 then
@@ -4055,6 +4122,13 @@ begin
     v_grain_secs := case when v_read_source = 'rollup_1h' then 3600 else 60 end;
   end if;
   v_read_source := coalesce(v_read_source, v_source);
+  v_result_source := v_source;
+  v_extreme_grain_secs := v_grain_secs;
+  if v_read_source = 'rollup_1h_minutes'
+     and ash._rollup_1h_has_flat(v_start_ts, v_end_ts, database) then
+    v_result_source := 'rollup_1h_flat';
+    v_extreme_grain_secs := 3600;
+  end if;
   -- snap to a whole grain multiple (see ash.aas): a non-multiple bucket
   -- misaligns with the grain rows and fabricates per-bucket AAS.
   v_bucket_secs := (greatest(v_bucket_secs, v_grain_secs) / v_grain_secs)
@@ -4092,20 +4166,24 @@ begin
   )
   select
     ash.ts_to_timestamptz(buckets.bstart),
-    v_source,
+    v_result_source,
     coalesce(agg.n, 0)::bigint,
     case when agg.n > 0 then
       round(agg.cnt * v_si / (least(buckets.bstart + v_bucket_secs, v_end_ts)
                             - greatest(buckets.bstart, v_start_ts)), 2)
     end,
-    case when agg.n > 0 then round(agg.peak, 2) end,
+    case when agg.n > 0
+                   and v_extreme_grain_secs <= v_requested_bucket_secs then
+      round(agg.peak, 2)
+    end,
     /*
-     * p99 stays null only for the genuinely hour-grain read (filtered
-     * rollup_1h): a percentile over hour averages would masquerade as a
-     * minute percentile. The unfiltered rollup_1h read is minute-grain via
-     * minute_counts and reports a real per-minute p99.
+     * A percentile over hour averages would masquerade as a minute percentile.
+     * Keep it NULL on a genuinely hour-grain filtered read, and NULL both
+     * extremes when a legacy flat hour is coarser than the requested bucket.
+     * Exact unfiltered rollup_1h reads use minute_counts and retain real p99.
      */
-    case when agg.n > 0 and v_read_source <> 'rollup_1h' then
+    case when agg.n > 0 and v_read_source <> 'rollup_1h'
+                   and v_extreme_grain_secs <= v_requested_bucket_secs then
       round(agg.p99::numeric, 2)
     end
   from buckets
@@ -4121,11 +4199,11 @@ $$;
  * windows read rollups). peak_aas/p99_aas are per-minute (worst /
  * 99th-percentile minute), which is what capacity triage wants, and
  * buckets_with_data is a true count of covered buckets at the grain named by
- * the bucket column — always '1 minute' here (unfiltered reads are
- * minute-grain on every source, incl. rollup_1h via minute_counts), exposed
- * per row so "43200 buckets" reads as "43200 @ 1 minute" without
- * cross-referencing. After the arithmetic-bucketing fix this is cheap even
- * for the 1-month window (~90ms for the whole call on a month of rollups).
+ * the bucket column — always '1 minute' here. Exact rollup_1h rows preserve
+ * that grain via minute_counts; legacy rows are labelled rollup_1h_flat and
+ * return NULL minute extremes. The bucket stays exposed so "43200 buckets"
+ * reads as "43200 @ 1 minute" without cross-referencing. After the arithmetic-
+ * bucketing fix this is cheap even for a 1-month window (~90ms on rollups).
  */
 create or replace function ash.periods(
   until timestamptz default null
@@ -4180,7 +4258,9 @@ $$;
  * filters. Companion to _grain_counts. key is the dimension value (text);
  * key_num carries the numeric query_id for the 'query_id' dimension (null
  * otherwise) so the caller can join query text. 'raw' supports the
- * wait<->query tie; rollup sources must not be asked for it.
+ * wait<->query tie; rollup sources must not be asked for it. The internal
+ * rollup_1h_minutes source supports only an unfiltered database breakdown,
+ * because minute_counts is stored per (hour, datid).
  */
 create or replace function ash._grain_by(
   start_ts int4,
@@ -4292,6 +4372,55 @@ begin
     return;
   end if;
 
+  if source = 'rollup_1h_minutes' then
+    /*
+     * minute_counts is stored on each (ts, datid) row, so database is the one
+     * breakdown whose real minute distribution survives the hourly rollup.
+     * Wait/query filters cannot use this path: those associations exist only
+     * in the hour-grain arrays.
+     */
+    if dimension <> 'database' or wait_event_type is not null
+       or wait_event is not null or query_id is not null then
+      raise exception
+        'ash._grain_by: rollup_1h_minutes supports only an unfiltered '
+        'database breakdown';
+    end if;
+    return query
+    with hours as (
+      select rollup_hour.ts, rollup_hour.datid,
+             rollup_hour.minute_counts, rollup_hour.wait_counts
+      from ash.rollup_1h as rollup_hour
+      where rollup_hour.ts >= start_ts - 3540
+        and rollup_hour.ts < end_ts
+        and (v_datid is null or rollup_hour.datid = v_datid)
+    ),
+    mins as (
+      select (hours.ts + (minute_elem.idx - 1) * 60)::int4 as mts,
+             hours.datid, minute_elem.mc::numeric as cnt
+      from hours
+      cross join lateral unnest(hours.minute_counts)
+        with ordinality as minute_elem(mc, idx)
+      where hours.minute_counts is not null and minute_elem.mc is not null
+      union all
+      select (hours.ts + minute_series.idx * 60)::int4,
+             hours.datid,
+             (select coalesce(sum(hours.wait_counts[pos + 1]), 0)
+              from generate_subscripts(hours.wait_counts, 1) as pos
+              where pos % 2 = 1)::numeric / 60.0
+      from hours
+      cross join generate_series(0, 59) as minute_series(idx)
+      where hours.minute_counts is null
+    )
+    select mins.mts,
+           coalesce(db.datname::text, '<oid:' || mins.datid || '>'),
+           null::bigint,
+           mins.cnt
+    from mins
+    left join pg_database as db on db.oid = mins.datid
+    where mins.mts >= start_ts and mins.mts < end_ts;
+    return;
+  end if;
+
   v_tbl := case
     when source = 'rollup_1h' then 'ash.rollup_1h'
     else 'ash.rollup_1m'
@@ -4375,7 +4504,8 @@ $$;
 
 /*
  * The single vertical drill: AAS broken down by one dimension, every row
- * carrying avg/peak/p99 plus its share (pct) of the window total. Filters
+ * carrying avg/peak/p99 plus its share (pct) of the window total. A coarse
+ * source never populates extremes for a finer requested bucket. Filters
  * compose with the dimension. Crossing the wait<->query tie (query_id
  * dimension with a wait filter, or a wait dimension with query_id) needs raw
  * samples and raises past raw retention. query_text is filled only for the
@@ -4420,9 +4550,13 @@ declare
   v_start_ts int4;
   v_end_ts int4;
   v_bucket_secs int4;
+  v_requested_bucket_secs int4;
   v_grain_secs int4;
+  v_extreme_grain_secs int4;
   v_si numeric;
   v_source text;
+  v_read_source text;
+  v_result_source text;
   v_tie boolean;
   v_raw_start timestamptz;
   v_has_pgss boolean := false;
@@ -4443,6 +4577,7 @@ begin
   if v_bucket_secs is null or v_bucket_secs < 60 then
     raise exception 'bucket must be at least 1 minute, got %', bucket;
   end if;
+  v_requested_bucket_secs := v_bucket_secs;
 
   v_start_ts := (ash.ts_from_timestamptz(v_from) / 60) * 60;
   v_end_ts := (ash.ts_from_timestamptz(v_to) / 60) * 60;
@@ -4469,6 +4604,26 @@ begin
     v_source := ash._pick_source_agg(ash.ts_to_timestamptz(v_start_ts),
                                      ash.ts_to_timestamptz(v_end_ts));
     v_grain_secs := case when v_source = 'rollup_1h' then 3600 else 60 end;
+  end if;
+  v_read_source := v_source;
+  v_result_source := v_source;
+
+  /*
+   * Unlike wait/query arrays, minute_counts is already partitioned by datid.
+   * The unfiltered database dimension can therefore use the honest minute
+   * path on rollup_1h instead of throwing away detail that is present.
+   */
+  if v_source = 'rollup_1h' and dimension = 'database'
+     and wait_event_type is null and wait_event is null
+     and query_id is null then
+    v_read_source := 'rollup_1h_minutes';
+    v_grain_secs := 60;
+  end if;
+  v_extreme_grain_secs := v_grain_secs;
+  if v_read_source = 'rollup_1h_minutes'
+     and ash._rollup_1h_has_flat(v_start_ts, v_end_ts, database) then
+    v_result_source := 'rollup_1h_flat';
+    v_extreme_grain_secs := 3600;
   end if;
   -- snap to a whole grain multiple (see ash.aas): a non-multiple bucket
   -- misaligns with the grain rows and fabricates per-bucket AAS.
@@ -4503,7 +4658,7 @@ begin
   with keyed as (
     select (grain_by_row.ts / v_bucket_secs) * v_bucket_secs as bstart,
            grain_by_row.key, grain_by_row.key_num, grain_by_row.cnt
-    from ash._grain_by(v_start_ts, v_end_ts, v_source, dimension,
+    from ash._grain_by(v_start_ts, v_end_ts, v_read_source, dimension,
            wait_event_type, wait_event, query_id, database) as grain_by_row
   ),
   /*
@@ -4515,7 +4670,7 @@ begin
    */
   covered as (
     select distinct (grain_row.ts / v_bucket_secs) * v_bucket_secs as bstart
-    from ash._grain_counts(v_start_ts, v_end_ts, v_source,
+    from ash._grain_counts(v_start_ts, v_end_ts, v_read_source,
            null, null, null, database) as grain_row
   ),
   keys as (
@@ -4555,22 +4710,25 @@ begin
     select key_bucket.key, key_bucket.key_num, key_bucket.total,
            round(key_bucket.total * v_si
                  / (v_end_ts - v_start_ts)::numeric, 2) as avg_aas,
-           round(max(key_bucket.bcnt * v_si
-                     / (least(key_bucket.bstart + v_bucket_secs, v_end_ts)
-                        - greatest(key_bucket.bstart, v_start_ts))), 2)
-             as peak_aas,
-           round(percentile_cont(0.99) within group (
-                   order by key_bucket.bcnt * v_si
-                     / (least(key_bucket.bstart + v_bucket_secs, v_end_ts)
-                        - greatest(key_bucket.bstart, v_start_ts)))::numeric, 2)
-             as p99_aas
+           case when v_extreme_grain_secs <= v_requested_bucket_secs then
+             round(max(key_bucket.bcnt * v_si
+                       / (least(key_bucket.bstart + v_bucket_secs, v_end_ts)
+                          - greatest(key_bucket.bstart, v_start_ts))), 2)
+           end as peak_aas,
+           case when v_extreme_grain_secs <= v_requested_bucket_secs then
+             round(percentile_cont(0.99) within group (
+                     order by key_bucket.bcnt * v_si
+                       / (least(key_bucket.bstart + v_bucket_secs, v_end_ts)
+                          - greatest(key_bucket.bstart, v_start_ts)))::numeric,
+                   2)
+           end as p99_aas
     from key_bucket
     group by key_bucket.key, key_bucket.key_num, key_bucket.total
   )
   select
     per_key.key,
     per_key.key_num,
-    v_source,
+    v_result_source,
     per_key.avg_aas,
     per_key.peak_aas,
     per_key.p99_aas,
@@ -4605,6 +4763,9 @@ $$;
 -- modes — and avg_delta is NULL, never a fake zero-baseline "regression";
 -- a NOTICE names the uncovered window. Within a covered window, a key absent
 -- from one side is a true measured zero and the delta stands.
+-- Grain honesty: source_1/source_2 disclose each side. If the effective grains
+-- differ, all four peak/p99 columns are NULL; avg_aas and avg_delta remain
+-- valid because total backend-time over each complete window is comparable.
 create or replace function ash.compare(
   since_1 timestamptz,
   until_1 timestamptz,
@@ -4621,6 +4782,8 @@ create or replace function ash.compare(
 returns table (
   key text,
   query_text text,
+  source_1 text,
+  source_2 text,
   avg_aas_1 numeric,
   avg_aas_2 numeric,
   avg_delta numeric,
@@ -4641,6 +4804,12 @@ declare
   v_aas2 record;
   v_cov1 boolean;
   v_cov2 boolean;
+  v_source1 text;
+  v_source2 text;
+  v_grain1 int4;
+  v_grain2 int4;
+  v_grains_match boolean;
+  v_database_minutes boolean;
 begin
   -- validate here, in compare's own frame, so the error names ash.compare
   -- and never leaks the internal delegation to ash.top.
@@ -4666,6 +4835,51 @@ begin
     wait_event_type, wait_event, query_id, database, bucket);
   v_cov1 := v_aas1.buckets_with_data > 0;
   v_cov2 := v_aas2.buckets_with_data > 0;
+
+  /*
+   * aas() is also the coverage probe, but a dimensional compare delegates its
+   * values to top(). Most rollup_1h dimensions retain only hour arrays; the
+   * database exception uses per-datid minute_counts. Preserve both public
+   * sources and calculate the effective grain explicitly so a raw/rollup_1m
+   * pair (both minute) remains comparable while an hour/minute pair does not.
+   */
+  v_database_minutes := dimension = 'database'
+                        and wait_event_type is null and wait_event is null
+                        and query_id is null;
+  if dimension is null then
+    v_source1 := v_aas1.source;
+    v_source2 := v_aas2.source;
+    v_grain1 := case
+      when v_source1 = 'rollup_1h_flat' then 3600
+      when v_source1 = 'rollup_1h'
+           and (wait_event_type is not null or wait_event is not null
+                or query_id is not null) then 3600
+      else 60 end;
+    v_grain2 := case
+      when v_source2 = 'rollup_1h_flat' then 3600
+      when v_source2 = 'rollup_1h'
+           and (wait_event_type is not null or wait_event is not null
+                or query_id is not null) then 3600
+      else 60 end;
+  else
+    v_source1 := case
+      when v_aas1.source = 'rollup_1h_flat' and not v_database_minutes
+        then 'rollup_1h'
+      else v_aas1.source end;
+    v_source2 := case
+      when v_aas2.source = 'rollup_1h_flat' and not v_database_minutes
+        then 'rollup_1h'
+      else v_aas2.source end;
+    v_grain1 := case
+      when v_source1 = 'rollup_1h_flat' then 3600
+      when v_source1 = 'rollup_1h' and not v_database_minutes then 3600
+      else 60 end;
+    v_grain2 := case
+      when v_source2 = 'rollup_1h_flat' then 3600
+      when v_source2 = 'rollup_1h' and not v_database_minutes then 3600
+      else 60 end;
+  end if;
+  v_grains_match := not (v_cov1 and v_cov2) or v_grain1 = v_grain2;
   if not v_cov1 then
     raise notice
       'ash.compare: window 1 (% to %) has no data coverage — its columns '
@@ -4685,14 +4899,15 @@ begin
     return query
     select
       'overall'::text, null::text,
+      v_source1, v_source2,
       case when v_cov1 then v_aas1.avg_aas end,
       case when v_cov2 then v_aas2.avg_aas end,
       case when v_cov1 and v_cov2
            then round(v_aas2.avg_aas - v_aas1.avg_aas, 2) end,
-      case when v_cov1 then v_aas1.peak_aas end,
-      case when v_cov2 then v_aas2.peak_aas end,
-      case when v_cov1 then v_aas1.p99_aas end,
-      case when v_cov2 then v_aas2.p99_aas end,
+      case when v_cov1 and v_grains_match then v_aas1.peak_aas end,
+      case when v_cov2 and v_grains_match then v_aas2.peak_aas end,
+      case when v_cov1 and v_grains_match then v_aas1.p99_aas end,
+      case when v_cov2 and v_grains_match then v_aas2.p99_aas end,
       null::numeric, null::numeric;
     return;
   end if;
@@ -4709,6 +4924,7 @@ begin
   select
     coalesce(window1.key, window2.key),
     coalesce(window1.query_text, window2.query_text),
+    v_source1, v_source2,
     window1.avg_aas, window2.avg_aas,
     /*
      * a key absent from a COVERED window is a true zero; an UNCOVERED window
@@ -4717,8 +4933,10 @@ begin
     case when v_cov1 and v_cov2
          then round(coalesce(window2.avg_aas, 0)
                     - coalesce(window1.avg_aas, 0), 2) end,
-    window1.peak_aas, window2.peak_aas,
-    window1.p99_aas, window2.p99_aas,
+    case when v_grains_match then window1.peak_aas end,
+    case when v_grains_match then window2.peak_aas end,
+    case when v_grains_match then window1.p99_aas end,
+    case when v_grains_match then window2.p99_aas end,
     window1.pct, window2.pct
   from window1
   /*
@@ -5749,19 +5967,19 @@ $$;
  * everywhere user-facing.
  */
 comment on function ash.periods(timestamptz) is
-$$START HERE (US-1 triage): AAS for six standard trailing windows (1m, 5m, 1h, 1d, 1w, 1mo) ending at until (default now()), one row each. Columns (period, period_start, period_end, source, bucket, buckets_with_data, avg_aas, peak_aas, p99_aas): peak/p99 vs avg distinguishes a spike from sustained load; buckets_with_data counts covered buckets at the grain named by bucket (always 1 minute here). Rollup-backed (source = rollup_1m|rollup_1h). Next: locate the spike in time with ash.timeline(), then drill with ash.top().$$;
+$$START HERE (US-1 triage): AAS for six standard trailing windows (1m, 5m, 1h, 1d, 1w, 1mo) ending at until (default now()), one row each. Columns (period, period_start, period_end, source, bucket, buckets_with_data, avg_aas, peak_aas, p99_aas): peak/p99 vs avg distinguishes a spike from sustained load; buckets_with_data counts covered buckets at the grain named by bucket (always 1 minute here). Exact rollup_1h minute_counts preserves minute extremes; legacy hours report source=rollup_1h_flat and NULL minute extremes. Next: locate the spike in time with ash.timeline(), then drill with ash.top().$$;
 
 comment on function ash.aas(timestamptz, timestamptz, text, text, bigint, name, interval) is
-$$Scalar AAS summary for one window [since, until) (defaults: last 1 hour). Optional uniform filters wait_event_type/wait_event/query_id/database. Columns (period_start, period_end, source, buckets_expected, buckets_with_data, avg_aas, peak_aas, p99_aas, backend_seconds); peak/p99 are over per-bucket AAS. Buckets are calendar-aligned (floored to bucket in UTC: an hour bucket starts on the hour, a day bucket on the UTC day) — the same absolute window always produces the same buckets. Also the US-4 leaf event summary: ash.aas(wait_event => 'IO:DataFileRead'). Combining a wait filter with query_id needs raw samples and raises past raw retention. source = raw|rollup_1m|rollup_1h. Next: ash.top('query_id', wait_event => ...).$$;
+$$Scalar AAS summary for one window [since, until) (defaults: last 1 hour). Optional uniform filters wait_event_type/wait_event/query_id/database. Columns (period_start, period_end, source, buckets_expected, buckets_with_data, avg_aas, peak_aas, p99_aas, backend_seconds); peak/p99 are over calendar-aligned per-bucket AAS and are BOTH NULL when the effective read grain exceeds the requested bucket — an hour average never masquerades as a minute extreme. avg_aas/backend_seconds remain valid. Exact rollup_1h minute_counts supports unfiltered/database-only minute extremes; wait/query-filtered reads retain hour grain. Legacy NULL arrays report source=rollup_1h_flat and NULL minute extremes. Combining a wait filter with query_id needs raw samples and raises past raw retention. source = raw|rollup_1m|rollup_1h|rollup_1h_flat|none. Next: ash.top('query_id', wait_event => ...).$$;
 
 comment on function ash.timeline(timestamptz, timestamptz, interval, text, text, bigint, name) is
-$$AAS time series (US-2 locate / US-6 capacity): one row per bucket across [since, until). bucket => null auto-selects grain by span (<= 6h: 1 minute, <= 7d: 1 hour, else 1 day). bucket_start is calendar-aligned (floored to bucket in UTC: hour buckets start on the hour, day buckets on the UTC day), so the same absolute window always returns identical bucket_start labels; the first bucket may start before since and edge buckets average over their in-window part only. Columns (bucket_start, source, data_points, avg_aas, peak_aas, p99_aas): data_points = 0 with null AAS marks a no-data bucket (distinct from measured-zero). Order by peak_aas desc nulls last to find the worst buckets (no-data buckets carry null peak_aas, which sorts first under a bare desc and would bury the real spike), then drill that window with ash.top(). peak_aas/p99_aas are per-minute even on rollup_1h-backed windows (per-minute totals are preserved in rollup_1h.minute_counts); p99_aas is null only for wait/query-filtered rollup_1h-backed buckets (hour grain).$$;
+$$AAS time series (US-2 locate / US-6 capacity): one row per bucket across [since, until). bucket => null auto-selects grain by span (<= 6h: 1 minute, <= 7d: 1 hour, else 1 day). bucket_start is calendar-aligned (floored to bucket in UTC: hour buckets start on the hour, day buckets on the UTC day), so the same absolute window always returns identical labels; edge buckets average over in-window coverage only. Columns (bucket_start, source, data_points, avg_aas, peak_aas, p99_aas): data_points=0 with null AAS marks no data. Order by peak_aas desc nulls last to find the worst buckets. New rollup_1h rows preserve per-minute totals in minute_counts for exact unfiltered/database-only extremes. Legacy rows without the array report source=rollup_1h_flat; their flat expansion remains available for averages/coverage but both extremes are NULL when hour grain exceeds bucket. A percentile over filtered hour averages is also NULL because it would masquerade as a minute percentile.$$;
 
 comment on function ash.top(text, timestamptz, timestamptz, text, text, bigint, name, int, interval, text) is
-$$The single vertical drill (US-3): AAS broken down by dimension in wait_event_type|wait_event|query_id|database over [since, until). Every row carries avg_aas, peak_aas, p99_aas, backend_seconds, and pct (share of window total). order_by in avg|peak|p99 (default avg) picks the ranking metric BEFORE the top-n cut — use order_by => 'peak' during incident triage so a query that spiked for one minute outranks steady background rows. For the query_id dimension, a NULL key is the unattributed bucket (activity whose query_id was not captured: not run with a queryid-reporting client, truncated, or utility/idle-in-transaction work) — it is real load, not an error. Filters compose: ash.top('wait_event', wait_event_type => 'IO') is the level-2 drill; ash.top('query_id', wait_event => 'IO:DataFileRead') is the US-4 leaf. query_text is filled for the query_id dimension when pg_stat_statements is present AND the caller can read other roles pg_stat_statements text — i.e. holds pg_read_all_stats (e.g. via membership in pg_monitor); a plain ash.grant_reader() role without it sees query_text NULL even though pgss is installed, because pgss restricts query text to the owning role. When pgss lives outside public, the caller also needs USAGE on that schema, else query_text is NULL. Crossing the wait<->query tie (query_id dimension + wait filter, or a wait dimension + query_id) reads raw samples and raises past raw retention. source = raw|rollup_1m|rollup_1h.$$;
+$$The single vertical drill (US-3): AAS by dimension wait_event_type|wait_event|query_id|database over [since, until). Columns (key, query_text, source, avg_aas, peak_aas, p99_aas, backend_seconds, pct). peak/p99 are BOTH NULL when effective read grain exceeds bucket; avg/backend_seconds/pct stay valid. order_by in avg|peak|p99 ranks before top-n; when the requested extreme is unavailable its NULL ties fall back to total load, never a fabricated spike. rollup_1h wait/query arrays have hour grain. Database is different: minute_counts is stored per (ts,datid), so unfiltered top('database') retains real minute peak/p99; legacy NULL arrays report rollup_1h_flat. A NULL query_id key is real unattributed load. query_text needs readable pg_stat_statements and otherwise degrades to NULL. Crossing the wait<->query tie reads raw and raises past raw retention. source = raw|rollup_1m|rollup_1h|rollup_1h_flat|none.$$;
 
 comment on function ash.compare(timestamptz, timestamptz, timestamptz, timestamptz, text, int, text, text, bigint, name, interval) is
-$$Before/after comparison of two windows (US-7): window 1 = [since_1, until_1), window 2 = [since_2, until_2). dimension => null gives one overall row; a dimension gives the top n keys by abs(avg_delta) via a full outer join (a key present in only one window still appears). Columns (key, query_text, avg_aas_1, avg_aas_2, avg_delta, peak_aas_1, peak_aas_2, p99_aas_1, p99_aas_2, pct_1, pct_2); avg_delta = window 2 minus window 1. A window with no data coverage (e.g. past retention) reports NULL on its side and a NULL avg_delta (plus a NOTICE) — never a fake zero baseline; within a covered window an absent key is a true zero. Use to tell whether a deploy regressed load and where.$$;
+$$Before/after comparison of two windows (US-7): dimension=>null gives one overall row; a dimension full-outer-joins top keys. Columns (key, query_text, source_1, source_2, avg_aas_1, avg_aas_2, avg_delta, peak_aas_1, peak_aas_2, p99_aas_1, p99_aas_2, pct_1, pct_2). source_1/source_2 disclose provenance. When effective grains differ, ALL FOUR peak/p99 fields are NULL rather than fabricating a regression; avg values/delta remain valid. Different source names may share minute grain (raw, rollup_1m, exact overall/database rollup_1h). A window with no coverage reports NULL on its side and NULL avg_delta plus a NOTICE; within coverage an absent key is true zero. Use to tell whether a deploy regressed load and where.$$;
 
 comment on function ash.samples(timestamptz, timestamptz, int, text, text, bigint, name) is
 $$Decoded raw sample rows, newest first (US-5 raw evidence) over [since, until) (default last 1 hour), up to n. Uniform filters wait_event_type/wait_event/query_id/database. Columns (sample_time, database_name, active_backends, wait_event, query_id, query_text). query_text needs pg_stat_statements AND that the caller holds pg_read_all_stats (e.g. via pg_monitor membership); it is null otherwise — a plain ash.grant_reader() role without pg_read_all_stats sees null even with pgss installed, because pgss restricts query text to the owning role. When pgss lives outside public, the caller also needs USAGE on that schema, else query_text is null. Reads ash.sample directly (raw retention only).$$;
@@ -5805,7 +6023,7 @@ comment on function ash.rollup_minute(int) is
 $$Admin: fold completed minutes of raw samples into ash.rollup_1m (the every-minute job scheduled by ash.start()); batch_limit caps catch-up minutes per call. Returns minutes processed. Readers pick rollups automatically — this only needs manual calls when pg_cron is absent.$$;
 
 comment on function ash.rollup_hour() is
-$$Admin: fold completed hours of ash.rollup_1m into ash.rollup_1h, preserving per-minute totals in minute_counts so long-window peak/p99 stay minute-grain (the hourly job scheduled by ash.start()). Returns hours processed.$$;
+$$Admin: fold completed hours of ash.rollup_1m into ash.rollup_1h, preserving per-minute totals in minute_counts so newly rolled hours retain exact long-window minute peak/p99 (the hourly job scheduled by ash.start()). Legacy pre-2.0 NULL arrays may remain outside rollup_1m retention and are labelled rollup_1h_flat by readers. Returns hours processed.$$;
 
 comment on function ash.rollup_cleanup() is
 $$Admin: delete rollup rows past retention (rollup_1m_retention_days / rollup_1h_retention_days in ash.config; the daily job scheduled by ash.start()). Returns a summary of rows deleted.$$;


### PR DESCRIPTION
Fixes #210 — the largest blocker from the pre-tag audit (#160). `ash.top()` and `ash.compare()`
report **hour-grain numbers in columns named `peak_aas` / `p99_aas`**, so `compare()` fabricates
regressions on byte-identical load.

**Draft on purpose.** This is the riskiest change in the release: it alters a user-visible contract
on eight readers and changes `ash.compare()`'s return signature. Needs REV and your approval.

## The rule implemented

**NULL `peak_aas` / `p99_aas` whenever the read grain is coarser than the requested bucket.**

Not an arbitrary pick — `ash.timeline()` already follows exactly this rule for filtered `rollup_1h`
reads, with the shipped comment *"a percentile over hour averages would masquerade as a minute
percentile"*. `aas` and `top` were violating an invariant this same file writes down two functions
away. This makes the file self-consistent.

| Sub | Fix |
|---|---|
| **B1a** | `top()` no longer emits hour averages under `peak_aas`/`p99_aas`. `avg_aas`, `backend_seconds`, `pct` stay valid. |
| **B1b** | `aas()` follows the same rule when a filter forces hour grain. |
| **B1c** | `compare()` gains `source_1` / `source_2`, and suppresses all four peak/p99 values when the two windows resolve to different grains. Average deltas remain valid. |
| **database dim** | **Fixed properly rather than NULLed** — `rollup_1h.minute_counts` is stored per `(ts, datid)`, so the minute detail already existed and simply wasn't read. Now expanded through `rollup_1h_minutes`, keeping true minute-grain peak/p99. `AAS_API.md` §2.4's justification ("the per-dimension arrays are stored per hour") was false for this dimension and is corrected. |
| **B1d** | Legacy hours (`minute_counts IS NULL`, ~98% of a mature 1.x→2.0 archive) now report `source = 'rollup_1h_flat'` instead of masquerading as measurement. |

**On B1d's marker choice:** `rollup_1h_flat` was chosen over `data_points = 0` because those hours
still hold usable average and backend-second evidence — zero data points would incorrectly signal
*no coverage*. That reasoning is sound and I'd keep it, but it's a contract decision worth your
confirmation.

## Verification

Tests were **committed before the implementation** (`98e4c2c test:` then `e135d22 fix:`) — the TDD
ordering is visible in the history, not just claimed.

Deterministic fixture: 59 minutes at AAS 1 plus one minute at AAS 10 → 4,140 backend-seconds,
avg 1.15, peak 10.00, p99 4.69. Every expected number is hand-computed.

RED against unpatched SQL, showing the actual wrong values:

    ERROR: B1a top key=CPU* source=rollup_1h avg=1.15 peak=1.15 p99=1.15 seconds=4140.00
    ERROR: B1b filtered source=rollup_1h avg=0.17 peak=0.17 p99=0.17 seconds=600.00
    ERROR: record "v_dim" has no field "source_1"
    ERROR: database spike source=rollup_1h avg=1.15 peak=1.15 p99=1.15 pct=36.51
    ERROR: B1d aas source=rollup_1h expected=60 with_data=60 avg=0.17 peak=0.17 p99=0.17

GREEN: all eight blocks pass, including **cross-reader agreement** — `aas`, `timeline`, `top`,
`summary` and `report` now assert to the *same* 1.15 / 10.00 / 4.69 / 4140.00 for one fixed window.
That agreement is the whole point of the fix, so it is asserted directly.

Also verified:
- **Docker matrix green on PG 14, 15, 16, 17, 18 and 19beta1**
- fresh install, full 1.0→2.0 chain, double re-apply
- fresh-vs-upgrade semantic schema snapshots: 288 lines each, **zero diff**
- `compare()`'s new signature identical on both paths
- zero-argument sweep of every reader (the regression shape #131 currently trips on)

I separately confirmed the riskiest mechanic by hand: a real `v2.0-beta1` install upgraded with
this branch's installer ends up with `source_1 text` / `source_2 text` present and `compare()`
callable. `CREATE OR REPLACE` cannot change a return type, so this depends on the installer's
dynamic drop block — it works, but that is the thing to re-check if anything here is rebased.

## ⚠️ Collides with #131 and #150 — neither is mechanically safe to merge

Both already collide with each other; this is a third party. **Do not resolve any of it with
`-X ours` / `-X theirs`.**

**vs #131** — overlaps `aas` `3885–3896`, `timeline` `4042–4063`, `top` `4470–4489`, catalog
`5752–5764` (all four function comments), and workflow `3837–3992`. Its chart hunk `5519–5560` is
separable. A human must rebuild its partial-hour policy around the new requested/read/effective
grain logic, **preserve the database minute-detail exception**, and keep now-relative and default
calls working. Its unconditional alignment guard must *not* be carried over — that is what breaks
zero-arg `ash.summary()`.

**vs #150** — overlaps `_grain_counts` ~`3578`, `aas` `3800–3867`, `timeline` `3950–4032`,
`_grain_by` `4179–4359`, `top` `4376–4507`, catalog `5752–5764`, blueprint `36–45`, `138`,
`174–204`, `381–400`, workflow `3712–3871`. Order matters: in `_grain_by`, keep this branch's early
database-minute expansion *then* apply #150's query-attribution branch; in `top`, apply #150's
exact-query decision *first*, then this branch's source / legacy-flat / extreme-validity logic.
`compare()`'s new signature belongs here, but its delegated reads must inherit #150's query policy
after the hand merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HzBGzjFyN8dXZHbdWmYBj
