### PR TITLE
ci: run tests on release-branch PRs, and make CI requirable (#241)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,10 @@ name: Test pg_ash
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
     tags: ['v*']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/**']
   workflow_dispatch:
     inputs:
       release_tag:
@@ -11420,3 +11420,25 @@ jobs:
           CRON: ${{ matrix.cron }}
         run: |
           echo "All tests passed for PostgreSQL $PG_MAJOR (pg_cron=$CRON)"
+
+  # One stable check name for the branch ruleset's required status checks.
+  # The matrix contexts embed PG versions ("test (19beta2, on)") and change
+  # every release, so requiring them by name would rot. Fails if any needed
+  # job failed or was cancelled; a job that never ran leaves this pending.
+  ci-required:
+    if: always()
+    needs: [docs-lint, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert every required job succeeded
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          set -euo pipefail
+          echo "needed job results: ${RESULTS}"
+          for r in ${RESULTS}; do
+            case "${r}" in
+              success|skipped) ;;
+              *) echo "a required job reported: ${r}" >&2; exit 1 ;;
+            esac
+          done

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,108 @@
+# CI and branch protection
+
+This file records which workflows run where, and the exact branch-ruleset
+configuration that makes "CI is green" a real merge precondition rather than
+an honour-system one.
+
+## Workflows and their triggers
+
+| Workflow | File | Triggers |
+| --- | --- | --- |
+| `Test pg_ash` | `.github/workflows/test.yml` | push to `main` and `release/**`, tags `v*`, PRs into `main` and `release/**`, `workflow_dispatch` |
+| `demo` | `.github/workflows/demo.yml` | every push, every PR, nightly cron, `workflow_dispatch` |
+| CodeQL | code scanning **default setup** (no file in this repo) | push to the default branch and PRs into it, weekly |
+
+`test.yml` originally filtered both `push` and `pull_request` to `branches:
+[main]`. Release-branch PRs — the `release/2.0` line, for example — therefore
+merged with the full PG 14–19 matrix never having run once. `demo.yml` has
+always used unfiltered `push:`/`pull_request:`, so it needed no change.
+
+CodeQL is configured through code-scanning *default setup*, which covers the
+default branch only and has no branch knob. A PR into a `release/**` branch
+will not get a `CodeQL` check run. That matters for the required-checks list
+below: if the ruleset is ever extended beyond `~DEFAULT_BRANCH`, requiring
+`CodeQL` would leave release-branch PRs blocked on a check that can never
+arrive. Switching to advanced setup (a committed `codeql.yml`) is the way to
+get CodeQL onto release branches, and is out of scope here.
+
+## The `ci-required` aggregator
+
+`test.yml` ends with a `ci-required` job: `if: always()`, `needs: [docs-lint,
+test]`, failing if any needed job reports anything other than `success` or
+`skipped`.
+
+It exists because the matrix contexts embed PostgreSQL versions — `test (14,
+on)`, `test (19beta2, on)` — and are renamed at every version bump. Requiring
+those names directly means the ruleset silently stops covering a version the
+moment the matrix changes, or blocks every PR on a context that no longer
+exists. `ci-required` is one stable name that transitively covers the whole
+matrix, whatever it contains next year.
+
+It also converts one specific silent failure into a hard block. GitHub refuses
+to create a run when a workflow file exceeds 512,000 bytes and reports nothing
+at all (see #237). Today that shows up as *absent* checks, which a required
+check cannot detect if the required names all come from that same file — but a
+required check that never reports leaves the PR permanently pending, which is
+visible. `test.yml` is large; keep an eye on its size.
+
+## Required status checks (owner action)
+
+The `main-protected` ruleset (id `13093534`) currently has `deletion`,
+`non_fast_forward` and `pull_request` rules but **no `required_status_checks`
+rule**. Nothing at the ruleset level requires any check to have run, so a PR
+whose workflows never started — a fork PR pending workflow approval, a branch
+the trigger filters excluded, a workflow file over the size limit — is
+mergeable into `main` with zero evidence.
+
+Applying the payload below adds that rule. It preserves the existing rules
+verbatim; only the new `required_status_checks` entry is added.
+
+```bash
+gh api -X PUT repos/NikolayS/pg_ash/rulesets/13093534 \
+  --input docs/ci/main-protected-ruleset.json
+```
+
+Verify afterwards with:
+
+```bash
+gh api repos/NikolayS/pg_ash/rulesets/13093534 \
+  --jq '.rules[] | select(.type=="required_status_checks")'
+```
+
+### Which checks, and why those
+
+| Context | App | Why |
+| --- | --- | --- |
+| `ci-required` | `github-actions` (15368) | Stable rollup of `docs-lint` + the whole PG matrix |
+| `renderer (fixtures, no database)` | `github-actions` (15368) | Fast demo gate, runs on every PR, stable name |
+| `capture + reel (real PostgreSQL)` | `github-actions` (15368) | Real-database demo gate; runs on every PR |
+| `CodeQL` | `github-advanced-security` (57789) | Default setup covers the default branch, which is all this ruleset targets |
+
+Deliberately **not** required: the individual `test (N, on)` matrix contexts
+(version-coupled names, covered by `ci-required`), `Analyze (actions)` and
+`Analyze (python)` (CodeQL's per-language runs, rolled up by `CodeQL`), and
+`size` (only exists once #238 lands; add it then).
+
+Two behaviours to keep in mind:
+
+- **A job skipped by a job-level `if:` still reports**, with conclusion
+  `skipped`, and GitHub treats that as satisfying a required check. So
+  `capture + reel (real PostgreSQL)` being required does not mean it always
+  really ran — its `if:` includes `github.event_name == 'pull_request'`, so on
+  PRs it does. A workflow skipped *entirely* (branch or path filter, or a file
+  over the size limit) reports nothing, and the required check stays pending —
+  the PR is blocked, which is the behaviour we want.
+- **Fork PRs need workflow approval.** With "require approval for all external
+  contributors", a fork PR's workflows do not start until a maintainer
+  approves them, so the required checks sit pending and the PR cannot be
+  merged. That is the hole being closed: today those PRs are mergeable with
+  nothing having run.
+
+### `strict_required_status_checks_policy`
+
+Recommended: `false` (as in the payload). `true` requires every PR branch to
+be up to date with `main` before merging. With a dozen PRs open against `main`
+at once, each merge invalidates all the others and forces a rebase plus a full
+PG 14–19 matrix re-run — serialising the queue for little benefit, since the
+matrix is a schema/behaviour test rather than a semantic-conflict detector.
+Turn it on for a release line if a stale-merge incident ever justifies it.

--- a/docs/RELEASE_PROCESS.md
+++ b/docs/RELEASE_PROCESS.md
@@ -1,5 +1,8 @@
 # pg_ash development and release SQL process
 
+CI triggers, the `ci-required` aggregator, and the branch-ruleset
+required-status-checks configuration live in [CI.md](CI.md).
+
 ## Version identity and prereleases
 
 Release tags use the repository's two-part version scheme. Prerelease stages

--- a/docs/ci/main-protected-ruleset.json
+++ b/docs/ci/main-protected-ruleset.json
@@ -1,0 +1,42 @@
+{
+  "name": "main-protected",
+  "target": "branch",
+  "enforcement": "active",
+  "bypass_actors": [],
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "required_reviewers": [],
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true,
+        "require_extra_approval_for_unattributed_changes": true,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "ci-required", "integration_id": 15368 },
+          { "context": "renderer (fixtures, no database)", "integration_id": 15368 },
+          { "context": "capture + reel (real PostgreSQL)", "integration_id": 15368 },
+          { "context": "CodeQL", "integration_id": 57789 }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #241.

Two holes that both end the same way: a change reaching `main` with no CI evidence behind it.

## Hole 1 — release-branch PRs run no tests

`.github/workflows/test.yml` filtered both triggers to `branches: [main]`, so a PR targeting `release/2.0` never started the PG 14–19 matrix. The open PR into `release/2.0` has an empty `statusCheckRollup` — zero checks, ever.

```diff
   push:
-    branches: [main]
+    branches: [main, 'release/**']
     tags: ['v*']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/**']
```

`demo.yml` needed no change — it already uses unfiltered `push:`/`pull_request:`, which is why the demo checks *do* appear on release-branch PRs. Those two were the only workflow files; CodeQL is code-scanning **default setup**, covering the default branch only, with no branch knob. Release-branch PRs therefore still get no `CodeQL` check. Fixing that means moving to advanced setup (a committed `codeql.yml`); I judged that out of scope and documented it instead, because it changes how code scanning is configured repo-wide.

## Hole 2 — nothing is required to merge into `main`

Ruleset `main-protected` (`13093534`) has `deletion`, `non_fast_forward` and `pull_request` rules and **no `required_status_checks` rule**. Nothing requires a check to have *run*. A PR whose workflows never started is mergeable with no evidence: a fork PR pending workflow approval, a branch the trigger filters excluded, or a workflow file over the 512,000-byte limit that GitHub silently refuses to run (#237).

Changing the ruleset is an owner-level action, so this PR does not touch it. It ships the payload instead: `docs/ci/main-protected-ruleset.json`, which reproduces the three existing rules verbatim and adds the fourth.

```bash
gh api -X PUT repos/NikolayS/pg_ash/rulesets/13093534 \
  --input docs/ci/main-protected-ruleset.json

# verify
gh api repos/NikolayS/pg_ash/rulesets/13093534 \
  --jq '.rules[] | select(.type=="required_status_checks")'
```

Contexts required, and why those four:

| Context | App id | Why |
| --- | --- | --- |
| `ci-required` | 15368 | Stable rollup of `docs-lint` + the whole PG matrix |
| `renderer (fixtures, no database)` | 15368 | Fast demo gate, every PR, stable name |
| `capture + reel (real PostgreSQL)` | 15368 | Real-database demo gate, every PR |
| `CodeQL` | 57789 | Default setup covers the default branch, which is all this ruleset targets |

Not required: the individual `test (N, on)` contexts (see below), `Analyze (actions)`/`Analyze (python)` (rolled up by `CodeQL`), and `size` (only exists once #238 lands — add it then).

`strict_required_status_checks_policy: false` is recommended in the payload. `true` forces every branch up to date with `main` before merge; with a dozen PRs open at once each merge invalidates the rest and forces a full matrix re-run, serialising the queue for little benefit — the matrix is a schema/behaviour test, not a semantic-conflict detector.

## The `ci-required` aggregator — yes, worth it

I did implement the aggregator (`if: always()`, `needs: [docs-lint, test]`, fails on any result other than `success`/`skipped`), for two reasons.

The matrix contexts embed PostgreSQL versions — `test (14, on)`, `test (19beta2, on)`. Requiring them by name means the ruleset silently stops covering a version the moment the matrix changes, or blocks every PR on a context that no longer exists. One stable name covers whatever the matrix contains next year.

It also turns the #237 failure mode into something visible. A required check whose workflow never ran stays **pending**, and the PR is blocked — as opposed to today, where absent checks are indistinguishable from nothing to report.

Two behaviours worth stating explicitly, since they decide whether a required check is real:

- A job skipped by a **job-level `if:`** still reports a check run with conclusion `skipped`, and GitHub treats that as satisfying a required check. So `capture + reel (real PostgreSQL)` being required does not by itself prove it ran — its `if:` does include `github.event_name == 'pull_request'`, so on PRs it does run. A workflow skipped **entirely** (branch/path filter, or a file over the size limit) reports nothing at all, and the required check stays pending. That asymmetry is the whole reason this works.
- Fork PRs need workflow approval; until a maintainer approves, nothing reports, the required checks stay pending, and the PR cannot be merged. That is precisely the case that is mergeable today.

## Size

`test.yml` grows 509,333 → 510,165 bytes, leaving 1,835 bytes under the 512,000 limit. Thin, deliberately: I kept the edit to the trigger block plus an appended job so it does not conflict with #238, which cuts the file to ~394,000. **#238 should land before any further test additions.** I did not consider putting the aggregator in a separate workflow file — `needs:` cannot cross workflows.

## Verification

- `actionlint` on both workflows: no new findings (the four pre-existing `SC2016`/`SC2295` info notes are untouched lines).
- Both files parse; `test.yml` jobs are `docs-lint`, `test`, `ci-required`; triggers confirmed as `[main, release/**]`.
- Ruleset JSON parses and reproduces the three current rules field-for-field.
- Trigger change materialising runs is confirmed by this PR's own checks.

Not merged, per CLAUDE.md — REV review and owner approval still outstanding. Applying the ruleset payload is an owner action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUvtEcka1av1GBDXYuQbfF