### PR TITLE
ci: enforce v2 candidate coverage and required checks

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -201,7 +201,11 @@ jobs:
         if: steps.gate.outputs.run == 'yes'
         env:
           ASH_BACKEND: local
-        run: make -C demos all
+        run: |
+          # Checkout contains these tracked reels. Removing them makes the
+          # post-capture existence checks prove this run recreated both.
+          rm -f -- assets/ash_demo.gif assets/ash_demo.mp4
+          make -C demos all
 
       - name: Demo-rot alarm
         if: steps.gate.outputs.run == 'yes'

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -10,7 +10,7 @@
 #                 works on frozen input. It cannot notice that pg_ash's output
 #                 changed shape underneath it. Only demo-refresh catches that.
 #
-#   demo-refresh  nightly, on demand, and whenever demos/** or sql/** changes.
+#   demo-refresh  nightly, on demand, and when candidate SQL/consumers change.
 #                 ~3 min. Seeds a real PostgreSQL, re-captures every scene, and
 #                 records the reel. `make -C demos rot` compares the fresh
 #                 reader contract with fixtures/shape.tsv: a changed capture
@@ -121,8 +121,8 @@ jobs:
           python-version: '3.12'
 
       - name: Decide whether this run needs the full pass
-        # On push/PR, only when demos/** or sql/** actually changed. Schedules
-        # and manual dispatches always run.
+        # Include development SQL: it is the active installer between stamps.
+        # Schedules and manual dispatches always run.
         id: gate
         run: |
           set -Eeuo pipefail
@@ -138,9 +138,10 @@ jobs:
           # base tree and use a two-tree diff; any fetch/diff error must fail
           # this step, never turn the expensive gate into a false green.
           git fetch --no-tags --depth=1 origin "$base"
-          changed="$(git diff --name-only "$base" HEAD -- demos sql)"
-          if [ -n "$changed" ]; then echo "run=yes" >> "$GITHUB_OUTPUT"
-          else echo "run=no" >> "$GITHUB_OUTPUT"; fi
+          changed="$(git diff --name-only "$base" HEAD)"
+          needed="$(printf '%s\n' "$changed" \
+            | python3 devel/scripts/ci_guards.py demo-needed)"
+          echo "run=$needed" >> "$GITHUB_OUTPUT"
 
       - name: Start the runner's own PostgreSQL cluster
         if: steps.gate.outputs.run == 'yes'
@@ -217,12 +218,21 @@ jobs:
         # red is a check nobody reads. See demos/render/scene_shape.py.
         run: make -C demos rot
 
