### PR TITLE
docs: state what ash.start() actually does, and test the trap it hides

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,6 +375,29 @@ Only `ash.rebuild_partitions` and `ash.uninstall` require the exact `'yes'` conf
 
 ## Scheduling
 
+### What `ash.start()` does, and does not do
+
+`ash.start()` starts no process. Despite the name, it does two things:
+
+1. sets `sampling_enabled` in `ash.config`;
+2. registers pg_cron jobs, when pg_cron is available.
+
+Consequences worth knowing before you wire it into an application:
+
+- **It is idempotent.** Calling it again does not duplicate jobs.
+- **You do not need to call it again after a restart.** pg_cron jobs live in
+  `cron.job`, which is an ordinary table; they survive restarts like any other
+  row. There is no in-memory state to lose.
+- **You still need it when you tick externally.** This is the trap. `ash.stop()`
+  clears `sampling_enabled`, and `ash.take_sample()` then returns `0` and
+  increments `skipped_samples` instead of collecting. An external scheduler
+  calling `ash.take_sample()` on a stopped installation will appear to run
+  perfectly and collect nothing. `ash.status()` reports both
+  `sampling_enabled` and `skipped_samples`; check them if samples are missing.
+
+The name is misleading and is expected to change — see
+[#223](https://github.com/NikolayS/pg_ash/issues/223).
+
 pg_cron is optional. For pg_cron scheduling, install pg_ash in the database
 named by `cron.database_name`; it still observes activity from every database.
 With pg_cron installed, `ash.start('1 second')` schedules:

--- a/devel/tests/degraded_no_cron.sql
+++ b/devel/tests/degraded_no_cron.sql
@@ -2,6 +2,9 @@ do $$
 declare
   v_rec record;
   v_status_val text;
+  v_sampled int;
+  v_skipped_before bigint;
+  v_skipped_after bigint;
 begin
   -- start() should work without pg_cron (no error, prints hints)
   select status into v_status_val
@@ -40,8 +43,40 @@ begin
   assert v_status_val like '%no%',
     'status() should show pg_cron not available, got: ' || v_status_val;
 
-  -- take_sample() should work without pg_cron
-  perform ash.take_sample();
+  /*
+   * The external-ticking trap: ash.stop() (called just above) clears
+   * ash.config.sampling_enabled, and take_sample() then silently no-ops and
+   * bumps skipped_samples. An integrator who ticks take_sample() from their
+   * own scheduler therefore still depends on ash.start(), even with pg_cron
+   * absent -- the opposite of what "you don't need start() without pg_cron"
+   * suggests. Assert both sides so the contract cannot regress unnoticed.
+   */
+  select skipped_samples into v_skipped_before from ash.config where singleton;
+  v_sampled := ash.take_sample();
+  select skipped_samples into v_skipped_after from ash.config where singleton;
+  assert v_sampled = 0,
+    format('take_sample() must no-op while sampling is disabled, got %s',
+      v_sampled);
+  assert v_skipped_after = v_skipped_before + 1,
+    format('disabled take_sample() must bump skipped_samples by exactly 1, '
+      'got %s -> %s', v_skipped_before, v_skipped_after);
+
+  -- Re-enabling restores collection without pg_cron.
+  perform * from ash.start('1 second');
+  select skipped_samples into v_skipped_before from ash.config where singleton;
+  v_sampled := ash.take_sample();
+  select skipped_samples into v_skipped_after from ash.config where singleton;
+  /*
+   * take_sample() excludes its own backend (pid <> pg_backend_pid()), so an
+   * otherwise idle test database legitimately captures zero backends. The
+   * exact discriminator between "sampled and found nothing" and "refused to
+   * sample" is therefore skipped_samples, not the return value.
+   */
+  assert v_sampled is not null and v_sampled >= 0,
+    format('re-enabled take_sample() must return a count, got %s', v_sampled);
+  assert v_skipped_after = v_skipped_before,
+    format('an accepted sample must not bump skipped_samples, got %s -> %s',
+      v_skipped_before, v_skipped_after);
 
   -- All 2.0 reader functions should work
   perform ash.periods();


### PR DESCRIPTION
Refs #223 (does not close it — the rename is still open).

## Why

`ash.start()` is the single biggest source of confusion for anyone integrating pg_ash. Three questions cannot be answered from the README:

| Question | Answer |
|---|---|
| What does it start? | Nothing. It sets `sampling_enabled` and registers pg_cron jobs. There is no background process. |
| Must it be re-called after a Postgres restart? | No. pg_cron jobs live in `cron.job`, an ordinary table. |
| Is it idempotent? | Yes — stated only in a `comment on function`, nowhere in the README. |

And the name invites a conclusion the docs do nothing to prevent: *"if I am not using pg_cron, I do not need to call it at all."*

That is wrong in the expensive direction. `ash.stop()` clears `sampling_enabled`; `ash.take_sample()` then returns `0` and increments `skipped_samples` instead of collecting (`sql/ash-install.sql:963`). Anyone ticking `take_sample()` from their own scheduler on a stopped installation sees every call succeed and collects nothing.

## What changed

- README `## Scheduling` gains a subsection stating what `ash.start()` does and does not do, the idempotency and restart facts, and the external-ticker trap with the two fields (`sampling_enabled`, `skipped_samples`) that diagnose it.
- `devel/tests/degraded_no_cron.sql` called `ash.take_sample()` at *exactly* the point where sampling had just been disabled by `ash.stop()` — and asserted nothing about the result. The trap was live and untested. Now asserted in both directions with exact values:
  - disabled: returns `0` **and** `skipped_samples` increases by exactly 1;
  - re-enabled: `skipped_samples` does **not** move.

The return value is deliberately not asserted positive: `take_sample()` filters `pid <> pg_backend_pid()`, so an idle test database correctly captures zero backends. `skipped_samples` is the honest discriminator between "sampled and found nothing" and "refused to sample".

Verified against real PostgreSQL 18 in Docker with pg_cron absent:

- red (expected delta perturbed to +2): `ERROR: disabled take_sample() must bump skipped_samples by exactly 1, got 0 -> 1`
- green: `All degraded-mode (no pg_cron) tests PASSED`

## Deliberately not done here

The **rename** (`start` -> `schedule` / `register`). Naming the flagship lifecycle function is a product decision, it must land before the 2.0 tag since 2.0 is meant to be the last interface change, and it touches demos, blueprints, and catalog comments repo-wide. #223 carries a concrete proposal and a full test plan. This PR is the half that is unambiguous and safe to land now.

No SQL changed — `sql/` and `devel/sql/` untouched.
