### PR TITLE
docs: state the soft-dependency contract and cadence guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,9 +510,7 @@ surface from the catalog alone.
 
 ## Requirements
 
-- Postgres 14+
-- `pg_stat_statements` optional but recommended for `query_text`
-- `pg_cron` optional but recommended for built-in scheduling
+Postgres 14+. Nothing else is required.
 
 `compute_query_id` must be on for useful query attribution:
 
@@ -520,6 +518,46 @@ surface from the catalog alone.
 alter system set compute_query_id = 'on';
 select pg_reload_conf();
 ```
+
+### Optional dependencies, and what you lose without them
+
+Both integrations are soft. pg_ash installs, samples, and answers questions
+with neither of them present — this is deliberate, because an application
+vendor embedding pg_ash cannot require every customer's DBA to install
+extensions, and on vendor-managed Postgres the application's own database user
+usually lacks the privilege to do it.
+
+| | pg_cron | pg_stat_statements | What you get |
+|---|---|---|---|
+| Both present | yes | yes | Everything: scheduled sampling and rollups, wait analysis, and query **text** on `ash.top`, `ash.samples`, and `ash.report` |
+| No pg_stat_statements | yes | no | Everything except query text. Query **IDs** still work — they come from `pg_stat_activity`, not from pg_stat_statements — so attribution by `query_id` is intact and `query_text` is `NULL`. `ash.report()` sets `top_queryids_available` accordingly |
+| No pg_cron | no | yes | Everything, but you schedule the jobs. `ash.start()` records the interval, enables sampling, and prints the external jobs to run; see [Scheduling](#scheduling) |
+| Neither | no | no | Wait-event analysis by type, event, and query ID, on a schedule you drive. This is the floor, and it is still the whole AAS story minus SQL text |
+
+`pg_cron` is a third-party extension (originally Citus, now maintained by
+Microsoft) and is not available on every platform. The external-scheduler path
+is a supported way to run pg_ash, not a fallback for the unlucky — some
+integrators choose it deliberately to keep scheduling under their own control.
+
+### Choosing a sampling interval
+
+| Interval | Verdict |
+|---|---|
+| 1 second | The default, and the right answer for almost everyone |
+| 15 seconds | Workable. Comparable to what managed platforms sample at; you will see sustained pressure but blur short bursts |
+| 1 minute | Too coarse. Spikes disappear entirely — a minute of trouble can average away to nothing |
+
+Sampling has a floor that no interval setting fixes. When an incident lasts a
+handful of seconds, 1-second sampling often cannot tell you which wait came
+first — whether a `LWLock` wave triggered lock contention or followed it. That
+ordering question needs wait-event *tracing*, not sampling, and pg_ash does not
+provide it. For sustained load, capacity questions, and "what was this database
+doing at 03:14", 1-second sampling answers well.
+
+The cost of sampling more often is roughly linear in the number of *active
+sessions*, not in database size: each sample stores the currently active
+backends, compressed. See [Retention and storage](#retention-and-storage) for
+the volume this implies.
 
 ## Compared to alternatives
 

--- a/devel/tests/degraded_no_pgss.sql
+++ b/devel/tests/degraded_no_pgss.sql
@@ -31,6 +31,19 @@ begin
   assert (select query_text from ash.samples(v_from, now()) limit 1) is null,
     'samples query_text should be NULL without pgss';
 
+  /*
+   * The documented degraded-mode contract (README "Optional dependencies") is
+   * that query *IDs* survive without pg_stat_statements and only the *text* is
+   * lost. Asserting NULL text alone cannot distinguish "text degraded" from
+   * "query attribution gone", so pin the exact surviving query_id.
+   */
+  assert (select key from ash.top('query_id', v_from, now()) limit 1) = '999999',
+    format('top must still attribute the exact query_id without pgss, got %s',
+      (select key from ash.top('query_id', v_from, now()) limit 1));
+  assert (select query_id from ash.samples(v_from, now()) limit 1) = 999999,
+    format('samples must still carry the exact query_id without pgss, got %s',
+      (select query_id from ash.samples(v_from, now()) limit 1));
+
   -- report still produces query ids (they come from samples, not pgss).
   j := ash.report(v_from, now());
   assert j is not null, 'report should work without pgss';


### PR DESCRIPTION
Closes #230.

## Why

Two questions decide whether pg_ash can be embedded in another product and enabled by default, and the README answered neither.

**"What is the minimal set of dependencies?"** The answer that makes embedding viable is that `pg_stat_statements` is soft *in a specific way*: query **IDs** survive without it (they come from `pg_stat_activity`), only query **text** is lost. That distinction matters because on vendor-managed Postgres an application's own database user cannot install extensions. The old three-bullet Requirements list — "optional but recommended for `query_text`" — does not convey it.

**Which sampling interval?** 1s is the target, 15s is workable, 1 minute is too coarse and loses spikes outright. Schedulers capped at minute granularity walk straight into that.

## What changed

- `## Requirements` becomes a real dependency contract: a four-row matrix over pg_cron x pg_stat_statements, each row saying what works and what is lost. pg_cron is described as third-party and not universally available, with the external-scheduler path given equal standing rather than framed as a consolation prize.
- A cadence section with the 1s / 15s / 1min tradeoff, plus the limit that no interval setting fixes: 1-second sampling cannot tell you which wait came first inside a multi-second incident. That needs wait-event tracing, which pg_ash does not provide. Better to say so than to imply precision we do not have.

## Test

The matrix makes a behavioral claim, so it gets a behavioral assert. `devel/tests/degraded_no_pgss.sql` previously asserted only that `query_text` is `NULL` without pg_stat_statements — which cannot distinguish "text degraded" from "query attribution gone entirely". Added exact-value asserts pinning the surviving `query_id` on both `ash.top()` and `ash.samples()`.

Verified against real PostgreSQL 18 in Docker with pg_stat_statements absent:

- red (expected id perturbed to 888888): `ERROR: top must still attribute the exact query_id without pgss, got 999999`
- green: `All degraded-mode (no pgss) 2.0 reader tests PASSED`

No SQL changed — `sql/` and `devel/sql/` are untouched.