+      - name: Verify fresh capture evidence exists
+        if: steps.gate.outputs.run == 'yes'
+        run: |
+          set -euo pipefail
+          test -s demos/out/window.env
+          test -s demos/out/transcript.log
+          test -s assets/ash_demo.gif
+          test -s assets/ash_demo.mp4
+
       - name: Upload the artifacts a human can eyeball
         if: steps.gate.outputs.run == 'yes' && always()
         uses: actions/upload-artifact@v7
         with:
           name: demo-assets
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 14
           path: |
             assets/*.svg
@@ -233,6 +243,7 @@ jobs:
             demos/out/stderr.log
             demos/out/window.env
             demos/out/shots/*.ansi
+            demos/out/raw/**
 
       - name: Teardown
         if: always() && steps.gate.outputs.run == 'yes'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,14 @@ jobs:
       - name: Test release stamp checker
         run: python3 devel/scripts/test_release_stamp.py -v
 
+      # Lives here, not in `test`, on purpose: this suite parses test.yml, and
+      # a job inside that workflow's matrix cannot be trusted to report on the
+      # parseability of the file it was scheduled from. docs-lint needs no
+      # database and runs on every event, so a break is loud and immediate.
+      # Without this the suite had no gate at all and #243 reached main.
+      - name: Test CI step extractor
+        run: python3 devel/scripts/test_ci_step_script.py -v
+
       - name: Verify release tag matches payload stamp
         if: >-
           github.ref_type == 'tag' ||

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Test mandatory-job and demo guards
         run: python3 devel/scripts/test_ci_guards.py -v
 
+      - name: Test interactive SQL runner
+        run: python3 devel/scripts/test_run_with_pty.py -v
+
       - name: Verify release tag matches payload stamp
         if: >-
           github.ref_type == 'tag' ||
@@ -510,10 +513,9 @@ jobs:
           # committable after the first error.
           printf '\\set ON_ERROR_ROLLBACK on\n\\i %s\ncommit;\n\\q\n' \
             "${install_path}" |
-            script --quiet --return \
-              --command \
-              "psql --no-psqlrc --host=localhost --username=postgres --dbname=ash_atomic_failure_test" \
-              /dev/null \
+            python3 devel/scripts/run_with_pty.py \
+              psql --no-psqlrc --host=localhost --username=postgres \
+              --dbname=ash_atomic_failure_test \
               >"${failure_log_dir}/on-error-rollback.log" 2>&1
           if ! grep -Fq \
               "forced mid-install failure at ash.rollup_1m" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -511,12 +511,21 @@ jobs:
           # A caller's interactive psql configuration must not turn each
           # installer statement into a savepoint and make a partial install
           # committable after the first error.
+          set +e
           printf '\\set ON_ERROR_ROLLBACK on\n\\i %s\ncommit;\n\\q\n' \
             "${install_path}" |
             python3 devel/scripts/run_with_pty.py \
+              --ready="ash_atomic_failure_test=# " \
               psql --no-psqlrc --host=localhost --username=postgres \
               --dbname=ash_atomic_failure_test \
               >"${failure_log_dir}/on-error-rollback.log" 2>&1
+          interactive_rc=$?
+          set -e
+          if (( interactive_rc != 0 )); then
+            cat "${failure_log_dir}/on-error-rollback.log" >&2
+            echo "interactive installer exit code: ${interactive_rc}" >&2
+            exit 1
+          fi
           if ! grep -Fq \
               "forced mid-install failure at ash.rollup_1m" \
               "${failure_log_dir}/on-error-rollback.log"; then
@@ -8886,7 +8895,8 @@ jobs:
   # One stable check name for the branch ruleset's required status checks.
   # The matrix contexts embed PG versions ("test (19beta3, on)") and change
   # every release, so requiring them by name would rot. Fails if any needed
-  # job failed or was cancelled; a job that never ran leaves this pending.
+  # job does not report success, including skipped/cancelled jobs; a workflow
+  # that never starts leaves this pending.
   ci-required:
     if: always()
     needs: [docs-lint, test]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -138,8 +138,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # PG19 is still beta, so the official image tag is 19beta2 until GA.
-        postgres: [14, 15, 16, 17, 18, 19beta2]
+        # PG19 is still beta, so the official image tag is 19beta3 until GA.
+        postgres: [14, 15, 16, 17, 18, 19beta3]
         # Quoted so YAML doesn't coerce on/off into booleans — GitHub Actions
         # compares these as strings in the step-level `if`/conditionals.
         cron: ["on"]
@@ -8882,7 +8882,7 @@ jobs:
           echo "All tests passed for PostgreSQL $PG_MAJOR (pg_cron=$CRON)"
 
   # One stable check name for the branch ruleset's required status checks.
-  # The matrix contexts embed PG versions ("test (19beta2, on)") and change
+  # The matrix contexts embed PG versions ("test (19beta3, on)") and change
   # every release, so requiring them by name would rot. Fails if any needed
   # job failed or was cancelled; a job that never ran leaves this pending.
   ci-required:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Test CI step extractor
         run: python3 devel/scripts/test_ci_step_script.py -v
 
+      - name: Test mandatory-job and demo guards
+        run: python3 devel/scripts/test_ci_guards.py -v
+
       - name: Verify release tag matches payload stamp
         if: >-
           github.ref_type == 'tag' ||
@@ -131,6 +134,7 @@ jobs:
           fi
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
@@ -8853,6 +8857,22 @@ jobs:
 
           assert_ash_absent
 
+      - name: Collect PostgreSQL failure log
+        if: failure()
+        env:
+          POSTGRES_CONTAINER: ${{ job.services.postgres.id }}
+        run: |
+          docker logs "$POSTGRES_CONTAINER" > postgres-failure.log 2>&1
+
+      - name: Upload PostgreSQL failure log
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: postgres-failure-${{ matrix.postgres }}-${{ matrix.cron }}
+          path: postgres-failure.log
+          if-no-files-found: error
+          retention-days: 14
+
       - name: Final summary
         env:
           PGPASSWORD: postgres
@@ -8869,16 +8889,10 @@ jobs:
     if: always()
     needs: [docs-lint, test]
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Assert every required job succeeded
         env:
-          RESULTS: ${{ join(needs.*.result, ' ') }}
-        run: |
-          set -euo pipefail
-          echo "needed job results: ${RESULTS}"
-          for r in ${RESULTS}; do
-            case "${r}" in
-              success|skipped) ;;
-              *) echo "a required job reported: ${r}" >&2; exit 1 ;;
-            esac
-          done
+          NEEDS_JSON: ${{ toJSON(needs) }}
+        run: python3 devel/scripts/ci_guards.py required-jobs

--- a/.github/workflows/workflow-size.yml
+++ b/.github/workflows/workflow-size.yml
@@ -14,9 +14,9 @@ name: Workflow size
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/**']
   workflow_dispatch:
 
 permissions:
@@ -25,6 +25,7 @@ permissions:
 jobs:
   size:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 

--- a/devel/docker/Dockerfile
+++ b/devel/docker/Dockerfile
@@ -1,7 +1,7 @@
 # pg_cron-capable PostgreSQL image for the release gate.
 #
 # Keep the image tag separate from PostgreSQL's numeric major. In particular,
-# postgres:19beta2 exports PG_MAJOR=19, which is the value required by the
+# postgres:19beta3 exports PG_MAJOR=19, which is the value required by the
 # postgresql-19-cron package name.
 ARG POSTGRES_TAG=18
 FROM postgres:${POSTGRES_TAG}

--- a/devel/scripts/ci_guards.py
+++ b/devel/scripts/ci_guards.py
@@ -11,7 +11,7 @@ def require_jobs(needs: object) -> None:
     """Both mandatory jobs must exist and have completed successfully."""
     if not isinstance(needs, dict):
         raise ValueError("required-job evidence must be an object")
-    for name in ("docs-lint", "test"):
+    for name in dict.fromkeys(("docs-lint", "test", *needs)):
         job = needs.get(name)
         if not isinstance(job, dict) or job.get("result") != "success":
             raise ValueError(f"mandatory job {name!r} did not succeed: {job!r}")

--- a/devel/scripts/ci_guards.py
+++ b/devel/scripts/ci_guards.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Fail closed on missing mandatory CI evidence and select live demo inputs."""
+
+import argparse
+import json
+import os
+import sys
+
+
+def require_jobs(needs: object) -> None:
+    """Both mandatory jobs must exist and have completed successfully."""
+    if not isinstance(needs, dict):
+        raise ValueError("required-job evidence must be an object")
+    for name in ("docs-lint", "test"):
+        job = needs.get(name)
+        if not isinstance(job, dict) or job.get("result") != "success":
+            raise ValueError(f"mandatory job {name!r} did not succeed: {job!r}")
+
+
+def demo_needed(event: str, paths: list[str]) -> bool:
+    """Changes to the candidate SQL and its consumers need a fresh capture."""
+    if event in ("schedule", "workflow_dispatch"):
+        return True
+    if event not in ("push", "pull_request"):
+        raise ValueError(f"unexpected demo event: {event!r}")
+    prefixes = ("devel/", "demos/", "sql/", "examples/", "assets/")
+    exact = {"README.md", ".github/workflows/demo.yml"}
+    return any(path in exact or path.startswith(prefixes) for path in paths)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("command", choices=("required-jobs", "demo-needed"))
+    parser.add_argument("--event", default=os.environ.get("GITHUB_EVENT_NAME", ""))
+    args = parser.parse_args()
+    try:
+        if args.command == "required-jobs":
+            require_jobs(json.loads(os.environ.get("NEEDS_JSON", "null")))
+            print("All mandatory jobs succeeded")
+        else:
+            paths = sys.stdin.read().splitlines()
+            print("yes" if demo_needed(args.event, paths) else "no")
+    except (ValueError, TypeError) as error:
+        print(f"CI evidence rejected: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/devel/scripts/ci_step_script.py
+++ b/devel/scripts/ci_step_script.py
@@ -240,7 +240,8 @@ def _deindent_literal_block(
     if not nonblank_indents:
         return ""
 
-    content_indent = min(nonblank_indents)
+    # YAML infers literal indentation from its first non-empty line.
+    content_indent = nonblank_indents[0]
     if content_indent <= parent_indent:
         raise WorkflowError(
             f"line {run_line}: run block content must be indented more than "

--- a/devel/scripts/ci_step_script.py
+++ b/devel/scripts/ci_step_script.py
@@ -210,13 +210,23 @@ def _deindent_literal_block(
         indentation = _block_scalar_indent(lines[idx], line_number=idx + 1)
         if indentation is None:
             continue
-        if indentation is not None and indentation <= parent_indent:
+        if indentation <= parent_indent:
             block_end = idx
             break
         if first_content_indent is None:
             first_content_indent = indentation
         elif (indentation < first_content_indent
               and lines[idx].lstrip().startswith("#")):
+            for later in range(idx + 1, end):
+                later_indent = _block_scalar_indent(lines[later], line_number=later + 1)
+                if later_indent is None or lines[later].lstrip().startswith("#"):
+                    continue
+                if later_indent <= parent_indent:
+                    break
+                raise WorkflowError(
+                    f"line {later + 1}: content resumes after a dedented comment "
+                    f"terminated the run block at line {run_line}"
+                )
             block_end = idx
             break
 

--- a/devel/scripts/ci_step_script.py
+++ b/devel/scripts/ci_step_script.py
@@ -48,15 +48,10 @@ def _without_eol(line: str) -> str:
 
 def _indent(line: str, *, line_number: int) -> int | None:
     """Return structural indentation, ignoring blank and comment-only lines."""
-    text = _without_eol(line)
-    leading = text[: len(text) - len(text.lstrip(" \t"))]
-    if "\t" in leading:
-        raise WorkflowError(
-            f"line {line_number}: tabs are not valid YAML indentation"
-        )
-    if not text.strip() or text.lstrip().startswith("#"):
+    indentation = _block_scalar_indent(line, line_number=line_number)
+    if line.lstrip().startswith("#"):
         return None
-    return len(leading)
+    return indentation
 
 
 def _block_scalar_indent(line: str, *, line_number: int) -> int | None:
@@ -64,9 +59,8 @@ def _block_scalar_indent(line: str, *, line_number: int) -> int | None:
 
     Unlike :func:`_indent`, a comment line reports its real indentation. Inside
     a literal block a ``#`` line indented at or beyond the content is ordinary
-    content (a shell comment), but one indented back to the parent's level ends
-    the scalar, exactly as YAML specifies. Treating it as content instead makes
-    the block appear to start at the comment's indentation.
+    content (a shell comment). The literal-block reader uses the first content
+    line to recognize a later dedented YAML comment as a block terminator.
     """
     text = _without_eol(line)
     leading = text[: len(text) - len(text.lstrip(" \t"))]
@@ -211,9 +205,18 @@ def _deindent_literal_block(
     run_line: int,
 ) -> str:
     block_end = end
+    first_content_indent = None
     for idx in range(start, end):
         indentation = _block_scalar_indent(lines[idx], line_number=idx + 1)
+        if indentation is None:
+            continue
         if indentation is not None and indentation <= parent_indent:
+            block_end = idx
+            break
+        if first_content_indent is None:
+            first_content_indent = indentation
+        elif (indentation < first_content_indent
+              and lines[idx].lstrip().startswith("#")):
             block_end = idx
             break
 

--- a/devel/scripts/ci_step_script.py
+++ b/devel/scripts/ci_step_script.py
@@ -59,6 +59,26 @@ def _indent(line: str, *, line_number: int) -> int | None:
     return len(leading)
 
 
+def _block_scalar_indent(line: str, *, line_number: int) -> int | None:
+    """Indentation for block-scalar termination; None only for blank lines.
+
+    Unlike :func:`_indent`, a comment line reports its real indentation. Inside
+    a literal block a ``#`` line indented at or beyond the content is ordinary
+    content (a shell comment), but one indented back to the parent's level ends
+    the scalar, exactly as YAML specifies. Treating it as content instead makes
+    the block appear to start at the comment's indentation.
+    """
+    text = _without_eol(line)
+    leading = text[: len(text) - len(text.lstrip(" \t"))]
+    if "\t" in leading:
+        raise WorkflowError(
+            f"line {line_number}: tabs are not valid YAML indentation"
+        )
+    if not text.strip():
+        return None
+    return len(leading)
+
+
 def _is_mapping_key(line: str, indent: int, key: str) -> bool:
     text = _without_eol(line)
     prefix = " " * indent + key + ":"
@@ -192,7 +212,7 @@ def _deindent_literal_block(
 ) -> str:
     block_end = end
     for idx in range(start, end):
-        indentation = _indent(lines[idx], line_number=idx + 1)
+        indentation = _block_scalar_indent(lines[idx], line_number=idx + 1)
         if indentation is not None and indentation <= parent_indent:
             block_end = idx
             break

--- a/devel/scripts/release_gate.sh
+++ b/devel/scripts/release_gate.sh
@@ -2,8 +2,8 @@
 # Run the pg_ash release-gate surfaces against disposable Docker PostgreSQL.
 #
 # Usage:
-#   devel/scripts/release_gate.sh <14|15|16|17|18|19beta2> [surface|all]
-#   PG_MAJORS="14 15 16 17 18 19beta2" devel/scripts/release_gate.sh all
+#   devel/scripts/release_gate.sh <14|15|16|17|18|19beta3> [surface|all]
+#   PG_MAJORS="14 15 16 17 18 19beta3" devel/scripts/release_gate.sh all
 #
 # The GitHub Actions workflow remains the canonical source for the large
 # regression and upgrade assertion sets. ci_step_script.py selects its exact
@@ -20,13 +20,13 @@ readonly REPO_ROOT
 readonly DOCKERFILE="${REPO_ROOT}/devel/docker/Dockerfile"
 readonly CHAIN_HELPER="${SCRIPT_DIR}/ash_sql_chain.py"
 readonly CI_STEP_HELPER="${SCRIPT_DIR}/ci_step_script.py"
-readonly DEFAULT_MAJORS="14 15 16 17 18 19beta2"
+readonly DEFAULT_MAJORS="14 15 16 17 18 19beta3"
 readonly IMAGE_REPOSITORY="pg-ash-release-gate"
 readonly POSTGRES_USER="postgres"
 readonly POSTGRES_DATABASE="postgres"
 readonly POSTGRES_PASSWORD="pg_ash_release_gate"
 
-readonly -a SUPPORTED_MAJORS=(14 15 16 17 18 19beta2)
+readonly -a SUPPORTED_MAJORS=(14 15 16 17 18 19beta3)
 readonly -a SURFACES=(
   fresh-install
   upgrade-chain
@@ -58,7 +58,7 @@ Usage:
   devel/scripts/release_gate.sh all [surface|all]
 
 Supported majors:
-  14 15 16 17 18 19beta2
+  14 15 16 17 18 19beta3
 
 Supported surfaces:
   fresh-install

--- a/devel/scripts/release_gate.sh
+++ b/devel/scripts/release_gate.sh
@@ -13,6 +13,11 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
+if ((BASH_VERSINFO[0] < 4)); then
+  echo 'release_gate: Bash 4+ is required; on macOS use Homebrew bash.' >&2
+  exit 2
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SCRIPT_DIR
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
@@ -865,7 +870,7 @@ run_all_majors() {
     child_summary="${parent_output}/pg_${safe_major}.tsv"
     RELEASE_GATE_OUTPUT_DIR="${child_output}" \
       RELEASE_GATE_SUMMARY="${child_summary}" \
-      "${BASH_SOURCE[0]}" "${major}" "${selector}" \
+      "${BASH}" "${BASH_SOURCE[0]}" "${major}" "${selector}" \
       >"${parent_output}/worker_${safe_major}.log" 2>&1 &
     pid=$!
     active_pids+=("${pid}")

--- a/devel/scripts/release_gate.sh
+++ b/devel/scripts/release_gate.sh
@@ -143,7 +143,6 @@ require_commands() {
     pg_isready
     psql
     python3
-    script
     sed
     sort
   )
@@ -373,7 +372,7 @@ run_ci_selection() {
     # Parallel major workers must not share the workflow's historical /tmp
     # filenames. This is the only transformation made to canonical step bodies.
     step_body="${step_body//\/tmp\//${surface_temp_dir}/}"
-    if ! bash \
+    if ! "${BASH}" \
       --noprofile \
       --norc \
       -e \

--- a/devel/scripts/run_with_pty.py
+++ b/devel/scripts/run_with_pty.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Run a finite input script on a pseudo-terminal, preserving command status."""
+
+import errno
+import os
+import pty
+import subprocess
+import sys
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        raise SystemExit("usage: run_with_pty.py command [argument ...]")
+    # Fixture input is finite and ends with the command's explicit exit command.
+    # Avoid pty.spawn: its stdin relay can hang on a pipe with BSD terminals.
+    source = sys.stdin.buffer.read()
+    master, slave = pty.openpty()
+    child = subprocess.Popen(sys.argv[1:], stdin=slave, stdout=slave, stderr=slave)
+    os.close(slave)
+    try:
+        while source:
+            source = source[os.write(master, source):]
+        while True:
+            try:
+                output = os.read(master, 65536)
+            except OSError as error:
+                if error.errno == errno.EIO:
+                    break
+                raise
+            if not output:
+                break
+            sys.stdout.buffer.write(output)
+            sys.stdout.buffer.flush()
+    finally:
+        os.close(master)
+    raise SystemExit(child.wait())

--- a/devel/scripts/run_with_pty.py
+++ b/devel/scripts/run_with_pty.py
@@ -1,36 +1,94 @@
 #!/usr/bin/env python3
-"""Run a finite input script on a pseudo-terminal, preserving command status."""
+"""Run a bounded interactive fixture, preserving terminal output and status."""
 
+import argparse
 import errno
 import os
 import pty
+import select
+import signal
 import subprocess
 import sys
+import termios
+import time
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--timeout", type=float, default=120)
+    parser.add_argument("--ready", help="wait for this output before sending input")
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+    if not args.command or args.timeout <= 0:
+        parser.error("a command and a positive timeout are required")
+
+    source = sys.stdin.buffer.read()
+    master, slave = pty.openpty()
+    # Canonical terminals need VEOF; closing the master would hang up the
+    # child before its final output/status could be collected.
+    eof = termios.tcgetattr(slave)[6][termios.VEOF]
+    source += 2 * (eof if isinstance(eof, bytes) else bytes([eof]))
+    child = subprocess.Popen(args.command, stdin=slave, stdout=slave, stderr=slave,
+                             start_new_session=True)
+    os.close(slave)
+    os.set_blocking(master, False)
+    ready = not args.ready
+    marker = args.ready.encode() if args.ready else b""
+    recent = b""
+    deadline = time.monotonic() + args.timeout
+    timed_out = False
+    try:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                timed_out = True
+                break
+            readable, writable, _ = select.select(
+                [master], [master] if ready and source else [], [], min(remaining, 0.1)
+            )
+            if readable:
+                try:
+                    output = os.read(master, 65536)
+                except OSError as error:
+                    if error.errno == errno.EIO:
+                        break
+                    if error.errno == errno.EAGAIN:
+                        continue
+                    raise
+                if not output:
+                    break
+                sys.stdout.buffer.write(output)
+                sys.stdout.buffer.flush()
+                if not ready:
+                    recent += output
+                    ready = marker in recent
+                    recent = recent[-len(marker):]
+            if writable:
+                try:
+                    source = source[os.write(master, source[:4096]):]
+                except OSError as error:
+                    if error.errno == errno.EIO:
+                        source = b""  # Child exited early; collect its status below.
+                    elif error.errno != errno.EAGAIN:
+                        raise
+    finally:
+        os.close(master)
+    if not timed_out:
+        try:
+            return child.wait(timeout=max(0.01, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired:
+            timed_out = True
+    print(f"interactive fixture timed out after {args.timeout:g}s; "
+          "output above is preserved", file=sys.stderr, flush=True)
+    if child.poll() is None:
+        os.killpg(child.pid, signal.SIGTERM)
+    try:
+        child.wait(timeout=2)
+    except subprocess.TimeoutExpired:
+        os.killpg(child.pid, signal.SIGKILL)
+        child.wait()
+    return 124
 
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        raise SystemExit("usage: run_with_pty.py command [argument ...]")
-    # Fixture input is finite and ends with the command's explicit exit command.
-    # Avoid pty.spawn: its stdin relay can hang on a pipe with BSD terminals.
-    source = sys.stdin.buffer.read()
-    master, slave = pty.openpty()
-    child = subprocess.Popen(sys.argv[1:], stdin=slave, stdout=slave, stderr=slave)
-    os.close(slave)
-    try:
-        while source:
-            source = source[os.write(master, source):]
-        while True:
-            try:
-                output = os.read(master, 65536)
-            except OSError as error:
-                if error.errno == errno.EIO:
-                    break
-                raise
-            if not output:
-                break
-            sys.stdout.buffer.write(output)
-            sys.stdout.buffer.flush()
-    finally:
-        os.close(master)
-    raise SystemExit(child.wait())
+    raise SystemExit(main())

--- a/devel/scripts/test_ci_guards.py
+++ b/devel/scripts/test_ci_guards.py
@@ -23,6 +23,16 @@ class RequiredJobsTests(unittest.TestCase):
                     with self.assertRaises(ValueError):
                         ci_guards.require_jobs(needs)
 
+    def test_additional_dependencies_must_also_succeed(self):
+        for result in ("success", "skipped", "failure"):
+            needs = {name: {"result": "success"} for name in ("docs-lint", "test")}
+            needs["extra"] = {"result": result}
+            if result == "success":
+                ci_guards.require_jobs(needs)
+            else:
+                with self.assertRaises(ValueError):
+                    ci_guards.require_jobs(needs)
+
     def test_missing_and_malformed_evidence_do_not_pass(self):
         for needs in ({}, {"test": {"result": "success"}}, None, [],
                       {"docs-lint": {}, "test": {"result": "success"}}):
@@ -37,15 +47,20 @@ class DemoDecisionTests(unittest.TestCase):
                      "demos/fixtures/shape.tsv", "sql/ash-install.sql",
                      "README.md", ".github/workflows/demo.yml",
                      "examples/llm-investigation.sql"):
-            with self.subTest(path=path):
-                self.assertTrue(ci_guards.demo_needed("pull_request", [path]))
+            for event in ("push", "pull_request"):
+                with self.subTest(path=path, event=event):
+                    self.assertTrue(ci_guards.demo_needed(event, [path]))
 
     def test_manual_and_nightly_always_capture(self):
         for event in ("workflow_dispatch", "schedule"):
             self.assertTrue(ci_guards.demo_needed(event, []))
 
     def test_unrelated_changes_can_skip_expensive_capture(self):
-        self.assertFalse(ci_guards.demo_needed("pull_request", ["LICENSE"]))
+        for event in ("push", "pull_request"):
+            for paths in ([], [""], ["LICENSE"], ["docs/CI.md"],
+                          [".github/workflows/test.yml"], ["devel"]):
+                with self.subTest(event=event, paths=paths):
+                    self.assertFalse(ci_guards.demo_needed(event, paths))
 
     def test_unknown_event_fails_closed(self):
         with self.assertRaises(ValueError):

--- a/devel/scripts/test_ci_guards.py
+++ b/devel/scripts/test_ci_guards.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Regression tests for mandatory-job and live-demo CI decisions."""
+
+import unittest
+
+import ci_guards
+
+
+class RequiredJobsTests(unittest.TestCase):
+    def test_both_required_jobs_succeeded(self):
+        ci_guards.require_jobs({
+            "docs-lint": {"result": "success"},
+            "test": {"result": "success"},
+        })
+
+    def test_skipped_failed_cancelled_and_unknown_do_not_pass(self):
+        for result in ("skipped", "failure", "cancelled", "pending", "", None):
+            for job in ("docs-lint", "test"):
+                with self.subTest(result=result, job=job):
+                    needs = {name: {"result": "success"}
+                             for name in ("docs-lint", "test")}
+                    needs[job] = {"result": result}
+                    with self.assertRaises(ValueError):
+                        ci_guards.require_jobs(needs)
+
+    def test_missing_and_malformed_evidence_do_not_pass(self):
+        for needs in ({}, {"test": {"result": "success"}}, None, [],
+                      {"docs-lint": {}, "test": {"result": "success"}}):
+            with self.subTest(needs=needs), self.assertRaises(ValueError):
+                ci_guards.require_jobs(needs)
+
+
+class DemoDecisionTests(unittest.TestCase):
+    def test_development_installer_and_discovery_trigger_real_capture(self):
+        for path in ("devel/sql/ash-install.sql",
+                     "devel/scripts/ash_sql_chain.py",
+                     "demos/fixtures/shape.tsv", "sql/ash-install.sql",
+                     "README.md", ".github/workflows/demo.yml",
+                     "examples/llm-investigation.sql"):
+            with self.subTest(path=path):
+                self.assertTrue(ci_guards.demo_needed("pull_request", [path]))
+
+    def test_manual_and_nightly_always_capture(self):
+        for event in ("workflow_dispatch", "schedule"):
+            self.assertTrue(ci_guards.demo_needed(event, []))
+
+    def test_unrelated_changes_can_skip_expensive_capture(self):
+        self.assertFalse(ci_guards.demo_needed("pull_request", ["LICENSE"]))
+
+    def test_unknown_event_fails_closed(self):
+        with self.assertRaises(ValueError):
+            ci_guards.demo_needed("unexpected", [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/devel/scripts/test_ci_step_script.py
+++ b/devel/scripts/test_ci_step_script.py
@@ -154,6 +154,123 @@ class WorkflowParserTests(unittest.TestCase):
             b"second\0echo done\n\0",
         )
 
+    # ---- issue #243: a dedented comment must end a run block ----
+
+    # The workflow is fine; the parser was not. Before the fix the reader
+    # skipped comment lines when looking for the end of a `run: |` block, so a
+    # comment at job indentation was swallowed as block content, dragged the
+    # computed content indentation down to its own, and raised. Any step that
+    # is the last one in its job trips this the moment another job follows.
+    DEDENTED_COMMENT = """\
+jobs:
+  test:
+    steps:
+      - name: Last step
+        run: |
+          echo hi
+%s
+  other-job:
+    runs-on: ubuntu-latest
+"""
+
+    def test_dedented_comment_terminates_run_block(self) -> None:
+        text = self.DEDENTED_COMMENT % (
+            "  # One stable check name for the branch ruleset."
+        )
+        steps = self.parse(text)
+        self.assertEqual([step.name for step in steps], ["Last step"])
+        # Exact body: the comment must not leak in, and nothing may be trimmed.
+        self.assertEqual(steps[0].run, "echo hi\n")
+
+    def test_dedented_comment_and_no_comment_agree(self) -> None:
+        """The comment is the only difference, so the body must be identical."""
+        with_comment = self.parse(self.DEDENTED_COMMENT % "  # trailing note")
+        without_comment = self.parse(self.DEDENTED_COMMENT % "")
+        self.assertEqual(
+            [step.run for step in with_comment],
+            [step.run for step in without_comment],
+        )
+
+    def test_comment_indented_into_the_block_stays_content(self) -> None:
+        """A shell comment inside `run: |` is content, not a terminator.
+
+        This is the over-correction guard: terminating on any comment at all
+        would silently truncate most real steps in this repository.
+        """
+        text = """\
+jobs:
+  test:
+    steps:
+      - name: Shell comments
+        run: |
+          # explain the next line
+          echo hi
+            # deeper still
+          echo bye
+
+  other-job:
+    runs-on: ubuntu-latest
+"""
+        steps = self.parse(text)
+        self.assertEqual(
+            steps[0].run,
+            "# explain the next line\necho hi\n  # deeper still\necho bye\n",
+        )
+
+    def test_blank_lines_inside_a_block_are_preserved(self) -> None:
+        text = """\
+jobs:
+  test:
+    steps:
+      - name: Blanks
+        run: |
+          echo one
+
+          echo two
+  # dedented comment right after a blank-containing block
+  other-job:
+    runs-on: ubuntu-latest
+"""
+        steps = self.parse(text)
+        self.assertEqual(steps[0].run, "echo one\n\necho two\n")
+
+    def test_under_indented_content_is_not_newly_tolerated(self) -> None:
+        """Characterization: the fix must not loosen anything for content.
+
+        Note on issue #243's wording. It asks that "a genuinely under-indented
+        content line still raises". Measured against the pre-fix parser, it
+        never did: a non-comment line at or below the block's parent
+        indentation has always simply ended the scalar, and the
+        `content_indent <= parent_indent` guard was only ever reachable through
+        the comment path -- which is the bug itself. Rather than invent a new
+        error to satisfy the wording, this pins the pre-existing behaviour so a
+        later change cannot quietly relax it: the block ends at the dedented
+        line and that line's text never becomes part of the body.
+        """
+        text = """\
+jobs:
+  test:
+    steps:
+      - name: Bad indent
+        run: |
+          echo one
+      echo two
+  other-job:
+    runs-on: ubuntu-latest
+"""
+        steps = self.parse(text)
+        self.assertEqual(steps[0].run, "echo one\n")
+        self.assertNotIn("echo two", steps[0].run or "")
+
+    def test_tabs_are_still_rejected_when_ending_a_block(self) -> None:
+        text = (
+            "jobs:\n  test:\n    steps:\n      - name: Tabbed\n"
+            "        run: |\n          echo hi\n\t# tabbed comment\n"
+        )
+        with self.assertRaises(ci_step_script.WorkflowError) as caught:
+            self.parse(text)
+        self.assertIn("tabs are not valid YAML indentation", str(caught.exception))
+
     def test_current_workflow_integration(self) -> None:
         steps = ci_step_script.parse_workflow(ci_step_script.DEFAULT_WORKFLOW)
         names = [step.name for step in steps]

--- a/devel/scripts/test_ci_step_script.py
+++ b/devel/scripts/test_ci_step_script.py
@@ -281,6 +281,15 @@ jobs:
         steps = self.parse(text)
         self.assertEqual(steps[0].run, "echo one\n")
 
+    def test_content_after_intermediate_comment_fails_loudly(self) -> None:
+        text = (
+            "jobs:\n  test:\n    steps:\n      - name: Bad boundary\n"
+            "        run: |\n          echo one\n"
+            "         # terminates scalar\n          echo two\n"
+        )
+        with self.assertRaisesRegex(ci_step_script.WorkflowError, "content resumes"):
+            self.parse(text)
+
     def test_current_workflow_integration(self) -> None:
         steps = ci_step_script.parse_workflow(ci_step_script.DEFAULT_WORKFLOW)
         names = [step.name for step in steps]

--- a/devel/scripts/test_ci_step_script.py
+++ b/devel/scripts/test_ci_step_script.py
@@ -290,6 +290,24 @@ jobs:
         with self.assertRaisesRegex(ci_step_script.WorkflowError, "content resumes"):
             self.parse(text)
 
+    def test_noncomment_below_content_indent_is_rejected(self) -> None:
+        text = (
+            "jobs:\n  test:\n    steps:\n      - name: Bad content indent\n"
+            "        run: |\n          echo one\n         echo two\n"
+        )
+        with self.assertRaisesRegex(
+            ci_step_script.WorkflowError, "line 7: inconsistent indentation"
+        ):
+            self.parse(text)
+
+    def test_deeper_shell_content_keeps_its_indentation(self) -> None:
+        text = (
+            "jobs:\n  test:\n    steps:\n      - name: Shell indentation\n"
+            "        run: |\n          if true; then\n"
+            "            echo one\n          fi\n"
+        )
+        self.assertEqual(self.parse(text)[0].run, "if true; then\n  echo one\nfi\n")
+
     def test_current_workflow_integration(self) -> None:
         steps = ci_step_script.parse_workflow(ci_step_script.DEFAULT_WORKFLOW)
         names = [step.name for step in steps]

--- a/devel/scripts/test_ci_step_script.py
+++ b/devel/scripts/test_ci_step_script.py
@@ -271,6 +271,16 @@ jobs:
             self.parse(text)
         self.assertIn("tabs are not valid YAML indentation", str(caught.exception))
 
+    def test_comment_below_content_indent_ends_literal_block(self) -> None:
+        text = (
+            "jobs:\n  test:\n    steps:\n      - name: Comment boundary\n"
+            "        run: |\n          echo one\n"
+            "         # YAML comment below the content indentation\n"
+            "  other-job:\n    runs-on: ubuntu-latest\n"
+        )
+        steps = self.parse(text)
+        self.assertEqual(steps[0].run, "echo one\n")
+
     def test_current_workflow_integration(self) -> None:
         steps = ci_step_script.parse_workflow(ci_step_script.DEFAULT_WORKFLOW)
         names = [step.name for step in steps]

--- a/devel/scripts/test_run_with_pty.py
+++ b/devel/scripts/test_run_with_pty.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Prove the interactive test runner supplies a TTY and propagates failures."""
+
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+
+
+class PtyRunnerTests(unittest.TestCase):
+    def test_terminal_input_and_exit_status(self):
+        runner = Path(__file__).with_name("run_with_pty.py")
+        for code in (0, 7):
+            with self.subTest(code=code):
+                result = subprocess.run(
+                    [sys.executable, str(runner), sys.executable, "-c",
+                     "import sys; assert sys.stdin.isatty(); "
+                     "assert input() == 'probe'; print('TTY_OK'); "
+                     f"raise SystemExit({code})"],
+                    input=b"probe\n", capture_output=True, timeout=10,
+                )
+                self.assertEqual(result.returncode, code, result.stderr)
+                self.assertIn(b"TTY_OK", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/devel/scripts/test_run_with_pty.py
+++ b/devel/scripts/test_run_with_pty.py
@@ -1,26 +1,74 @@
 #!/usr/bin/env python3
-"""Prove the interactive test runner supplies a TTY and propagates failures."""
+"""Exercise native terminal setup, EOF, backpressure, status, and time bounds."""
 
 from pathlib import Path
 import subprocess
 import sys
 import unittest
 
+RUNNER = Path(__file__).with_name("run_with_pty.py")
+
+
+def run_child(code: str, source: bytes = b"", timeout: str = "5", ready=None):
+    return subprocess.run(
+        [sys.executable, str(RUNNER), "--timeout", timeout,
+         *(["--ready", ready] if ready else []), sys.executable, "-c", code],
+        input=source, capture_output=True, timeout=10,
+    )
+
 
 class PtyRunnerTests(unittest.TestCase):
     def test_terminal_input_and_exit_status(self):
-        runner = Path(__file__).with_name("run_with_pty.py")
         for code in (0, 7):
             with self.subTest(code=code):
-                result = subprocess.run(
-                    [sys.executable, str(runner), sys.executable, "-c",
-                     "import sys; assert sys.stdin.isatty(); "
-                     "assert input() == 'probe'; print('TTY_OK'); "
-                     f"raise SystemExit({code})"],
-                    input=b"probe\n", capture_output=True, timeout=10,
+                result = run_child(
+                    "import sys; assert sys.stdin.isatty(); "
+                    "assert input() == 'probe'; print('TTY_OK'); "
+                    f"raise SystemExit({code})", b"probe\n"
                 )
                 self.assertEqual(result.returncode, code, result.stderr)
                 self.assertIn(b"TTY_OK", result.stdout)
+
+    def test_readiness_survives_terminal_initialization_flush(self):
+        result = run_child(
+            "import sys, termios, time; time.sleep(.1); "
+            "termios.tcflush(sys.stdin.fileno(), termios.TCIFLUSH); "
+            "print('READY>', flush=True); assert input() == 'probe'; "
+            "print('READY_OK')", b"probe\n", ready="READY>"
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(b"READY_OK", result.stdout)
+
+    def test_eof_ends_a_reader_without_an_explicit_exit_command(self):
+        for source in (b"probe\n", b"probe"):
+            with self.subTest(source=source):
+                result = run_child(
+                    "import sys; print('EOF_OK', len(sys.stdin.read()))", source
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn(f"EOF_OK {len(source)}".encode(), result.stdout)
+
+    def test_large_chatty_input_does_not_deadlock(self):
+        result = run_child(
+            "import sys; n = 0\n"
+            "for line in sys.stdin:\n"
+            " n += 1; print(line, end='', flush=True)\n"
+            "print('ALL_INPUT', n)", (b"x" * 100 + b"\n") * 2000
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn(b"ALL_INPUT 2000", result.stdout)
+
+    def test_early_child_failure_preserves_status(self):
+        result = run_child("raise SystemExit(9)", b"unused\n" * 10000)
+        self.assertEqual(result.returncode, 9, result.stderr)
+        self.assertNotIn(b"Traceback", result.stderr)
+
+    def test_timeout_is_bounded_and_keeps_output(self):
+        result = run_child("import time; print('BEFORE_WAIT', flush=True); "
+                           "time.sleep(30)", timeout="0.3")
+        self.assertEqual(result.returncode, 124, result.stderr)
+        self.assertIn(b"BEFORE_WAIT", result.stdout)
+        self.assertIn(b"timed out", result.stderr)
 
 
 if __name__ == "__main__":

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -28,8 +28,9 @@ get CodeQL onto release branches, and is out of scope here.
 ## The `ci-required` aggregator
 
 `test.yml` ends with a `ci-required` job: `if: always()`, `needs: [docs-lint,
-test]`. Both named dependencies must exist and report `success`; skipped,
-failed, cancelled and malformed/missing evidence fail closed.
+test]`. Both named dependencies must exist, and every dependency supplied in
+`needs` must report `success`; skipped, failed, cancelled and malformed/missing
+evidence fail closed.
 `devel/scripts/test_ci_guards.py` tests those cases and the real-demo path
 selection. The stable check runs even after a dependency fails.
 
@@ -96,8 +97,8 @@ Two behaviours to keep in mind:
 - **Fork PRs need workflow approval.** With "require approval for all external
   contributors", a fork PR's workflows do not start until a maintainer
   approves them, so the required checks sit pending and the PR cannot be
-  merged. That is the hole being closed: today those PRs are mergeable with
-  nothing having run.
+  merged. Before required checks were enforced, those PRs could merge without
+  completed workflows.
 
 ### `strict_required_status_checks_policy`
 
@@ -129,3 +130,7 @@ verified on 2026-09-04. Update the hosted matrix and local gate defaults togethe
 The Docker release runner requires Bash 4+ (Homebrew Bash on macOS). It
 rejects the system Bash 3.2 before creating resources, and parallel workers
 reuse the invoking Bash executable.
+
+An RC gate result authorizes only the reviewed RC preparation workflow. Final
+`v2.0` tagging or publication still requires explicit owner approval; passing
+CI does not provide merge or final-release approval.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -28,8 +28,10 @@ get CodeQL onto release branches, and is out of scope here.
 ## The `ci-required` aggregator
 
 `test.yml` ends with a `ci-required` job: `if: always()`, `needs: [docs-lint,
-test]`, failing if any needed job reports anything other than `success` or
-`skipped`.
+test]`. Both named dependencies must exist and report `success`; skipped,
+failed, cancelled and malformed/missing evidence fail closed.
+`devel/scripts/test_ci_guards.py` tests those cases and the real-demo path
+selection. The stable check runs even after a dependency fails.
 
 It exists because the matrix contexts embed PostgreSQL versions — `test (14,
 on)`, `test (19beta2, on)` — and are renamed at every version bump. Requiring
@@ -45,7 +47,7 @@ check cannot detect if the required names all come from that same file — but a
 required check that never reports leaves the PR permanently pending, which is
 visible. `test.yml` is large; keep an eye on its size.
 
-## Required status checks (owner action)
+## Required status checks
 
 The `main-protected` ruleset (id `13093534`) currently has `deletion`,
 `non_fast_forward` and `pull_request` rules but **no `required_status_checks`
@@ -73,6 +75,7 @@ gh api repos/NikolayS/pg_ash/rulesets/13093534 \
 
 | Context | App | Why |
 | --- | --- | --- |
+| `size` | `github-actions` (15368) | Independent workflow-size guard, including release branches |
 | `ci-required` | `github-actions` (15368) | Stable rollup of `docs-lint` + the whole PG matrix |
 | `renderer (fixtures, no database)` | `github-actions` (15368) | Fast demo gate, runs on every PR, stable name |
 | `capture + reel (real PostgreSQL)` | `github-actions` (15368) | Real-database demo gate; runs on every PR |
@@ -80,16 +83,18 @@ gh api repos/NikolayS/pg_ash/rulesets/13093534 \
 
 Deliberately **not** required: the individual `test (N, on)` matrix contexts
 (version-coupled names, covered by `ci-required`), `Analyze (actions)` and
-`Analyze (python)` (CodeQL's per-language runs, rolled up by `CodeQL`), and
-`size` (only exists once #238 lands; add it then).
+`Analyze (python)` (CodeQL's per-language runs, rolled up by `CodeQL`).
 
 Two behaviours to keep in mind:
 
 - **A job skipped by a job-level `if:` still reports**, with conclusion
   `skipped`, and GitHub treats that as satisfying a required check. So
   `capture + reel (real PostgreSQL)` being required does not mean it always
-  really ran — its `if:` includes `github.event_name == 'pull_request'`, so on
-  PRs it does. A workflow skipped *entirely* (branch or path filter, or a file
+  really ran. The job runs on PRs, but its database steps are selected by
+  changed inputs: `devel/`, `sql/`, `demos/`, `examples/`, `assets/`, README
+  and the demo workflow. Manual/nightly runs always capture. Successful full
+  runs require fresh window/transcript files plus rendered artifacts.
+  A workflow skipped *entirely* (branch or path filter, or a file
   over the size limit) reports nothing, and the required check stays pending —
   the PR is blocked, which is the behaviour we want.
 - **Fork PRs need workflow approval.** With "require approval for all external
@@ -106,3 +111,17 @@ at once, each merge invalidates all the others and forces a rebase plus a full
 PG 14–19 matrix re-run — serialising the queue for little benefit, since the
 matrix is a schema/behaviour test rather than a semantic-conflict detector.
 Turn it on for a release line if a stale-merge incident ever justifies it.
+
+## Pre-tag dispatch verification
+
+The manual mechanism was successfully rehearsed on main `2c3286a` with its
+existing `v2.0-beta1` identity: [run 33924051160](https://github.com/NikolayS/pg_ash/actions/runs/33924051160),
+all nine jobs passed. This is not RC certification; repeat against the exact
+stamped candidate with its RC identity. A queued run with zero jobs requires
+investigation of workflow size, approval and runner scheduling, not an
+unbounded wait. See #247.
+
+Database matrix jobs have a 40-minute timeout and upload PostgreSQL logs on
+failure. The independent size guard fails at 460,000 bytes, before the known
+512,000-byte workflow failure boundary. Keep large assertions in external
+SQL/shell files without reducing behavior coverage.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -49,15 +49,11 @@ visible. `test.yml` is large; keep an eye on its size.
 
 ## Required status checks
 
-The `main-protected` ruleset (id `13093534`) currently has `deletion`,
-`non_fast_forward` and `pull_request` rules but **no `required_status_checks`
-rule**. Nothing at the ruleset level requires any check to have run, so a PR
-whose workflows never started — a fork PR pending workflow approval, a branch
-the trigger filters excluded, a workflow file over the size limit — is
-mergeable into `main` with zero evidence.
-
-Applying the payload below adds that rule. It preserves the existing rules
-verbatim; only the new `required_status_checks` entry is added.
+The `main-protected` ruleset (id `13093534`) requires the five contexts below.
+This configuration was applied and read back on 2026-09-04 during #249,
+preserving its existing deletion, non-fast-forward and pull-request rules.
+The checked-in payload documents that configuration; re-read the live ruleset
+before updating it so concurrent policy changes are preserved.
 
 ```bash
 gh api -X PUT repos/NikolayS/pg_ash/rulesets/13093534 \

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -34,7 +34,7 @@ failed, cancelled and malformed/missing evidence fail closed.
 selection. The stable check runs even after a dependency fails.
 
 It exists because the matrix contexts embed PostgreSQL versions — `test (14,
-on)`, `test (19beta2, on)` — and are renamed at every version bump. Requiring
+on)`, `test (19beta3, on)` — and are renamed at every version bump. Requiring
 those names directly means the ruleset silently stops covering a version the
 moment the matrix changes, or blocks every PR on a context that no longer
 exists. `ci-required` is one stable name that transitively covers the whole
@@ -121,3 +121,7 @@ Database matrix jobs have a 40-minute timeout and upload PostgreSQL logs on
 failure. The independent size guard fails at 460,000 bytes, before the known
 512,000-byte workflow failure boundary. Keep large assertions in external
 SQL/shell files without reducing behavior coverage.
+
+The current PG19 test image is `postgres:19beta3`, matching the
+[PostgreSQL beta information](https://www.postgresql.org/developer/beta/)
+verified on 2026-09-04. Update the hosted matrix and local gate defaults together.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -125,3 +125,7 @@ SQL/shell files without reducing behavior coverage.
 The current PG19 test image is `postgres:19beta3`, matching the
 [PostgreSQL beta information](https://www.postgresql.org/developer/beta/)
 verified on 2026-09-04. Update the hosted matrix and local gate defaults together.
+
+The Docker release runner requires Bash 4+ (Homebrew Bash on macOS). It
+rejects the system Bash 3.2 before creating resources, and parallel workers
+reuse the invoking Bash executable.

--- a/docs/V2_RC_PLAN.md
+++ b/docs/V2_RC_PLAN.md
@@ -1,0 +1,421 @@
+# pg_ash 2.0 release-candidate preparation plan
+
+Audit date: 2026-09-04. Target: **`v2.0-rc1`**, with payload version
+**`2.0-rc1`**. Status: **not ready to stamp or tag**.
+
+Owner authorization: RC tags are permitted after verification. **Never create
+the final `v2.0` tag or publish a final 2.0 release without the owner's explicit
+approval.** The owner intends to test the RC fully first.
+
+This plan covers all 12 open PRs, their integration, API decisions, automated
+and manual verification, documentation, and the RC publication gate. It is
+based on freshly fetched `origin/main` at
+`2c3286ac2551a89ab6bf6e2c982b6988578d5640`, not the older local checkout.
+Historical PR descriptions and passing checks are evidence for their recorded
+commits, not certification of a future combined candidate.
+
+See [the audit evidence and adjudication](V2_RC_REVIEW.md) for work completed
+during this review, including all 12 samorev runs and the successful hosted
+pre-tag mechanism rehearsal.
+
+The central issue is correctness and integration, not the number of green
+checks. Cadence changes still corrupt historical AAS; the held release stamp
+has an installer-atomicity defect fixed only in its stacked follow-up; several
+PRs have no CI; and independently reasonable lifecycle changes conflict.
+Do not publish an RC with those unresolved.
+
+## 1. Queue disposition and landing order
+
+Links below identify the reviewed PRs; the short SHA pins the inspected head.
+“Green” means the observed test matrix and aggregator passed, not that every
+reported demo check executed its database steps.
+
+| PR / head | Observed state | Disposition and required work |
+|---|---|---|
+| [#244](https://github.com/NikolayS/pg_ash/pull/244) `4a948205` | Green; GitHub reports blocked | Land first after review. Fixes the release-gate extractor on current main; 13 parser tests pass versus 1 error among 7 on main. Add the intermediate-indentation comment case found by samorev; avoid claiming full YAML conformance. Check the actual merge-block reason rather than assuming green CI permits merge. |
+| [#235](https://github.com/NikolayS/pg_ash/pull/235) `793e4688` | Green | First feature-stack PR. Keep additive `run_*` procedures, explicit admin ACLs, command migration, and custom-command preservation. Recheck real pg_cron execution and routed external calls; `CALL` is not a universal router guarantee. Resolve its scheduler semantics jointly with #204. |
+| [#239](https://github.com/NikolayS/pg_ash/pull/239) `23f53168` | Green; includes #235 | Land after #235. Review the incremental delta separately. Require both discriminating seam tests and physical standby/promotion tests, plus reader provenance and primary-positive controls. Do not equate a guard-generated no-op with local sampling. |
+| [#240](https://github.com/NikolayS/pg_ash/pull/240) `9a704803` | Green; includes #235 and #239 | Land after #239 only after logged/unlogged, failure rollback, real standby, restart/crash/promotion and upgrade checks. Keep logged default. Update the cumulative migration for `sample_unlogged` at stamp time; current overlay tests are not proof of the promoted public-wrapper path. |
+| [#204](https://github.com/NikolayS/pg_ash/pull/204) `fc810ef7` | Draft, conflicts, zero checks | Rebuild its lifecycle delta on the composed feature stack. Preserve exact-ID teardown, failure propagation and owner binding, while retaining #235's custom-command policy and #239's recovery guards. Document the owner-only behavior change and `SET ROLE` remedy. Move large inline regression bodies out of YAML. |
+| [#201](https://github.com/NikolayS/pg_ash/pull/201) `f7a7c8ef` | Conflicts, zero checks; older approval exists | Split behavioral/API changes from prose. This is not a docs-only PR: it restricts cadences, renames status metrics and changes message severity. Rebase on the composed installer, retain deleted legacy demo files as deleted, port relevant changes to the current harness and regenerate assets. Re-review the new head. |
+| [#232](https://github.com/NikolayS/pg_ash/pull/232) `aee733df` | Green | Land corrected dependency documentation. State query-ID generation and visibility prerequisites in the matrix itself. Remove the claim that `report()` returns SQL text; separate raw attribution availability from pgss text resolution. Add live collection without pgss, not just a pre-seeded ID test. |
+| [#234](https://github.com/NikolayS/pg_ash/pull/234) `77afff73` | Green | Retain explanation of enablement, scheduling, restart persistence and external-ticker trap. Align names with the API decision and #201 status labels. Assert the documented `status()` diagnostic as well as config counters; demonstrate actual re-enabled collection with a concurrent workload. |
+| [#233](https://github.com/NikolayS/pg_ash/pull/233) `f40b2772` | Green | Rewrite misleading report/AAS guidance, then restore the original investigation walkthrough using v2 APIs. Keep JSON-shape guards but permit additive keys as promised by the contract. Verify populated, unavailable and partial-attribution examples. |
+| [#236](https://github.com/NikolayS/pg_ash/pull/236) `e67aa8f7` | Green | Land after reconciling goals with actual capabilities. Qualify permissions, AAS/vCPU interpretation and overhead estimates; specify one transaction per sampling tick plus maintenance. Update “known gaps” for the final integrated scope. |
+| [#205](https://github.com/NikolayS/pg_ash/pull/205) `38af9f2f` | Draft, zero checks; base is `release/2.0` | Salvage with the atomicity part of #200. Keep transaction-ID-bound include ownership and the cached decision through the installer footer. Port the complete fresh/upgrade fault-injection suite. Do not merge this isolated delta into main without its migration-transaction prerequisite. |
+| [#200](https://github.com/NikolayS/pg_ash/pull/200) `ba96f785` | Draft, conflicts; old July CI | Replace the stale final-`2.0` stamp after the development gate passes. Salvage migration atomicity and useful release notes first, together with #205. Recreate the mechanical stamp as `2.0-rc1`; never overwrite the composed development installer with this old full-file payload. |
+
+The verified ancestry is **#235 → #239 → #240**, although all three PRs
+currently target main. After each merge, rebase the remaining stack, keeping
+main as the PR base (feature-parent bases are outside the workflow triggers),
+so reviewers see only its remaining delta. A squash merge needs particular
+care: remove already-landed ancestor commits instead of replaying them as new
+work. Every rewritten head needs fresh checks and review.
+
+Recommended sequence:
+
+1. Repair CI/extractor reliability (#244 plus the CI work below).
+2. Settle the API contracts below; integrate #235 → #239 → #240.
+3. Port #204 onto that stack; extract and integrate #201's accepted behavioral
+   changes; implement the cadence fix/containment from #137.
+4. Port #200 + #205 atomicity as a coherent development change. Stage the complete current-line migration refresh, including the new
+   config normalizer, in a development/test path. Test a temporary promoted
+   layout whose public wrapper and relative includes resolve to the composed
+   development installer. This is required before the development gate. Do
+   not stamp yet.
+5. Finish #201 prose, #232/#234/#233/#236, examples and regenerated demos.
+6. Run the complete development-candidate gate; fix findings and repeat it.
+7. Prepare and review a new RC stamp, then repeat verification on its final
+   promoted payload and exact eventual main commit before tagging.
+
+For each step record the implementing PR, current SHA, owner, review report,
+manual transcript and CI URLs. Do not close superseded PRs until their unique
+fixes and tests are accounted for in the replacement.
+
+## 2. Decisions to freeze before the RC
+
+### Historical AAS and cadence — release blocker #137
+
+The latest #240 installer still weights history using today's
+`ash.config.sample_interval`. Independent PostgreSQL 18 reproduction during
+this audit used 60 observations collected at one second, followed by 12 at
+five seconds. After `ash.start('5 seconds')`, the two true 1-AAS minutes become
+5 and 1; the aggregate becomes 3 AAS / 360 backend-seconds instead of 1 AAS /
+120 backend-seconds. A two-minute cadence also produces a one-minute peak of
+2 from one observed backend.
+
+**Preferred complete fix:** persist sampling weights/epoch information with
+observations and propagate weighted backend time through minute/hour rollups.
+Define what happens to older rows lacking that information; never infer a
+past cadence from current configuration and claim exactness.
+
+**Recommended bounded RC alternative:** enforce a constant supported cadence
+while any retained raw or rollup history exists, and reject cadences that
+cannot support the advertised one-minute statistics. Cover every supported
+configuration path, including direct config updates, aliases, installer
+reapply and external-scheduler setup. Rebuilding only the raw ring is not
+sufficient to change cadence while old rollups survive. Do not silently purge
+history to make a configuration update work. An explicit reset or segmented
+history operation needs its own documented data-loss/interpretation contract.
+
+Choose and implement one path before stamping. #201's cron-divisor correction
+does not solve historical reweighting. A README caveat alone is insufficient.
+Acceptance: fixed-history results do not change when present configuration
+changes, mixed-cadence results are correct or the transition is refused, and
+coarse observations never masquerade as exact one-minute peaks.
+
+### Lifecycle and scheduling
+
+Recommendation: keep `start`/`stop` callable for compatibility, add clear
+sampling enable/disable operations if the responsibilities are split, and use
+`schedule`/`unschedule` only for explicit scheduler management. Specify whether
+unscheduling leaves sampling enabled for an external ticker. Avoid replacing
+one ambiguous name with another that still changes hidden state. Do not adopt
+#223's proposed removal of compatibility wrappers in 2.1 while promising a
+stable 2.x interface; use a deprecation policy consistent with the public
+compatibility commitment.
+
+Before implementation, write a state table for each entry point covering:
+`sampling_enabled`, interval, the five managed jobs, existing custom commands,
+inactive jobs, job database/owner, missing pg_cron, recovery, errors and
+rollback. The #204/#235 conflict is semantic: #204 force-repairs commands and
+activation while #235 intentionally preserves custom commands. Recommended
+contract: migrate recognized legacy commands, preserve custom commands, and
+make any explicit repair/reset operation visible and separately tested.
+
+Add a same-owner, same-job-name, different-database collision test. The current
+lookup filter does not prevent `cron.schedule()` from updating that other
+job: pg_cron keys named jobs by name and username and updates the database on
+conflict. Reject the collision or explicitly establish managed-job ownership;
+do not silently claim isolation. Verify behavior against each supported
+pg_cron version.
+
+Retain the additive `run_*` procedure names unless the complete call surface
+is deliberately redesigned before RC. Document their NOTICE/result behavior,
+admin privileges and lack of internal transaction control. Do not imply #235
+implements the chunked-commit design in #228. Verify routing with a named
+supported router configuration; syntax alone cannot promise primary routing.
+
+### Reader, report and diagnostic contracts
+
+Freeze routine signatures, argument names/defaults, result columns, allowed
+dimensions, units, NULL/error behavior, SQLSTATEs and privilege requirements.
+Verify positional and named calls. Keep raw evidence, aggregate data and
+rendering functions distinct in documentation.
+
+Preserve `report()`'s chosen minute-rollup-only contract: no raw/hourly fallback
+that fabricates class-level one-minute detail. SQL NULL can mean no usable
+minute-rollup data, even while another reader has data. Explain the NOTICE and
+the next action. Its JSON contract permits additive keys; tests should require
+the documented subset and types rather than forbid every future addition.
+
+Choose #201's status-label policy explicitly. Recommendation: retain existing
+labels as documented compatibility aliases while adding clearer labels, unless
+the owner deliberately accepts their removal as a v2 breaking change. Update
+README, tests, demos, fixtures, catalog comments and release notes together.
+Configuration enabled, latest activity-bearing observation and a confirmed
+sampler heartbeat are different facts; current storage cannot distinguish
+every quiet period from an outage.
+
+Document #204's schema-owner restriction, including the effect on a different
+superuser and a permitted `SET ROLE` workaround. Validate the full reader
+grant bundle and deny all new maintenance procedures/admin helpers to readers
+and PUBLIC. Test useful reading as the positive control for each denied-write
+test. Resolve #171/#195/#196 by reproducing the final documented grant/reapply
+policy, not by carrying forward hardcoded bundle sizes from old reviews.
+
+## 3. Make CI evidence dependable
+
+Current main has a useful seven-cell PostgreSQL matrix (14–18 and 19beta2 with
+cron, plus 17 without cron), release-stamp tests, behavior/upgrade/security
+tests, an independent size workflow and a `ci-required` job. Preserve this
+coverage while improving its enforcement.
+
+Required work:
+
+- Apply actual required status checks to the active main ruleset. The live
+  `main-protected` ruleset `13093534` currently contains no
+  `required_status_checks` rule. Require `ci-required`, the independent
+  workflow-size check, renderer, real demo verification, and CodeQL with the
+  correct app identities. Inspect any other rulesets/classic protection too;
+  a JSON file in the repository is not proof of active enforcement.
+- Make `ci-required` fail unless both mandatory dependencies succeeded.
+  Current `success|skipped` acceptance permits a skipped test job to pass.
+  Keep any genuinely optional job separate with a documented reason. Add
+  failure/cancellation/skipped/missing-job probes for the aggregator and
+  confirm the expected matrix cells materialized on the candidate SHA.
+- Extend the independent size workflow to release branches as well as main.
+  Retain its 460,000-byte guardrail. Reviewed `test.yml` sizes: #201 513,684;
+  #204 530,255; #200/#205 509,529; #240 437,634. The first two exceed the
+  repository's known 512,000-byte failure boundary; #200/#205 leave almost
+  no room. Combining the pending inline bodies also threatens the guardrail.
+  Move behavioral bodies into `devel/tests/` and keep YAML orchestration short.
+- Include **`devel/sql`**, discovery helpers, relevant test/harness files and
+  rendered documentation inputs in the demo gate's change detection. Today
+  `git diff ... -- demos sql` misses development SQL; a successful
+  `capture + reel` job may have skipped every database step. Force full
+  capture for RC workflow dispatches and assert artifact production.
+- Give database jobs explicit timeouts, bounded readiness/workload waits,
+  reliable cleanup and failure artifacts. Preserve exact-value assertions and
+  independent test databases. Avoid sleeps as evidence that a cron job fired.
+- Run the extractor tests and stamp/discovery tests before any Docker gate.
+  Assert extracted step names/counts, shell parseability and all seven local
+  surfaces. Keep new report/procedure/standby/persistence tests in both hosted
+  CI and the local gate; audit range-based selection after moving steps.
+- Keep PG14–18 required; test the currently supported PG19 prerelease and
+  record the exact image/package versions. Recheck the supported-version
+  policy and available PG19 image before changing `19beta2`; do not silently
+  drop a cell because its package setup is inconvenient.
+- Prove manual `workflow_dispatch` end to end before stamp day. A rehearsal
+  was started during this audit on current main using its existing
+  `v2.0-beta1` stamp and passed all nine jobs in
+  [run 33924051160](https://github.com/NikolayS/pg_ash/actions/runs/33924051160).
+  It is a mechanism check, not approval of beta payload identity or an RC test.
+  Diagnose queued/zero-job runs promptly; workflow size is a known cause,
+  not the only possible cause of scheduling delay.
+
+## 4. Review protocol using Tanya301/samorev
+
+Pin samorev revision **`24924b4900efdf1b11e43ae7c7477e0c0fc3d2d3`** for this
+audit. Its README/runbook are stale: source at this revision invokes Claude
+analysis and an adversarial finding check; `--blocking` returns nonzero on
+FAIL. The executed command is:
+
+```sh
+bun run samorev review https://github.com/NikolayS/pg_ash/pull/PR_NUMBER \
+  --fetch --no-comment --blocking
+```
+
+Run on every finalized PR head and again on the composed candidate/stamp PR.
+Keep the full local report, exit code, tool revision, PR head/base and CI
+snapshot. Reports must distinguish tool execution failure, actual findings,
+draft status, missing CI and a known optional skipped check.
+
+Two limitations require an additional full-context review:
+
+1. This revision can label green PRs `ci_status=unknown` because of the skipped
+   duplicate demo invocation. Adjudicate against the individual mandatory
+   jobs; never globally convert `unknown`, `skipped` or zero checks to PASS.
+2. Its main model prompt caps source diff content at 40,000 characters,
+   shared per file. Large SQL/workflow diffs are truncated. Review omitted
+   bodies and tests explicitly; review #239/#240 incremental deltas and the
+   composed installer. A no-code-findings report is not complete certification.
+
+Use independent agents for security/privileges, bugs/data semantics, test
+quality, migration/lifecycle behavior and documentation. Give them the actual
+relevant source and tests, not only the proposed interpretation. Require a
+reproduction or source-grounded argument for each blocking finding, and record
+why contested findings are fixed, rejected or deferred. A prior PASS becomes
+stale after a relevant change or conflict resolution.
+
+The repository requires review reports on PRs and explicit owner merge
+approval. This audit uses `--no-comment`; it has not posted reports. Prepare
+the adjudicated reports before the publication step. Do not post raw tool
+claims as independently verified conclusions.
+
+## 5. Automated and manual release gate
+
+Run against disposable real PostgreSQL instances. Hosted CI is necessary but
+does not replace the repository's Docker release gate or human inspection.
+The local Docker daemon was unavailable during the audit; isolated local PG18
+reproductions are supplementary evidence, not the complete release pass.
+
+| Surface | Required automated evidence | Manual acceptance |
+|---|---|---|
+| Fresh install / regression | PG14–18 + supported PG19 prerelease; all current regression tests; install/reapply success; deterministic late failure rolls back | Follow pinned-tag Quick Start from an empty database with realistic owner privileges; generate live activity and inspect status, periods, chart, top and report |
+| Historical upgrades | Real tagged v1.0–v1.5; full discovered chain; v2.0-alpha1…alpha5 and beta1 to RC; canonical migration and root wrapper; wrapper reapply; fresh/upgrade schema equivalence | Upgrade a populated v1.5 and beta installation with nondefault config, complete/narrow grants, pg_monitor opt-out, custom/inactive cron jobs and retained raw/rollup data |
+| Migration failure | Custom triggers, dependent view/DROP RESTRICT, externally preset transaction marker, same-session rollback, late installer failure, empty database and real v1.5 | Check nonzero psql exit and unchanged identity, config contents/OID, schema, blockers and jobs from a new connection; retry successfully after removing the deliberate blocker |
+| AAS / reader correctness | Conservation of backend-seconds and percentages across raw/1m/1h, compacted residuals, stale watermark fallback, partial hours, retention boundaries, peaks/percentiles, fixed/mixed cadence, NULL/empty/inverted windows | Explain one known lock storm from raw evidence through aggregate/chart/report; reconcile values and identify the actual source/grain and coverage limits |
+| Scheduling / lifecycle | Exact five-job state, no duplicate jobs, legacy-command migration, custom-command preservation, inactive/wrong-database/foreign-owner cases, teardown failure rollback, bounded lock/cancellation tests | Live cron tick and wall-clock external ticker; stop/re-enable; clean restart; restricted roles; deliberately blocked unschedule must not report success or partially uninstall |
+| Dependencies / grants | Four cron×pgss modes; actual ID collection with query-ID generation enabled; unavailable ID/text cases; hostile search_path/schema; positive reader access and negative admin/procedure calls | Follow no-extension setup with realistic privileges, observe IDs without pgss, demonstrate when text is unavailable, and diagnose a disabled external ticker |
+| Replica / persistence | Real physical standby as well as seam tests; logged/unlogged primary and standby; raw-only vs rollup readers; clean restart, crash/immediate shutdown and promotion; conversion failure rollback; rebuild and installer reapply | Demonstrate that standby output describes primary history; unlogged raw access reports unavailable with remedy; promotion resumes correct local writes; logged rollups survive while raw loss is disclosed |
+| Docs / demos / examples | Renderer fixtures, live capture, shape/rot checks, real report samples and copied SQL, no removed v1 readers in active examples | Inspect README at desktop and narrow widths; view every image and the full animation; check labels, units, version and readability; run the LLM walkthrough verbatim |
+| Overhead / resilience | Repeatable sampling-off/on measurements at idle, normal and saturated load; tick latency, skipped/failed ticks, CPU/TPS/latency impact, raw/rollup bytes, WAL and replication impact | Try an already-saturated small instance and a representative application-vendor setup; document measured limits instead of “safe for everyone” claims |
+
+For overhead (#226), establish the acceptable budget before examining results,
+record duration/concurrency/cadence/PG version/hardware and separate measured
+results from estimates. Do not require an arbitrary percentage to manufacture
+a PASS. No published “enable everywhere by default” recommendation until the
+evidence supports it.
+
+Assign independent agents to fresh/regression, upgrade/atomicity, new features,
+existing/security/degraded behavior, and demos/docs. With four agent slots,
+schedule these in waves while preserving independent ownership. Save logs,
+TSV results, CI URLs, schema/ACL snapshots, workload setup and candidate hashes.
+If any gate agent finds a defect, track it, fix it and rerun the **entire**
+comprehensive pass; targeted green reruns alone do not meet repository policy.
+
+## 6. README, API reference and restored LLM examples
+
+Arrange the README around the first successful investigation: what pg_ash
+measures; requirements/privileges; pinned install and upgrade; automatic or
+external scheduling; periods → timeline/chart → waits → queries; JSON/LLM
+analysis; API reference; retention, replicas and limitations. Keep the full
+reference in linked documentation if the landing page becomes difficult to
+scan. Distinguish released SQL from the development overlay until stamping.
+
+Restore **both** use cases: the old step-by-step investigation and #233's
+copyable JSON prompt. The original walkthrough was introduced by commit
+[`28ecece`](https://github.com/NikolayS/pg_ash/commit/28ecece) and removed with
+the beta README rewrite. Port its question/answer progression, not removed
+function names or invented output. Map its API calls as follows:
+
+| Original example | v2 replacement |
+|---|---|
+| `activity_summary` | `periods`, then `aas`/`summary` for the selected bounded window |
+| `top_waits` | `top('wait_event', ...)` |
+| `timeline_chart` | typed `timeline(...)` and optional human `chart(...)` |
+| `event_queries_at` | `top('query_id', ..., wait_event => ...)` inside raw retention |
+| `top_queries_with_text` | query-ID `top(...)` / `samples(...)` with text when available |
+
+Reuse the current demo workload for reproducible output. Capture actual
+timestamps, query IDs and result columns from the final candidate; show how
+each result motivates the next query. Conclude with a supported hypothesis
+and a verification step. Lock waiters are not automatically the blockers or
+proof of a particular application-level root cause.
+
+Correct the JSON prompt before freezing it:
+
+- AAS/vCPU is an active-session-to-core ratio, not measured CPU utilization
+  or a universal healthy/overloaded threshold. CPU*, locks, I/O and other
+  waits have different implications. CPU* includes uninstrumented activity.
+- `report.total` sums the five supported report classes; it is not necessarily
+  every wait class represented by other readers.
+- Per-class worst-minute values can come from different minutes. Do not read
+  them as the decomposition at the minute of the total peak. Use a common
+  timeline/window to establish simultaneity.
+- Report averages/percentiles summarize stored activity-bearing minute rows;
+  missing rows do not prove quiet time or missing sampler ticks.
+  `minutes_with_data` is not a heartbeat or a sampling-completeness percentage.
+- `top_queryids_available` indicates whether raw-covered extreme-minute
+  attribution was possible. It does not test pgss availability. Query IDs,
+  SQL text resolution and raw attribution coverage are separate dimensions.
+- `raw_retention_start` is a planning/loss boundary, not an assurance of exact
+  attribution at every timestamp. Drill-down can still be unavailable.
+- Treat NULL report, partial coverage, missing vCPU, missing SQL text and
+  absent/partial per-class query IDs explicitly. Ask for further evidence
+  instead of forcing a health verdict.
+
+Ship a plain JSON export recipe (no psql table framing), a provider-neutral
+prompt and a small expected-response rubric. Treat embedded SQL text as data,
+not instructions; remove sensitive values before sharing externally. Keep
+pg_ash itself free of LLM credentials and external calls. Test the example on
+a populated report, no-pgss report, old extreme outside raw retention, no
+minute-rollup coverage and a mixed-wait incident. Never require exact generated
+prose in CI; check the documented fields, SQL execution and semantic rubric.
+
+Regenerate the existing demo harness outputs after final API/status changes.
+Use its actual `make check`, `make all`, `make rot`, `make stills`/`make demo`
+targets as documented. Do not restore deleted shell scripts or hand-edit a
+recording to disguise API drift. Update screenshots/version text at the RC
+stamp and rerun visual verification.
+
+## 7. Stamp, tag and publish only after the gates
+
+1. Finish scope triage. Verify apparently fixed issues (#122/#124/#128/#130/
+   #136/#138/#146/#155/#167) against the integrated candidate and link tests
+   before closing. Keep #137/#202/#203 and all unresolved review defects on
+   the blocking list. Explicitly defer replica collection (#227), chunked
+   commits (#228), log digests (#229), recovery counters (#246), chart styling
+   (#176), and oversized-input wording (#177) unless a shipped contract
+   requires them. #223 needs a compatibility decision; #226 needs measured
+   evidence for overhead claims.
+2. Obtain a clean comprehensive development gate on one recorded commit.
+   Prepare a replacement RC stamp PR from it. Promote the composed installer,
+   update all three version stamp sites and release-identity comments to
+   `2.0-rc1`, refresh the current `1.5-to-2.0` migration and retain its root
+   compatibility wrapper. Preserve the five finalized 1.x migrations and
+   their wrappers byte-for-byte.
+3. Promote the already-tested migration's complete normalization contract for all new
+   columns, including `sample_unlogged`: expected columns/order, types,
+   nullability, table recreation and preservation. Include #200/#205
+   transaction ownership. Exercise the **promoted canonical migration and
+   public wrapper**, not just released migration followed by a dev overlay.
+4. Recreate `devel/sql/ash-install.sql` as the byte-identical promoted baseline,
+   as the current release process now requires. Fix the later stale paragraph
+   that still says to leave the directory empty. Verify discovery works for
+   fresh, full, pinned and reapply paths after promotion.
+5. Update README, release notes, SECURITY/support text, catalog comments,
+   examples and generated assets consistently. Release notes must name the
+   breaking API/owner/status/cadence changes, upgrade actions, data durability
+   choices, remaining limitations and supported versions. Do not claim final
+   `v2.0` is already released.
+6. Review the stamp with samorev and full source context. Dispatch `test.yml`
+   with `release_tag=v2.0-rc1` against the precise stamped revision and run
+   the full Docker/manual/visual gate again. Require all expected jobs and
+   artifacts, no blocking findings and owner acceptance of manual visuals.
+7. After explicit owner approval, merge the reviewed stamp. If the merge
+   changes the tested commit/tree, run CI and the complete gate on the exact
+   resulting main candidate. Record the final SHA, payload hashes and results.
+   Draft the GitHub prerelease body and upgrade instructions before approval
+   to publish. No tag is a substitute for this pre-tag verification.
+8. Create the immutable `v2.0-rc1` tag on that verified main SHA; publish a
+   GitHub release marked **prerelease**, not latest stable. Verify tag-triggered
+   checks, release links and a clean install/upgrade using the downloaded
+   tagged payload. A post-tag fix gets `rc2`; never move `rc1` or replace its
+   payload under the same identity.
+9. Invite RC testing with a concrete matrix: fresh installs, real upgrades,
+   no-extension operation, constrained privileges, replica topology and
+   workload scale. Recommended soak: at least seven days, including daily
+   maintenance and a retention/rotation boundary (time-accelerated tests still
+   run beforehand). Advance to stable only after feedback is triaged, all
+   blockers are fixed and the complete gate is repeated on the final stamp.
+
+The release checklist is complete only when each item has an evidence link
+and exact candidate identity. Downgrading the SQL payload is not a tested
+rollback mechanism: document restore from a verified backup and forward-fix
+options, particularly after schema normalization or unlogged raw-data loss.
+
+## 8. Execution ownership and stop conditions
+
+Use one release integrator to own the composed tree and merge order; assign
+named owners for CI, API/data correctness, migrations/lifecycle, and docs/demo
+acceptance. These are work assignments, not independent release authorities.
+The project owner retains the required human merge and publication decision.
+
+Stop RC publication for any wrong aggregate, partial-success install/teardown,
+privilege regression, untested promoted upgrade path, missing/skipped required
+test surface, unresolved semantic merge, or misleading core example. Record
+lesser accepted limitations with scope and evidence rather than quietly
+lowering the gate. This audit creates the plan and review evidence; it does
+not certify the unfinished integrated candidate or authorize its tag.

--- a/docs/V2_RC_REVIEW.md
+++ b/docs/V2_RC_REVIEW.md
@@ -1,0 +1,186 @@
+# v2 RC preparation: review evidence, 2026-09-04
+
+Verdict: **do not stamp or tag yet**. The [finalization plan](V2_RC_PLAN.md)
+describes how to reach `v2.0-rc1`. This record separates completed review and
+tests from the integration and comprehensive release gate still required.
+
+## Scope and provenance
+
+- Freshly fetched main: `2c3286ac2551a89ab6bf6e2c982b6988578d5640`.
+- All 12 open PRs inspected through metadata, diffs, relevant source/tests,
+  previous reviews and samorev. Three independent agents reviewed API/data
+  correctness, docs/examples, and migration/release safety.
+- samorev checkout: `24924b4900efdf1b11e43ae7c7477e0c0fc3d2d3` from
+  [Tanya301/samorev](https://github.com/Tanya301/samorev).
+- Each samorev invocation used `review URL --fetch --no-comment --blocking`.
+  All 12 produced review reports and exited 1; none reported an unavailable
+  or timed-out main reviewer. These are FAIL reports, not blanket merge
+  approvals. Known false positives and tool limitations are adjudicated below.
+- No PR was merged, retargeted, marked ready or commented on. No tag or GitHub
+  release was created. Repository changes from this task are the plan and this
+  review record. The one hosted mutation was the test workflow dispatch below.
+- Historical PR-body runtime claims were read but are not counted as fresh
+  tests performed in this audit.
+
+## Completed verification
+
+| Check | Result and interpretation |
+|---|---|
+| Current main extractor tests | **FAIL:** 7 tests, 1 error; `WorkflowError` at workflow line 8853. This reproduces #243 and blocks the local release-gate extraction path. |
+| #244 extractor tests | **PASS:** all 13 tests on `4a948205`. A separate intermediate-indentation probe shows the parser still treats a nine-space comment as content after a ten-space literal-block line; track the supported YAML subset accurately. |
+| Current main release-stamp tests | **PASS:** all 17 tests. |
+| Hosted manual pre-tag mechanism | **PASS:** [run 33924051160](https://github.com/NikolayS/pg_ash/actions/runs/33924051160), `workflow_dispatch`, main SHA above, input `release_tag=v2.0-beta1`. Docs/stamp job, PG14/15/16/17/18/19beta2 with cron, PG17 without cron and `ci-required`: **9/9 succeeded**. This resolves the lack of a demonstrated successful dispatch mechanism in #247, but is not an RC payload gate. |
+| Exact #240 CALL surface | **PASS:** `procedures_call_surface.sql` on isolated local PostgreSQL 18 with a tagged real workload backend, including effects and reader denials. |
+| Exact #240 sample persistence suite | **PASS:** `sample_persistence.sql`, including installer reapply, rotation/rebuild, round trips, drift and negative cases. |
+| UNLOGGED restart experiment | **PASS:** clean restart retained raw/rollup counts `1/1`; immediate shutdown/recovery yielded `0/1`. Matches the intended raw-loss/rollup-preservation contract. |
+| Conversion lock-timeout experiment | **PASS for atomicity; documentation defect:** lock `sample_1`, attempt conversion, timeout after 5.01 seconds. Config remains `false`; all three partitions remain logged. No partially converted ring survives. |
+| Cadence conservation experiment | **FAIL:** two true 1-AAS minutes become 5 and 1 after cadence changes to five seconds; total 360 backend-seconds instead of 120. Two-minute cadence produces a one-minute peak of 2 from one observed backend. |
+| Complete Docker/visual release gate | **NOT RUN:** local Docker daemon unavailable; no combined final candidate exists yet. No claim of real standby promotion, all-origin upgrades or full visual acceptance is made. |
+
+The isolated PostgreSQL instance was stopped after the experiments. Relevant
+SQL and transcripts, the raw samorev reports, PR metadata/diffs and checksums
+are retained in the local evidence bundle described at the end.
+
+## Confirmed release and integration findings
+
+**P1 — historical AAS remains wrong (#137).** At #240 head,
+`devel/sql/ash-install.sql:4459` reads the current interval;
+`ash.start()` changes it without preserving past cadence. The live test
+demonstrates the wrong values above. #201's calendar-divisor restriction
+does not address this. Enforce the plan's persistence or containment contract,
+including `stop(); start()` after a nondefault interval and all retained
+rollup history.
+
+**P1 — public migration is incompatible with the prospective #240 payload.**
+Current `sql/migrations/ash-1.5-to-2.0.sql:63` defines a 22-column config
+normalization contract and rejects unexpected columns at line 201; #240 adds
+`sample_unlogged`. Simply promoting its installer will make this public
+migration fail. Update every canonical column/type/nullability/table-copy
+site and test the promoted canonical and root-wrapper entrypoints, including
+reapply and preservation of an existing unlogged choice.
+
+**P1 — migration transaction ownership needs both #200 and #205.** Current
+migration starts normalization after installer replay has committed
+(`sql/migrations/ash-1.5-to-2.0.sql:38`). #200 fixes that transaction split
+but accepts an ambient literal `on` marker; #205 binds include mode to the
+assigned transaction ID and caches the decision. Carry the coherent fix and
+all fault-injection cases forward before stamping.
+
+**P1 — lifecycle teardown is still capable of partial success.** Main
+`devel/sql/ash-install.sql:2495` and #240 line 2971 swallow rollup unschedule
+failures; rebuild/uninstall consume that result. #204 contains the atomic
+failure fix, but is stale. It also overwrites custom commands and activation,
+conflicting with #235's deliberate command preservation. Resolve this as a
+single lifecycle state contract, not a file conflict.
+
+**P1 — CI evidence is not fully enforced.** The inspected active ruleset
+`13093534` lacks required status checks. `ci-required` accepts skipped
+dependencies. The real-demo change detector only includes `demos` and `sql`,
+missing `devel/sql`. #201/#204 carry workflows over the known size limit and
+have no checks. Rebase, reduce workflow size, enforce actual checks, and
+require artifact-backed demo execution for candidate changes.
+
+**P2 — same-name cross-database cron collision.** #235/#240 filter existing
+sampler lookup by database, then call `cron.schedule()` when no local match
+exists. pg_cron's named-job upsert is keyed by `(jobname, username)` and
+updates its target database. Thus the lookup filter does not protect a
+same-owner job in another database. This is source-verified, not a live
+multi-database reproduction here; add that regression and an explicit
+collision/ownership policy. [Upstream pg_cron implementation](https://raw.githubusercontent.com/citusdata/pg_cron/main/src/job_metadata.c).
+
+**P2 — report/LLM documentation would produce misleading conclusions.**
+#233 README lines 381–419 treats load/core ratio as capacity utilization,
+CPU* as measured CPU execution, report total as every wait class, independent
+class maxima as the decomposition at the total peak, and attribution
+availability as pgss resolution. The implementation contradicts those claims:
+main `devel/sql/ash-install.sql:6489` chooses per-class peak minutes;
+line 6574 sums the five report classes; line 6598 independently chooses the
+total peak; line 6674 builds attribution availability from raw-covered
+extreme minutes. Missing activity-bearing rows also do not prove missing
+sampler ticks. Correct the prompt and restore the original investigation
+walkthrough, not just a JSON handoff.
+
+**P2 — dependency docs conflate text, IDs and report attribution.** #232
+README line 532 promises SQL text from `report()`; line 533 associates its
+attribution flag with pgss. IDs also require query-ID generation and adequate
+visibility. PostgreSQL defaults `compute_query_id` to `auto`; `on` explicitly
+enables generation, while `auto` lets a requesting module enable it. A seeded
+ID fixture does not test capture from a live backend under those settings.
+[PostgreSQL statistics configuration](https://www.postgresql.org/docs/current/runtime-config-statistics.html).
+
+**P2 — #201 status/API changes break current consumers unless composed.**
+Its status metric renames affect main `demos/scenes/scenes.tsv:35` and #234's
+documented diagnostic. It modifies deleted demo scripts and a recorded cast;
+those changes must be ported to the current harness and regenerated. Its
+cadence, status and severity changes need a behavioral PR/review, not a
+docs-only label. Until promotion, distinguish its new overlay behavior from
+the released installer still used by README Quick Start.
+
+**P2 — planned goals exceed verified guarantees.** #236 must qualify
+installation/visibility permissions, overhead units and estimates, the
+ability to distinguish idle from missing data, and absolute upgrade
+data-preservation claims. Keep goals as requirements to verify rather than
+statements of already proven behavior.
+
+**P3 — UNLOGGED conversion comment is wrong.** #240 installer lines 739 and
+777 claim timed-out conversion leaves partial persistence changes. The live
+experiment proves rollback preserves the original config and every partition.
+Correct those comments and keep the regression. A five-second lock timeout
+bounds lock acquisition, not total rewrite duration; test/document the impact
+of successful long conversion on sampling and readers.
+
+## samorev results and adjudication
+
+The raw report's “BLOCKING ISSUES” section can include LOW findings. Priority
+below follows actual impact. Existing draft status is expected, but remains
+a real merge gate. Missing CI is a gate even when samorev calls it `none`
+without reporting it as a failure.
+
+| PR / reviewed head | Raw findings | Disposition of substantive findings |
+|---|---:|---|
+| #200 `ba96f785` | 2 | Draft + ambient-marker atomicity defect. Confirmed; require #205 and recreate RC stamp. |
+| #201 `f7a7c8ef` | 3 | Accept released/dev docs mismatch. Consolidate WARNING consequence/remediation so `client_min_messages=warning` does not hide the hint. Align counter wording after settling status labels. Main conflicts/no CI are additional blockers. |
+| #204 `fc810ef7` | 3 | Draft; preserving useful error DETAIL/HINT is reasonable. The claim that specifying `database` to `alter_job` necessarily requires superuser is **not supported by current upstream source**: database changes check CONNECT; username changes require superuser. Still test supported pg_cron versions and routine ACLs with a non-superuser owner. |
+| #205 `38af9f2f` | 2 | Draft; residual psql variable is a cleanup nit, recomputed on each entry. Do not undo the cached ownership decision. Missing CI and its held base remain gates. |
+| #232 `aee733df` | 3 | Optional-skip CI artifact; qualify live ID-generation precondition and add actual no-pgss collection. Independent review found the additional report/text errors above. |
+| #233 `f40b2772` | 1 | Only optional-skip CI artifact reported. This does **not** clear the documented semantic defects. Its defender incorrectly claimed `report()` prefers raw; source proves minute-rollup-only behavior. Fixture-isolation concern remains unverified and needs checking, not dismissal using that premise. |
+| #234 `77afff73` | 2 | Optional-skip artifact; accept adding exact `status()` diagnostic assertions after final naming decision. Do not copy the tool's illustrative query blindly: status columns are `metric,value`. |
+| #235 `793e4688` | 2 | Optional-skip artifact + cross-database named-job collision. Collision supported by source; add live regression. |
+| #236 `e67aa8f7` | 4 | Optional-skip artifact; clarify ID prerequisites and transaction/time units. Reject the hypothetical missing `docs/RELEASE_PROCESS.md` finding: the file exists. Link it properly as normal polish. |
+| #239 `23f53168` | 3 | Optional-skip artifact; accept explicit recovery tests for all five CALL wrappers. Primary-positive fixture writes are outside rollback while cleanup is PG18-only: normalize fixture cleanup across cells. This is a test-isolation gap, not proof of an observed reader failure. |
+| #240 `9a704803` | 3 | Optional-skip artifact; conversion can block samplers during rewrite, so add operational evidence/runbook. Logical-publication interaction is **unverified**: test against supported configurations before presenting the tool's claimed restriction as fact. |
+| #244 `4a948205` | 3 | Optional-skip artifact; add intermediate-indentation characterization and narrow conformance wording. Duplicate indentation code is nonblocking maintainability feedback. The tool's exact character-loss explanation was not reproduced; the separate probe showed altered deindentation with the comment retained. |
+
+For the eight recent PRs with 17 checks, the observed rollup was 16 successes
+plus one skipped duplicate `capture + reel` invocation. This explains the
+tool's `unknown` artifact; it does **not** prove the successful duplicate did
+database work. Inspect step execution/artifacts separately.
+
+The CLI source, unlike its current README/runbook, invokes Claude and honors
+`--blocking` with exit 1 on FAIL. It also caps source diff content at 40,000
+characters, spread across files, so full-context review was necessary. Pin
+the source revision, not just a tool name, when repeating this protocol.
+
+## Remaining verification and publication boundary
+
+The review establishes actionable defects and a tested path through the
+manual CI trigger. It does not establish a clean combined candidate. Still
+required: semantic integration, cadence correction, new migration contract,
+every actual tagged upgrade origin, full Docker matrix, real promotion/resume,
+external scheduler/router behavior, overhead measurements, executed restored
+examples and regenerated visual inspection, followed by review/CI of the new
+stamp and exact candidate main SHA.
+
+No agent reported a fresh full release pass. Human merge/publish approval
+remains required by the repository; ask only after the concrete candidate and
+evidence are ready. Posted review summaries should contain this adjudication,
+not the raw tool's unverified or disproven claims.
+
+## Local evidence bundle
+
+`/tmp/pg-ash-v2-audit/evidence.tar.gz` contains the downloaded PR metadata and
+diffs, 12 samorev reports and stderr logs, the cadence reproduction and local
+PG18 transcripts, the hosted dispatch result, and checksums. These temporary
+artifacts are for review/reproduction and are not an immutable published
+release record. Preserve them with the eventual release tracking artifacts;
+the essential findings and outcome are recorded in this file.

--- a/docs/ci/main-protected-ruleset.json
+++ b/docs/ci/main-protected-ruleset.json
@@ -31,6 +31,7 @@
         "strict_required_status_checks_policy": false,
         "do_not_enforce_on_create": false,
         "required_status_checks": [
+          { "context": "size", "integration_id": 15368 },
           { "context": "ci-required", "integration_id": 15368 },
           { "context": "renderer (fixtures, no database)", "integration_id": 15368 },
           { "context": "capture + reel (real PostgreSQL)", "integration_id": 15368 },


### PR DESCRIPTION
A development-installer change could produce a successful demo check without a database capture, and the final CI aggregator accepted skipped mandatory tests. Include development SQL and its consumers in demo selection, require every declared dependency to succeed, and require fresh capture evidence.

This includes #244's workflow parser fix and dedented-comment regressions, extends the independent size guard to release branches, adds bounded jobs and failure logs, and records the active required-check ruleset. A portable PTY runner replaces incompatible BSD/GNU script flags in the interactive installer test. The Docker gate requires Bash 4+ before creating resources and reuses the invoking Bash for nested workers.

Validation:
- 17 parser tests, 8 CI-guard tests, 6 PTY tests (readiness, EOF, exit status, large concurrent input/output, and bounded timeout), and 17 release-stamp tests pass.
- Complete local Docker Postgres 17 gate at c516b0c passes all 7 surfaces: fresh installation, full upgrades, features, three degraded modes, and cron path.
- Latest c516b0c passes the complete atomic installer fixture on Linux and all six PTY tests on Linux and macOS. The full PG17 rerun and all hosted required checks pass, including seven matrix jobs, PostgreSQL19 beta3, and real capture/reel. The superseded bc82cc0 hosted run was cancelled after preserving job evidence: pre-fed input raced Linux psql terminal initialization.
- Exact c516b0c samorev completed its model and defender review and found one low-severity invalid-YAML indentation gap. Fix8d87ddd uses the first non-empty literal line as the indentation boundary; its malformed-input regression fails before the fix and passes afterward, with all78 current extracted workflow steps byte-identical. New-head hosted CI and exact follow-up review remain pending.
- Actual capture PNGs and three reel frames were inspected for readable results and clipping. All 8 demo fixtures previously re-rendered byte-identically.
- Main manual pre-tag mechanism rehearsal passed all 9 jobs: https://github.com/NikolayS/pg_ash/actions/runs/33924051160 (existing beta identity, not RC certification).

The original samorev findings about additional dependencies, parser truncation, and missing trigger cases are addressed with regression tests. Draft status remains intentional until release preparation is complete. The tool labels CI UNKNOWN because one push-event capture is skipped; the PR-event capture and required checks pass, and this metadata adjudication is separate from semantic review. Ruleset enforcement was applied/read back with existing rules preserved.

Closes #249. Includes #244; relates to #243, #247, and #248. The audit and RC plan are included. No merge or tag is performed here; final v2.0 publication still requires explicit owner approval.
