### PR TITLE
docs: restore the LLM-analysis section, grounded in AAS and ash.report()

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,6 +83,22 @@ jobs:
             fi
           done
 
+          # Keep the copyable LLM prompt aligned with ash.report's payload.
+          if ! grep -Fq "## LLM analysis" README.md; then
+            echo "README.md must retain the LLM analysis section" >&2
+            exit 1
+          fi
+          llm_analysis="$(sed -n "/^## LLM analysis$/,/^## /p" README.md)"
+          for field in \
+            "aas_avg" "aas_worst1m" "aas_p99" "aas_p999" "top_events_" \
+            "top_queryids_available" "coverage" "minutes_with_data" \
+            "minutes_expected" "raw_retention_start" "vcpus"; do
+            if ! grep -Fq "$field" README.md || ! grep -Fq "$field" <<<"$llm_analysis"; then
+              echo "README.md LLM analysis must document ash.report field $field" >&2
+              exit 1
+            fi
+          done
+
           if ! grep -Fq "Only \`ash.rebuild_partitions\` and \`ash.uninstall\` require the exact \`'yes'\` confirmation token." README.md; then
             echo "README.md must limit the exact 'yes' confirmation contract to rebuild_partitions and uninstall." >&2
             exit 1
@@ -5733,6 +5749,12 @@ jobs:
           PGPASSWORD: postgres
         run: |
           psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f devel/tests/query_attribution_assert.sql
+
+      - name: "Test 2.0: ash.report payload contract the README prompt relies on"
+        env:
+          PGPASSWORD: postgres
+        run: |
+          psql -h localhost -U postgres -d postgres -v ON_ERROR_STOP=1 -f devel/tests/report_contract.sql
 
       - name: "Test 2.0: stale and rounded-up rollup source selection"
         env:

--- a/README.md
+++ b/README.md
@@ -353,6 +353,84 @@ naming that alternate source; it does not synthesize per-minute class data.
 The payload contract is stable for the 2.0 minor line: keys may be added, not
 renamed or removed.
 
+## LLM analysis
+
+`ash.report()` is already the shape an LLM wants: one JSONB document, stable
+keys, no scraping. What a model lacks is the meaning of the numbers. "AAS" is
+not general knowledge, and a model that guesses at it will confidently call a
+sick database healthy.
+
+Pass the payload together with the prompt below.
+
+```sql
+select ash.report(
+  since => now() - interval '1 day',
+  vcpus => 16   -- required for a verdict: AAS is judged against core count
+);
+```
+
+<details>
+<summary>Prompt (copy this, then paste the JSON after it)</summary>
+
+```text
+You are analyzing a PostgreSQL database's Active Session History, produced by
+pg_ash. Below is one JSON document from ash.report().
+
+Background you need:
+
+AAS means Average Active Sessions: the average number of database sessions
+that were concurrently running or waiting during the window. It is the
+Postgres analogue of the Linux load average, and it is only meaningful when
+compared against the machine's core count. AAS of 8 on 64 vCPUs is idle; AAS
+of 8 on 4 vCPUs is an incident. The "vcpus" field gives the core count; if it
+is absent, say you cannot issue a capacity verdict rather than guessing.
+
+Wait classes tell you what the sessions were doing:
+  cpu     - running on CPU (this is work, not waiting)
+  io      - waiting on disk or page reads
+  ipc     - waiting on another backend, e.g. parallel workers
+  lock    - waiting on a row or table lock (application contention)
+  lwlock  - waiting on internal shared-memory locks (engine contention)
+
+How to read the document:
+
+- aas_avg, aas_worst1m, aas_p99, aas_p999 are each an object keyed by
+  "total" plus the five wait classes above. "total" is the whole workload.
+- Averages hide incidents. Always report the peak alongside the average.
+  For example: a 16-vCPU cluster averaging 4.9 AAS over a week is 31% of
+  capacity and looks healthy, while a worst single minute of 295 AAS is
+  1844% of capacity. The average is true and useless.
+- top_events_* name the specific wait events at the extreme minutes,
+  broken down by class.
+- top_queryids_* attribute those extreme minutes to query IDs. These keys
+  are optional. Check top_queryids_available first: when it is false,
+  pg_stat_statements is not resolving queries, so say query attribution is
+  unavailable. Never invent a query.
+- coverage tells you whether to trust any of it. minutes_with_data versus
+  minutes_expected is the resolution you actually got; if it is far below,
+  the window is mostly uncovered and your verdict is weak. source names the
+  data tier. raw_retention_start is the oldest point that can be drilled
+  into.
+
+Produce:
+
+1. A one-line verdict: healthy, degraded, or overloaded, with avg and peak
+   AAS each expressed as a percentage of vcpus.
+2. The dominant wait class at the peak, and what that class implies.
+3. The specific wait events and, if available, query IDs responsible.
+4. What to investigate next - one concrete step, not a checklist.
+5. Any caveat forced by coverage or by missing query attribution.
+
+State only what the document supports. If a field is absent, say so.
+```
+
+</details>
+
+The same payload is what an embedding application should put behind a "copy
+report" action: the operator copies JSON, pastes it into whatever model they
+already use, and gets a plain-language verdict without pg_ash calling any
+external service itself.
+
 ## Admin API
 
 | Function | Purpose |

