### PR TITLE
fix(ci): end a run block at a dedented comment, and gate the parser (#243)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,14 @@ jobs:
       - name: Test release stamp checker
         run: python3 devel/scripts/test_release_stamp.py -v
 
+      # Lives here, not in `test`, on purpose: this suite parses test.yml, and
+      # a job inside that workflow's matrix cannot be trusted to report on the
+      # parseability of the file it was scheduled from. docs-lint needs no
+      # database and runs on every event, so a break is loud and immediate.
+      # Without this the suite had no gate at all and #243 reached main.
+      - name: Test CI step extractor
+        run: python3 devel/scripts/test_ci_step_script.py -v
+
       - name: Verify release tag matches payload stamp
         if: >-
           github.ref_type == 'tag' ||

--- a/devel/scripts/ci_step_script.py
+++ b/devel/scripts/ci_step_script.py
@@ -59,6 +59,26 @@ def _indent(line: str, *, line_number: int) -> int | None:
     return len(leading)
 
 
+def _block_scalar_indent(line: str, *, line_number: int) -> int | None:
+    """Indentation for block-scalar termination; None only for blank lines.
+
+    Unlike :func:`_indent`, a comment line reports its real indentation. Inside
+    a literal block a ``#`` line indented at or beyond the content is ordinary
+    content (a shell comment), but one indented back to the parent's level ends
+    the scalar, exactly as YAML specifies. Treating it as content instead makes
+    the block appear to start at the comment's indentation.
+    """
+    text = _without_eol(line)
+    leading = text[: len(text) - len(text.lstrip(" \t"))]
+    if "\t" in leading:
+        raise WorkflowError(
+            f"line {line_number}: tabs are not valid YAML indentation"
+        )
+    if not text.strip():
+        return None
+    return len(leading)
+
+
 def _is_mapping_key(line: str, indent: int, key: str) -> bool:
     text = _without_eol(line)
     prefix = " " * indent + key + ":"
@@ -192,7 +212,7 @@ def _deindent_literal_block(
 ) -> str:
     block_end = end
     for idx in range(start, end):
-        indentation = _indent(lines[idx], line_number=idx + 1)
+        indentation = _block_scalar_indent(lines[idx], line_number=idx + 1)
         if indentation is not None and indentation <= parent_indent:
             block_end = idx
             break

--- a/devel/scripts/test_ci_step_script.py
+++ b/devel/scripts/test_ci_step_script.py
@@ -154,6 +154,123 @@ class WorkflowParserTests(unittest.TestCase):
             b"second\0echo done\n\0",
         )
 
+    # ---- issue #243: a dedented comment must end a run block ----
+
+    # The workflow is fine; the parser was not. Before the fix the reader
+    # skipped comment lines when looking for the end of a `run: |` block, so a
+    # comment at job indentation was swallowed as block content, dragged the
+    # computed content indentation down to its own, and raised. Any step that
+    # is the last one in its job trips this the moment another job follows.
+    DEDENTED_COMMENT = """\
+jobs:
+  test:
+    steps:
+      - name: Last step
+        run: |
+          echo hi
+%s
+  other-job:
+    runs-on: ubuntu-latest
+"""
+
+    def test_dedented_comment_terminates_run_block(self) -> None:
+        text = self.DEDENTED_COMMENT % (
+            "  # One stable check name for the branch ruleset."
+        )
+        steps = self.parse(text)
+        self.assertEqual([step.name for step in steps], ["Last step"])
+        # Exact body: the comment must not leak in, and nothing may be trimmed.
+        self.assertEqual(steps[0].run, "echo hi\n")
+
+    def test_dedented_comment_and_no_comment_agree(self) -> None:
+        """The comment is the only difference, so the body must be identical."""
+        with_comment = self.parse(self.DEDENTED_COMMENT % "  # trailing note")
+        without_comment = self.parse(self.DEDENTED_COMMENT % "")
+        self.assertEqual(
+            [step.run for step in with_comment],
+            [step.run for step in without_comment],
+        )
+
+    def test_comment_indented_into_the_block_stays_content(self) -> None:
+        """A shell comment inside `run: |` is content, not a terminator.
+
+        This is the over-correction guard: terminating on any comment at all
+        would silently truncate most real steps in this repository.
+        """
+        text = """\
+jobs:
+  test:
+    steps:
+      - name: Shell comments
+        run: |
+          # explain the next line
+          echo hi
+            # deeper still
+          echo bye
+
+  other-job:
+    runs-on: ubuntu-latest
+"""
+        steps = self.parse(text)
+        self.assertEqual(
+            steps[0].run,
+            "# explain the next line\necho hi\n  # deeper still\necho bye\n",
+        )
+
+    def test_blank_lines_inside_a_block_are_preserved(self) -> None:
+        text = """\
+jobs:
+  test:
+    steps:
+      - name: Blanks
+        run: |
+          echo one
+
+          echo two
+  # dedented comment right after a blank-containing block
+  other-job:
+    runs-on: ubuntu-latest
+"""
+        steps = self.parse(text)
+        self.assertEqual(steps[0].run, "echo one\n\necho two\n")
+
+    def test_under_indented_content_is_not_newly_tolerated(self) -> None:
+        """Characterization: the fix must not loosen anything for content.
+
+        Note on issue #243's wording. It asks that "a genuinely under-indented
+        content line still raises". Measured against the pre-fix parser, it
+        never did: a non-comment line at or below the block's parent
+        indentation has always simply ended the scalar, and the
+        `content_indent <= parent_indent` guard was only ever reachable through
+        the comment path -- which is the bug itself. Rather than invent a new
+        error to satisfy the wording, this pins the pre-existing behaviour so a
+        later change cannot quietly relax it: the block ends at the dedented
+        line and that line's text never becomes part of the body.
+        """
+        text = """\
+jobs:
+  test:
+    steps:
+      - name: Bad indent
+        run: |
+          echo one
+      echo two
+  other-job:
+    runs-on: ubuntu-latest
+"""
+        steps = self.parse(text)
+        self.assertEqual(steps[0].run, "echo one\n")
+        self.assertNotIn("echo two", steps[0].run or "")
+
+    def test_tabs_are_still_rejected_when_ending_a_block(self) -> None:
+        text = (
+            "jobs:\n  test:\n    steps:\n      - name: Tabbed\n"
+            "        run: |\n          echo hi\n\t# tabbed comment\n"
+        )
+        with self.assertRaises(ci_step_script.WorkflowError) as caught:
+            self.parse(text)
+        self.assertIn("tabs are not valid YAML indentation", str(caught.exception))
+
     def test_current_workflow_integration(self) -> None:
         steps = ci_step_script.parse_workflow(ci_step_script.DEFAULT_WORKFLOW)
         names = [step.name for step in steps]