--- a/devel/tests/report_contract.sql
+++ b/devel/tests/report_contract.sql
@@ -1,0 +1,87 @@
+/*
+ * ash.report() payload-shape contract.
+ *
+ * README's "LLM analysis" section ships a prompt that instructs a model to
+ * read specific fields of this payload. A prompt naming fields that no longer
+ * exist is worse than no prompt: the model reports on absent data instead of
+ * failing loudly. These asserts pin the exact shape the prompt depends on, so
+ * a contract change breaks CI rather than the prompt.
+ *
+ * Shape only -- the value-level asserts live with the seeded fixture in the
+ * reader API test. Self-contained: seeds its own minimal sample.
+ */
+insert into ash.wait_event_map (state, type, event) values
+  ('active', 'CPU*', 'CPU*'),
+  ('active', 'IO', 'DataFileRead')
+  on conflict do nothing;
+insert into ash.query_map_0 (query_id) values (4242) on conflict do nothing;
+
+do $$
+declare
+  v_cpu smallint;
+  v_io smallint;
+  v_q int4;
+  v_ts int4;
+  v_from timestamptz;
+  j jsonb;
+  v_keys text;
+  v_grain text;
+begin
+  select id into v_cpu from ash.wait_event_map where type = 'CPU*';
+  select id into v_io from ash.wait_event_map where event = 'DataFileRead';
+  select id into v_q from ash.query_map_0 where query_id = 4242;
+
+  -- Minute-aligned, 3 minutes back, so the window is covered by rollup_1m.
+  v_ts := (ash.ts_from_timestamptz(
+             date_trunc('minute', now() - interval '3 minutes')) / 60) * 60;
+  v_from := ash.ts_to_timestamptz(v_ts);
+  insert into ash.sample (sample_ts, datid, active_count, data, slot)
+    values (v_ts, 1, 2, array[-v_cpu, 1, v_q, -v_io, 1, v_q]::integer[], 0);
+  perform ash.rollup_minute();
+
+  j := ash.report(v_from, now());
+  assert j is not null, 'report_contract: report returned null on a seeded window';
+
+  -- Every field the README prompt tells a model to read must be present.
+  assert j ?& array[
+           'aas_avg', 'aas_worst1m', 'aas_p99', 'aas_p999',
+           'top_events_worst1m', 'top_events_p99', 'top_events_p999',
+           'top_queryids_available', 'coverage'],
+    format('report_contract: payload is missing fields the README prompt '
+           'depends on; got %s',
+      (select string_agg(k, ',' order by k) from jsonb_object_keys(j) k));
+
+  -- The AAS objects are keyed by total plus the five wait classes the prompt
+  -- explains. Exact key set, so an added or dropped class is caught.
+  foreach v_grain in array array['aas_avg', 'aas_worst1m', 'aas_p99', 'aas_p999']
+  loop
+    assert jsonb_typeof(j -> v_grain) = 'object',
+      format('report_contract: %s must be a jsonb object, got %s',
+        v_grain, jsonb_typeof(j -> v_grain));
+    select string_agg(k, ',' order by k) into v_keys
+      from jsonb_object_keys(j -> v_grain) k;
+    assert v_keys = 'cpu,io,ipc,lock,lwlock,total',
+      format('report_contract: %s keys must be cpu,io,ipc,lock,lwlock,total, '
+             'got %s', v_grain, v_keys);
+  end loop;
+
+  -- coverage is what the prompt uses to decide whether to trust a verdict.
+  assert jsonb_typeof(j -> 'coverage') = 'object',
+    'report_contract: coverage must be a jsonb object';
+  select string_agg(k, ',' order by k) into v_keys
+    from jsonb_object_keys(j -> 'coverage') k;
+  assert v_keys
+    = 'from,minutes_expected,minutes_with_data,raw_retention_start,source,to',
+    format('report_contract: coverage keys changed, got %s', v_keys);
+
+  -- vcpus drives the whole capacity verdict, so both directions matter: it is
+  -- echoed exactly when supplied, and absent when not, so a consumer can tell
+  -- "no core count given" from a fabricated one.
+  assert not (j ? 'vcpus'),
+    'report_contract: vcpus must be absent when it is not supplied';
+  assert (ash.report(v_from, now(), vcpus => 16) ->> 'vcpus')::int = 16,
+    'report_contract: vcpus must be echoed exactly when supplied';
+
+  raise notice 'ash.report payload contract PASSED';
+end;
+$$;