### PR DESCRIPTION
Closes #243.

## The bug

`devel/scripts/ci_step_script.py` could no longer parse `.github/workflows/test.yml`, so its own suite failed on a pristine `main`:

```text
$ python3 devel/scripts/test_ci_step_script.py
ci_step_script.WorkflowError: line 8830: run block content must be indented more than the run key
Ran 7 tests — FAILED (errors=1)
```

Nothing is wrong with the workflow. When scanning for the end of a `run: |` block, the reader used `_indent()`, which returns `None` for **comment** lines as well as blank ones. A comment at job indentation was skipped rather than treated as a terminator, so the block ran on past it into the next job, the comment's own indentation became the computed minimum, and the guard fired.

Any step that is last in its job trips this the moment another job follows it — which is exactly what the `ci-required` job in #242 introduced.

## The fix

New `_block_scalar_indent()`, which returns `None` **only** for blank lines, used for the terminator scan.

The distinction it draws is the one YAML actually makes: a `#` line indented at or beyond the block's content is ordinary content — a shell comment, which is extremely common in this repo's steps — while one dedented back to the parent's level ends the scalar. The old code could not tell those apart because it discarded the indentation of every comment.

Behaviour is unchanged for every non-comment input. I verified that by running the pre-fix and post-fix parsers over the same fixtures and diffing the results, rather than assuming it.

## Red / green

Four tests fail against the unfixed parser, including the real-workflow integration test:

```text
ERROR: test_dedented_comment_terminates_run_block
ERROR: test_dedented_comment_and_no_comment_agree
ERROR: test_blank_lines_inside_a_block_are_preserved
ERROR: test_current_workflow_integration
Ran 13 tests — FAILED (errors=4)
```

All 13 pass after it:

```text
Ran 13 tests in 0.040s
OK
```

End to end against the real workflow, showing the comment does not leak into the body:

```text
$ python3 devel/scripts/ci_step_script.py step "Final summary"
echo "All tests passed for PostgreSQL $PG_MAJOR (pg_cron=$CRON)"
```

## Coverage added

- the issue's minimal repro, asserting the body is **exactly** `echo hi\n`
- with-comment and without-comment parses must produce identical bodies, since the comment is the only difference
- shell comments at **and beyond** content indentation stay in the body — the over-correction guard, since terminating on any comment at all would silently truncate most real steps here
- blank lines inside a block still preserved
- tabs still rejected on the termination path
- a characterization test pinning that an under-indented content line is not newly tolerated

## Gating it so this cannot regress silently

`docs-lint` now runs `test_ci_step_script.py`. It belongs there rather than in `test` deliberately: this suite parses `test.yml`, and a job inside that workflow's own matrix cannot be trusted to report on the parseability of the file it was scheduled from. `docs-lint` needs no database and runs on every event, so a break is loud and immediate.

Cost to `test.yml` is **8 lines** (8853 → 8861), five of which are the comment explaining the placement — worth being mindful of given the 512,000-byte workflow ceiling that #237 dealt with.

## One correction to the acceptance criteria

The issue asks that "a genuinely under-indented *content* line still raises". **Measured against the pre-fix parser, it never did.** A non-comment line at or below the parent indentation has always simply ended the scalar, and the `content_indent <= parent_indent` guard was only ever reachable through the comment path — that is, through the bug itself. The `indentation < content_indent` guard is likewise unreachable, since `content_indent` is the minimum over the same set of lines.

```text
                                          pre-fix              post-fix
under-indented content (9 vs run key 8)   OK ' echo one\necho two\n'   identical
way-under content (7)                     OK 'echo one\n'              identical
block content at step indent              OK ''                        identical
```

So rather than invent a new error to satisfy the wording, I pinned the existing behaviour in a characterization test with the reasoning written down, so it cannot be quietly relaxed later. Making the parser genuinely strict here would be a deliberate behaviour change that could reject workflows it accepts today, and belongs in its own PR if wanted.

Every other acceptance criterion is met.

## Verification

```text
python3 devel/scripts/test_ci_step_script.py   ->  13 tests, OK
python3 devel/scripts/test_release_stamp.py    ->  17 tests, OK
yaml.safe_load(test.yml)                       ->  jobs: docs-lint, test, ci-required
```

Not merging — flagging for review.