### PR DESCRIPTION
Closes #225.

## Why

The README's LLM-analysis section was removed and never replaced. It should come back, rebuilt around AAS rather than raw sample dumps.

`ash.report()` already returns the payload an LLM wants, so the missing piece was never SQL — it was the prompt that makes the payload interpretable. "AAS" is not general knowledge, and a model handed the JSON without it will confidently issue a verdict on a database it has misread.

## What changed

A `## LLM analysis` section after `## Machine report`, containing a copy-pasteable prompt that:

- defines AAS as the Postgres load average and insists it is judged **against vCPU count** — AAS 8 on 64 cores is idle, AAS 8 on 4 cores is an incident;
- explains the five wait classes in operator terms;
- walks the document's real structure (the `aas_*` objects keyed by `total` plus the five classes, `top_events_*`, `coverage`);
- states the peak-versus-average trap with a worked illustration: a 16-vCPU cluster averaging 4.9 AAS over a week reads as healthy at 31% of capacity, while a worst single minute of 295 AAS is 1844% of it. The average is true and useless;
- forces honesty on missing data: check `top_queryids_available` before attributing queries, check `minutes_with_data` against `minutes_expected` before trusting the verdict, and never invent a query.

## Tests

A prompt that names payload fields rots silently when the contract moves, so this guards both directions:

1. **Docs guard** (existing `Guard docs against stale privilege and reader names` step): every documented field must appear *inside* the LLM analysis section, not merely somewhere in the README — the section is extracted with `sed` before grepping.
2. **Behavioral** — new `devel/tests/report_contract.sql`, run as its own CI step. Self-contained (seeds its own minimal sample) and asserts the payload **shape** the prompt depends on: the exact sorted key sets of `aas_avg` / `aas_worst1m` / `aas_p99` / `aas_p999` (`cpu,io,ipc,lock,lwlock,total`) and of `coverage` (`from,minutes_expected,minutes_with_data,raw_retention_start,source,to`), plus that `vcpus` is echoed exactly when supplied and **absent** when not — so a consumer can distinguish "no core count given" from a fabricated one. Value-level asserts stay with the seeded fixture in the reader API test; this file deliberately covers shape only.

Verified against real PostgreSQL 18 in Docker:

- red (an AAS class key set perturbed): `ERROR: report_contract: aas_avg keys must be cpu,io,ipc,lock,lwlock,total, got cpu,io,ipc,lock,lwlock,total`
- green: `ash.report payload contract PASSED`
- docs guard: green, and verified to trip when a documented field is renamed.

## A CI landmine worth knowing about

The asserts were first written inline in the existing `Test 2.0 reader API (behavioral)` step, which pushed that single step past **27,000 characters**. GitHub Actions then silently refused to materialize *any* job for the workflow on this branch: the `pull_request` run was never created, and a `workflow_dispatch` run sat `queued` with **zero jobs** and no error anywhere. The YAML parsed fine locally, including a strict duplicate-key check, which made it look like a GitHub outage rather than our change.

Moving the SQL into `devel/tests/` — the pattern the repo already uses for `query_attribution_assert.sql` and `stale_rollup_source.sql` — fixed it immediately. Worth remembering before adding more inline SQL to that step; it is the largest one in the workflow by a wide margin.

## Scope

No SQL changed — `sql/` and `devel/sql/` untouched. The CI wiring was drafted with Codex (`gpt-5.6-sol`) and reviewed here; I dropped a redundant `vcpus => 16` echo assert it added next to an existing `vcpus => 8` one, and restructured the placement as described above.
